### PR TITLE
Smoke test: verify CI workflow runs on PRs

### DIFF
--- a/.github/CI_SMOKE.md
+++ b/.github/CI_SMOKE.md
@@ -1,0 +1,1 @@
+Throwaway file to trigger the CI workflow on a PR. Delete after the `CI / build` status check has been observed green on this PR (closing the PR without merging is fine — the goal is just to see the check appear).


### PR DESCRIPTION
## Summary
- Throwaway PR to verify the newly-added `.github/workflows/ci.yml` actually runs on pull requests and the `CI / build` status check appears.
- Adds a single throwaway file (`.github/CI_SMOKE.md`). Do not merge — close once CI has reported green and delete the branch.

## Test plan
- [ ] Observe the `CI / build` status check appear on this PR
- [ ] CI run goes green (build, format, npm, CSS build all pass)
- [ ] Close this PR without merging and delete the branch
- [ ] Enable "Require status checks to pass" on the `main` protection rule and attach `CI / build`