### PR TITLE
Drag-and-drop reorder on Want to Watch queue (closes #39)

### DIFF
--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -30,7 +30,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     });
 builder.Services.AddScoped<IAuthorizationHandler, AdminRequirementHandler>();
-builder.Services.AddAuthorization(options => options.AddPolicy("Admin", policy => policy.AddRequirements(new AdminRequirement())));
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy("Admin", policy => policy.AddRequirements(new AdminRequirement()));
 
 string[] corsOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
 if (builder.Environment.IsDevelopment())

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -861,7 +861,7 @@ public class DbService(IConfiguration config)
         int watched = await db.QuerySingleAsync<int>(
             "SELECT COUNT(*)::int FROM WatchedEpisodes WHERE UserId = @UserId", new { UserId = userId });
 
-        (decimal Cost, int RequestCount) ai = await db.QuerySingleAsync<(decimal Cost, int RequestCount)>(
+        (decimal aiCost, int aiRequestCount) = await db.QuerySingleAsync<(decimal Cost, int RequestCount)>(
             "SELECT COALESCE(SUM(EstimatedCostUsd), 0)::decimal AS Cost, COUNT(*)::int AS RequestCount FROM AIUsage WHERE UserId = @UserId",
             new { UserId = userId });
 
@@ -877,8 +877,8 @@ public class DbService(IConfiguration config)
             seasonSent,
             episodeSent,
             watched,
-            ai.Cost,
-            ai.RequestCount);
+            aiCost,
+            aiRequestCount);
     }
 
     public async Task<AdminAiUsageResponse> GetAdminAiUsageAsync()

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -80,7 +80,7 @@ else
                 <div @key="item.Id" data-item-id="@item.Id"
                      class="flex items-center gap-3 md:gap-4 bg-surface-50 rounded-lg p-2.5 md:p-3 hover:bg-surface-100 transition-colors group">
 
-                    @if (_activeTab == "wanttowatch")
+                    @if (_activeTab == WantToWatchTab)
                     {
                         bool reordering = _reorderingIds.Contains(item.Id);
                         <button class="@($"drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1 transition-opacity {(reordering ? "opacity-30 pointer-events-none" : "text-gray-600 hover:text-gray-300")}")"
@@ -197,11 +197,15 @@ else
     private string _activeTab = "all";
     private int? _expandedStatusId;
 
+    // drag-reorder is meaningful only on the WantToWatch tab — Position is the primary
+    // sort signal there; other tabs are sorted by recency / status. See Plans/issue-39.
+    private const string WantToWatchTab = "wanttowatch";
+
     private ElementReference _listEl;
     private IJSObjectReference? _sortableHandle;
     private DotNetObjectReference<Queue>? _dotNetRef;
-    private string? _attachedTab; // tracks which tab the sortable is currently bound to
-    private readonly HashSet<int> _reorderingIds = []; // items with an in-flight position update
+    private string? _attachedTab;
+    private readonly HashSet<int> _reorderingIds = [];
 
     private static readonly (string key, string label)[] _tabs =
     [
@@ -313,10 +317,7 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // attach SortableJS only when on the Want to Watch tab and there are visible rows;
-        // detach when switching to any other tab. Position is the primary sort signal only
-        // for WantToWatch (other tabs sort by recency / status), so drag is a no-op there.
-        bool wantSortable = _activeTab == "wanttowatch" && !_loading && FilteredItems.Any();
+        bool wantSortable = _activeTab == WantToWatchTab && !_loading && FilteredItems.Any();
 
         if (wantSortable && _attachedTab != _activeTab)
         {

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -1,10 +1,11 @@
 @page "/queue"
 @attribute [Authorize]
-@implements IDisposable
+@implements IAsyncDisposable
 @inject ApiClient Api
 @inject MediaFilterService MediaFilter
 @inject UserServicesCache UserServicesCache
 @inject QuickActionService QuickActionSvc
+@inject IJSRuntime JS
 
 <PageTitle>My List - Hurrah.tv</PageTitle>
 
@@ -73,10 +74,19 @@ else
     }
     else
     {
-        <div class="space-y-2 md:space-y-3 fade-in">
+        <div @ref="_listEl" class="space-y-2 md:space-y-3 fade-in">
             @foreach (QueueItem item in visible)
             {
-                <div class="flex items-center gap-3 md:gap-4 bg-surface-50 rounded-lg p-2.5 md:p-3 hover:bg-surface-100 transition-colors group">
+                <div @key="item.Id" data-item-id="@item.Id"
+                     class="flex items-center gap-3 md:gap-4 bg-surface-50 rounded-lg p-2.5 md:p-3 hover:bg-surface-100 transition-colors group">
+
+                    @if (_activeTab == "wanttowatch")
+                    {
+                        <button class="drag-handle flex-shrink-0 text-gray-600 hover:text-gray-300 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1"
+                                aria-label="Reorder @item.Title" tabindex="-1">
+                            <span class="icon-[heroicons--bars-3] w-5 h-5 block"></span>
+                        </button>
+                    }
 
                     <a href="/details/@item.MediaType/@item.TmdbId" class="flex-shrink-0 relative">
                         @if (!string.IsNullOrEmpty(item.PosterUrl("w92")))
@@ -186,6 +196,11 @@ else
     private string _activeTab = "all";
     private int? _expandedStatusId;
 
+    private ElementReference _listEl;
+    private IJSObjectReference? _sortableHandle;
+    private DotNetObjectReference<Queue>? _dotNetRef;
+    private string? _attachedTab; // tracks which tab the sortable is currently bound to
+
     private static readonly (string key, string label)[] _tabs =
     [
         ("all", "All"),
@@ -294,9 +309,85 @@ else
         catch { }
     }
 
-    public void Dispose()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // attach SortableJS only when on the Want to Watch tab and there are visible rows;
+        // detach when switching to any other tab. Position is the primary sort signal only
+        // for WantToWatch (other tabs sort by recency / status), so drag is a no-op there.
+        bool wantSortable = _activeTab == "wanttowatch" && !_loading && FilteredItems.Any();
+
+        if (wantSortable && _attachedTab != _activeTab)
+        {
+            await DisposeSortableAsync();
+            _dotNetRef ??= DotNetObjectReference.Create(this);
+            _sortableHandle = await JS.InvokeAsync<IJSObjectReference>(
+                "hurrahSortableInit", _listEl, _dotNetRef, nameof(OnReorder), null);
+            _attachedTab = _activeTab;
+        }
+        else if (!wantSortable && _attachedTab is not null)
+        {
+            await DisposeSortableAsync();
+        }
+    }
+
+    private async Task DisposeSortableAsync()
+    {
+        if (_sortableHandle is not null)
+        {
+            try { await JS.InvokeVoidAsync("hurrahSortableDispose", _sortableHandle); } catch { }
+            try { await _sortableHandle.DisposeAsync(); } catch { }
+            _sortableHandle = null;
+        }
+        _attachedTab = null;
+    }
+
+    [JSInvokable]
+    public async Task OnReorder(int itemId, int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex) return;
+
+        List<QueueItem> visible = FilteredItems.ToList();
+        if (newIndex < 0 || newIndex >= visible.Count) return;
+
+        QueueItem? dragged = visible.FirstOrDefault(i => i.Id == itemId);
+        QueueItem target = visible[newIndex];
+        if (dragged is null || ReferenceEquals(dragged, target)) return;
+
+        // ReorderAsync sets dragged.Position = target.Position and shifts the displaced
+        // item out of the way. Net effect: dragged lands exactly where target used to be.
+        int targetPos = target.Position;
+
+        // optimistic local rearrange so the UI doesn't snap back during the API call
+        List<QueueItem> snapshot = [.._items];
+        _items.Remove(dragged);
+        int targetInItems = _items.IndexOf(target);
+        if (targetInItems < 0) { _items = snapshot; return; }
+        int insertAt = newIndex > oldIndex ? targetInItems + 1 : targetInItems;
+        _items.Insert(insertAt, dragged);
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            bool ok = await Api.UpdateQueuePositionAsync(itemId, targetPos);
+            if (!ok)
+            {
+                _items = snapshot;
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch
+        {
+            _items = snapshot;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
     {
         MediaFilter.OnChanged -= OnMediaFilterChanged;
         UserServicesCache.Changed -= OnServicesChanged;
+        await DisposeSortableAsync();
+        _dotNetRef?.Dispose();
+        _dotNetRef = null;
     }
 }

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -83,10 +83,12 @@ else
                     @if (_activeTab == WantToWatchTab)
                     {
                         bool reordering = _reorderingIds.Contains(item.Id);
-                        <button class="@($"drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1 transition-opacity {(reordering ? "opacity-30 pointer-events-none" : "text-gray-600 hover:text-gray-300")}")"
-                                aria-label="Reorder @item.Title" tabindex="-1">
+                        // visual-only drag affordance; SortableJS owns the gesture. aria-hidden
+                        // because v1 is mouse/touch-only — keyboard reorder is a planned follow-on.
+                        <div class="@($"drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1 transition-opacity {(reordering ? "opacity-30 pointer-events-none" : "text-gray-600 hover:text-gray-300")}")"
+                             aria-hidden="true">
                             <span class="icon-[heroicons--bars-3] w-5 h-5 block"></span>
-                        </button>
+                        </div>
                     }
 
                     <a href="/details/@item.MediaType/@item.TmdbId" class="flex-shrink-0 relative">
@@ -206,6 +208,7 @@ else
     private DotNetObjectReference<Queue>? _dotNetRef;
     private string? _attachedTab;
     private readonly HashSet<int> _reorderingIds = [];
+    private int _reorderVersion;
     private bool _disposed;
 
     private static readonly (string key, string label)[] _tabs =
@@ -324,9 +327,18 @@ else
         {
             await DisposeSortableAsync();
             _dotNetRef ??= DotNetObjectReference.Create(this);
-            _sortableHandle = await JS.InvokeAsync<IJSObjectReference>(
-                "hurrahSortableInit", _listEl, _dotNetRef, nameof(OnReorder), null);
-            _attachedTab = _activeTab;
+            try
+            {
+                _sortableHandle = await JS.InvokeAsync<IJSObjectReference>(
+                    "hurrahSortableInit", _listEl, _dotNetRef, nameof(OnReorder), null);
+            }
+            catch
+            {
+                _sortableHandle = null;
+            }
+            // only mark attached on a successful handle — leaves _attachedTab null on failure
+            // so the next render can retry (e.g. CDN recovers, JS reloads on hot-reload)
+            if (_sortableHandle is not null) _attachedTab = _activeTab;
         }
         else if (!wantSortable && _attachedTab is not null)
         {
@@ -363,7 +375,10 @@ else
         // item out of the way. Net effect: dragged lands exactly where target used to be.
         int targetPos = target.Position;
 
-        // optimistic local rearrange so the UI doesn't snap back during the API call
+        // optimistic local rearrange so the UI doesn't snap back during the API call.
+        // _reorderVersion is captured per-call: a later drag bumps the version, so an
+        // older failure won't revert and clobber the newer drag's local mutation.
+        int version = ++_reorderVersion;
         List<QueueItem> snapshot = [.._items];
         _items.Remove(dragged);
         int targetInItems = _items.IndexOf(target);
@@ -373,17 +388,19 @@ else
         _reorderingIds.Add(itemId);
         await InvokeAsync(StateHasChanged);
 
+        bool shouldRevert = false;
         try
         {
             bool ok = await Api.UpdateQueuePositionAsync(itemId, targetPos);
-            if (!ok) _items = snapshot;
+            shouldRevert = !ok;
         }
         catch
         {
-            _items = snapshot;
+            shouldRevert = true;
         }
         finally
         {
+            if (shouldRevert && version == _reorderVersion) _items = snapshot;
             _reorderingIds.Remove(itemId);
             await InvokeAsync(StateHasChanged);
         }

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -206,6 +206,7 @@ else
     private DotNetObjectReference<Queue>? _dotNetRef;
     private string? _attachedTab;
     private readonly HashSet<int> _reorderingIds = [];
+    private bool _disposed;
 
     private static readonly (string key, string label)[] _tabs =
     [
@@ -347,7 +348,9 @@ else
     [JSInvokable]
     public async Task OnReorder(int itemId, int oldIndex, int newIndex)
     {
-        if (oldIndex == newIndex) return;
+        // a drag in flight when the user navigates away can deliver onEnd after
+        // the component is gone — do not mutate state on a disposed component
+        if (_disposed || oldIndex == newIndex) return;
 
         List<QueueItem> visible = FilteredItems.ToList();
         if (newIndex < 0 || newIndex >= visible.Count) return;
@@ -388,6 +391,7 @@ else
 
     public async ValueTask DisposeAsync()
     {
+        _disposed = true;
         MediaFilter.OnChanged -= OnMediaFilterChanged;
         UserServicesCache.Changed -= OnServicesChanged;
         await DisposeSortableAsync();

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -82,7 +82,8 @@ else
 
                     @if (_activeTab == "wanttowatch")
                     {
-                        <button class="drag-handle flex-shrink-0 text-gray-600 hover:text-gray-300 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1"
+                        bool reordering = _reorderingIds.Contains(item.Id);
+                        <button class="@($"drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1 transition-opacity {(reordering ? "opacity-30 pointer-events-none" : "text-gray-600 hover:text-gray-300")}")"
                                 aria-label="Reorder @item.Title" tabindex="-1">
                             <span class="icon-[heroicons--bars-3] w-5 h-5 block"></span>
                         </button>
@@ -200,6 +201,7 @@ else
     private IJSObjectReference? _sortableHandle;
     private DotNetObjectReference<Queue>? _dotNetRef;
     private string? _attachedTab; // tracks which tab the sortable is currently bound to
+    private readonly HashSet<int> _reorderingIds = []; // items with an in-flight position update
 
     private static readonly (string key, string label)[] _tabs =
     [
@@ -364,20 +366,21 @@ else
         if (targetInItems < 0) { _items = snapshot; return; }
         int insertAt = newIndex > oldIndex ? targetInItems + 1 : targetInItems;
         _items.Insert(insertAt, dragged);
+        _reorderingIds.Add(itemId);
         await InvokeAsync(StateHasChanged);
 
         try
         {
             bool ok = await Api.UpdateQueuePositionAsync(itemId, targetPos);
-            if (!ok)
-            {
-                _items = snapshot;
-                await InvokeAsync(StateHasChanged);
-            }
+            if (!ok) _items = snapshot;
         }
         catch
         {
             _items = snapshot;
+        }
+        finally
+        {
+            _reorderingIds.Remove(itemId);
             await InvokeAsync(StateHasChanged);
         }
     }

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -99,6 +99,12 @@ public class ApiClient(HttpClient http)
         return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>() : null;
     }
 
+    public async Task<bool> UpdateQueuePositionAsync(int id, int position)
+    {
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/position", new { Position = position });
+        return res.IsSuccessStatusCode;
+    }
+
     public async Task<QueueItem?> UpdateProgressAsync(int id, int? season, int? episode)
     {
         HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/progress", new { Season = season, Episode = episode });

--- a/HurrahTv.Client/Services/CurationCache.cs
+++ b/HurrahTv.Client/Services/CurationCache.cs
@@ -131,5 +131,6 @@ public class CurationCache : IDisposable
         _quickActions.OnItemUpdated -= OnInvalidate;
         _quickActions.OnEpisodeWatchedChanged -= OnEpisodeInvalidate;
         _hydrateLock.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -683,8 +683,14 @@
   .fade-in {
     animation: fadeIn 0.3s ease-in;
   }
+  .cursor-grab {
+    cursor: grab;
+  }
   .cursor-pointer {
     cursor: pointer;
+  }
+  .touch-none {
+    touch-action: none;
   }
   .snap-x {
     scroll-snap-type: x var(--tw-scroll-snap-strictness);
@@ -1870,6 +1876,11 @@
     &:focus {
       --tw-outline-style: none;
       outline-style: none;
+    }
+  }
+  .active\:cursor-grabbing {
+    &:active {
+      cursor: grabbing;
     }
   }
   .disabled\:opacity-30 {

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -1446,6 +1446,9 @@
   .opacity-0 {
     opacity: 0%;
   }
+  .opacity-30 {
+    opacity: 30%;
+  }
   .opacity-40 {
     opacity: 40%;
   }

--- a/HurrahTv.Client/wwwroot/index.html
+++ b/HurrahTv.Client/wwwroot/index.html
@@ -62,6 +62,8 @@
             let timer = null, startX = 0, startY = 0, fired = false, activeEvent = null;
             const onStart = (e) => {
                 if (!e.touches.length) return;
+                // skip when the touch starts on a sortable drag handle — Sortable owns that gesture
+                if (e.target?.closest?.('.drag-handle')) return;
                 const t = e.touches[0];
                 startX = t.clientX; startY = t.clientY; fired = false;
                 activeEvent = e;
@@ -102,7 +104,33 @@
             if (handle.onContextMenu) handle.el.removeEventListener('contextmenu', handle.onContextMenu);
             handle.el.removeEventListener('click', handle.onClick, true);
         };
+        window.hurrahSortableInit = (el, dotNetRef, callbackName, options) => {
+            if (!el || !window.Sortable) return null;
+            const opts = Object.assign({
+                handle: '.drag-handle',
+                animation: 150,
+                delay: 0,
+                delayOnTouchOnly: true,
+                touchStartThreshold: 5,
+                ghostClass: 'sortable-ghost',
+                chosenClass: 'sortable-chosen',
+                dragClass: 'sortable-drag',
+            }, options || {});
+            opts.onEnd = (evt) => {
+                if (evt.oldIndex === evt.newIndex) return;
+                const itemId = parseInt(evt.item?.dataset?.itemId, 10);
+                if (isNaN(itemId)) return;
+                dotNetRef.invokeMethodAsync(callbackName, itemId, evt.oldIndex, evt.newIndex);
+            };
+            const instance = Sortable.create(el, opts);
+            return { instance };
+        };
+        window.hurrahSortableDispose = (handle) => {
+            if (!handle?.instance) return;
+            try { handle.instance.destroy(); } catch {}
+        };
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/Learnings/js-interop-init-failure-recovery.md
+++ b/Learnings/js-interop-init-failure-recovery.md
@@ -1,0 +1,73 @@
+# JS Interop Init Can Fail Transiently — Gate "Attached" State on the Handle
+
+> **Area:** WASM | UI
+> **Date:** 2026-05-07
+
+## Context
+
+`Queue.razor`'s `OnAfterRenderAsync` attaches a SortableJS instance to the list element when the user is on the WantToWatch tab. The first version had this shape:
+
+```csharp
+if (wantSortable && _attachedTab != _activeTab)
+{
+    await DisposeSortableAsync();
+    _dotNetRef ??= DotNetObjectReference.Create(this);
+    _sortableHandle = await JS.InvokeAsync<IJSObjectReference>(
+        "hurrahSortableInit", _listEl, _dotNetRef, nameof(OnReorder), null);
+    _attachedTab = _activeTab; // ← unconditional
+}
+```
+
+Works in the happy path. But `hurrahSortableInit` returns `null` if the SortableJS CDN failed to load (`if (!el || !window.Sortable) return null;`). It can also throw if the JS module errored. Either way, after the failed attempt, `_attachedTab == _activeTab` — so the next render's gate evaluates false, and **the page can't retry init until the user leaves and comes back to the tab**. The drag handle is visible but inert; the user thinks the feature is broken.
+
+Surfaced by a Copilot review on PR #65.
+
+## Learning
+
+When you wire JS interop in `OnAfterRenderAsync` (or any "attach once, render many" lifecycle hook), the registration call has three possible outcomes:
+
+1. Returns a non-null handle — success.
+2. Returns null — JS-side guard tripped (dependency missing, element gone).
+3. Throws — JS-side runtime error during init.
+
+Outcomes 2 and 3 are real and recoverable. The fix:
+
+- Wrap the `InvokeAsync<IJSObjectReference>` in `try/catch` (catch sets `_handle = null`).
+- Set the "attached" / "current state" flag (`_attachedTab` here) **only when the handle is non-null**.
+- Leave the gate-flag in its old/null state on failure so the next render attempts re-init.
+
+```csharp
+if (wantSortable && _attachedTab != _activeTab)
+{
+    await DisposeSortableAsync();
+    _dotNetRef ??= DotNetObjectReference.Create(this);
+    try
+    {
+        _sortableHandle = await JS.InvokeAsync<IJSObjectReference>(
+            "hurrahSortableInit", _listEl, _dotNetRef, nameof(OnReorder), null);
+    }
+    catch
+    {
+        _sortableHandle = null;
+    }
+    if (_sortableHandle is not null) _attachedTab = _activeTab;
+}
+```
+
+This way: a transient failure (CDN slow, JS error during a hot-reload, network blip) is recovered automatically by the next render — which fires for any unrelated state change (status toggle, tab switch, search update, etc.). The user gets a working drag handle once the dependency loads, with no manual recovery step.
+
+## Distinct from the disposal-lifecycle learning
+
+`blazor-js-interop-handle-lifecycle.md` covers the *cleanup* side — `IJSObjectReference` disposal, `DotNetObjectReference` disposal, dictionary-tracked per-element handles, `InvokeAsync<IJSObjectReference>` (not Void). That's about closing the loop.
+
+This learning is about the *open* side — gating success state so failures don't permanently lock the component out of retry. Both are needed; either alone leaves a hole.
+
+## Generalization
+
+Whenever a registration call yields a value you'll later use to detect "am I attached?", **derive that detection from the value's existence, not from a parallel boolean you set at the call site**. The boolean drifts from reality whenever the call's outcome is non-binary; the value is authoritative.
+
+When you can't avoid a parallel boolean (because you also care about *which* attached state you're in — e.g., "attached for the WantToWatch tab specifically"), set it conditionally on the value.
+
+## File pointer
+
+`HurrahTv.Client/Pages/Queue.razor` — `OnAfterRenderAsync` shows the corrected shape.

--- a/Learnings/optimistic-update-version-token.md
+++ b/Learnings/optimistic-update-version-token.md
@@ -1,0 +1,85 @@
+# Optimistic Updates with Snapshot Revert Need a Version Token Under Concurrency
+
+> **Area:** UI | WASM
+> **Date:** 2026-05-07
+
+## Context
+
+Drag-reorder on the queue uses optimistic UI: snapshot `_items`, mutate locally, fire the API call, revert on failure. The naive shape works fine in isolation but breaks when the user fires multiple drags before the first API call completes. Surfaced by a Copilot review on PR #65.
+
+## Learning
+
+If your optimistic-update pattern has the shape
+
+```csharp
+List<T> snapshot = [.._items];
+_items = ApplyChange(_items);
+StateHasChanged();
+try { ok = await Api.Mutate(...); if (!ok) _items = snapshot; }
+catch     { _items = snapshot; }
+```
+
+then **two overlapping operations corrupt state on failure of the older one.** Walkthrough:
+
+1. User performs Move-1: `snapshot1 = [A, B, C]`. Local becomes `[B, C, A]`. API1 fires.
+2. Before API1 returns, user performs Move-2: `snapshot2 = [B, C, A]` (the post-Move-1 state). Local becomes `[C, B, A]`. API2 fires.
+3. API1 returns failure. Revert path runs: `_items = snapshot1 = [A, B, C]`. **Move-2's local mutation is silently discarded.** If API2 succeeds, server state and client state diverge until the next refetch.
+
+The user has moved on; their newer intent should win.
+
+### Fix: a per-call monotonic version token
+
+```csharp
+private int _operationVersion;
+
+public async Task OnReorder(...)
+{
+    int version = ++_operationVersion;
+    List<T> snapshot = [.._items];
+    _items = ApplyChange(_items);
+    StateHasChanged();
+
+    bool shouldRevert = false;
+    try
+    {
+        bool ok = await Api.Mutate(...);
+        shouldRevert = !ok;
+    }
+    catch
+    {
+        shouldRevert = true;
+    }
+    finally
+    {
+        // a later operation has bumped _operationVersion — newer intent wins, do not clobber
+        if (shouldRevert && version == _operationVersion) _items = snapshot;
+        StateHasChanged();
+    }
+}
+```
+
+The semantics: "only revert if I'm still the most recent operation." If a newer operation is in flight or already applied, the failure of the older one is silently absorbed — its local mutation is preserved, and any divergence with the server resolves on the next refetch.
+
+### When this rule applies
+
+- Any `await`-mediated operation that mutates client state optimistically and reverts on failure.
+- The user can plausibly fire two before the first completes (drag-reorder, rapid status toggles, batched checkbox flips, like-button spam).
+- The mutation isn't naturally serialized (you didn't disable the input during in-flight, or you can't because UX demands responsiveness).
+
+### When this rule does **not** apply
+
+- Per-item in-flight tracking that disables the affordance per row (e.g. `_reorderingIds.Contains(item.Id)` greys out the handle on the dragged item only — but other items remain interactive). Per-item disable is a partial mitigation, not a substitute for the version token, because the user can still operate on a *different* item while one is in flight.
+- Operations that can't be undone client-side anyway (e.g. delete + show toast). No revert means no clobber.
+- Operations that always refetch on completion (the source of truth re-arrives, no manual revert needed).
+
+## Anti-pattern: serializing operations to dodge the problem
+
+"Just disable Sortable while a reorder is in flight" *works* but degrades UX. The user has to wait for the API on every drag. The version-token approach lets them keep dragging at the speed of optimistic UI; only the failure path is restricted, and failure is rare.
+
+## Generalization
+
+The deeper rule: **when you snapshot state to enable a revert, the snapshot is only valid for as long as no other operation has overlapped it.** Track that with a monotonic counter or a "this snapshot's generation matches current" check. Without one, snapshot revert is a time-travel bug waiting to happen.
+
+## File pointer
+
+`HurrahTv.Client/Pages/Queue.razor` — `OnReorder` uses `_reorderVersion`.

--- a/Learnings/sortablejs-interop-and-gesture-conflicts.md
+++ b/Learnings/sortablejs-interop-and-gesture-conflicts.md
@@ -1,0 +1,81 @@
+# SortableJS via JS Interop + Coexisting With Existing Touch Gestures
+
+> **Area:** UI | WASM
+> **Date:** 2026-05-07
+
+## Context
+Issue #39 added drag-to-reorder on the queue's Want to Watch tab. The page already uses `hurrahLongPress` on poster cards to open QuickActions. Both gestures live on the same row — long-press on the body opens QuickActions, drag from the handle reorders. Wired naively, a long-press *anywhere* on the row including on the drag handle fires QuickActions, and the SortableJS drag never starts on touch devices.
+
+## Learning
+
+Three distinct things have to be right for a JS-interop drag library to coexist with an existing touch gesture in Blazor WASM:
+
+### 1. Restrict the drag affordance to a specific child element via `handle:`
+
+`Sortable.create(el, { handle: '.drag-handle', ... })` makes the rest of the row inert to drag. This is what keeps the `<a href>` and other clickable children working — without `handle:`, every child element of the list participates in drag detection and ordinary clicks get swallowed.
+
+Critical SortableJS options for a Blazor list:
+
+```javascript
+{
+    handle: '.drag-handle',
+    delay: 0,
+    delayOnTouchOnly: true,    // immediate on mouse, settable delay on touch
+    touchStartThreshold: 5,    // 5px movement before drag starts → vertical scroll still works
+    animation: 150,
+    ghostClass: 'sortable-ghost',
+    chosenClass: 'sortable-chosen',
+    dragClass: 'sortable-drag'
+}
+```
+
+### 2. Teach the *other* gesture to skip when the touch starts on the handle
+
+SortableJS's `handle:` only stops *Sortable* from reacting elsewhere. Existing gestures on the row body still see touch events on the handle. Add a one-line guard at the top of any other touch handler:
+
+```javascript
+const onStart = (e) => {
+    if (e.target?.closest?.('.drag-handle')) return;
+    // ... rest of long-press / swipe / etc. logic
+};
+```
+
+This is cheaper than restructuring the markup to lift the handle outside the long-press element.
+
+### 3. Use the JS-interop handle lifecycle pattern (existing learning)
+
+`hurrahSortableInit` returns a JS object; the C# side holds an `IJSObjectReference` and disposes via `hurrahSortableDispose` + `IJSObjectReference.DisposeAsync`. Same shape as `hurrahLongPress` (see `blazor-js-interop-handle-lifecycle.md`). Don't use `InvokeVoidAsync` — the handle would be lost.
+
+### Computing the target Position from a SortableJS event in a *filtered* list
+
+SortableJS's `onEnd` reports `oldIndex` / `newIndex` in the rendered DOM, which for a filtered queue view is **a subset of the underlying list**. The reorder endpoint takes an absolute Position. Translating:
+
+```csharp
+// in [JSInvokable] OnReorder(itemId, oldIndex, newIndex)
+List<QueueItem> visible = FilteredItems.ToList();
+QueueItem dragged = visible.First(i => i.Id == itemId);
+QueueItem target  = visible[newIndex];
+int targetPos = target.Position;
+// → set dragged.Position = target.Position; the server's ReorderAsync shifts
+//   the displaced item out of the way. Net effect: dragged lands exactly where
+//   target used to be in the visible list, and other items keep their order.
+```
+
+This works for any filter (status tab, media type, both) because Position is a strict total order — slotting a single item to an absolute Position never disturbs the relative order of the items not in the visible subset.
+
+### Optimistic UI with snapshot revert
+
+Snapshot via `[.._items]` (cheap shallow copy of the list — items inside are references, untouched), apply the visible reorder locally, fire the API call, revert from the snapshot in the failure path. Track per-item in-flight state with a `HashSet<int>` if you need a visual disabled state on the dragged row.
+
+## Why each piece matters separately
+
+- Without `handle:` → ordinary clicks on `<a>` children get hijacked.
+- Without the long-press guard → long-pressing the handle opens QuickActions instead of starting a drag.
+- Without `touchStartThreshold` → vertical scrolling on touch devices triggers a drag.
+- Without `delayOnTouchOnly: true` → desktop drag feels laggy if you also set `delay`.
+- Without snapshot revert → a 5xx leaves the optimistic UI lying.
+
+## File pointers
+- `HurrahTv.Client/wwwroot/index.html` — `hurrahSortableInit`, `hurrahSortableDispose`, plus the `.drag-handle` skip in `hurrahLongPress.onStart`
+- `HurrahTv.Client/Pages/Queue.razor` — wiring (`OnAfterRenderAsync` attach/detach by tab, `[JSInvokable] OnReorder`, `IAsyncDisposable`)
+- `HurrahTv.Api/Services/DbService.cs` — `ReorderAsync` (transactional shift, accepts absolute target Position)

--- a/Learnings/user-ordering-vs-algorithmic-sort.md
+++ b/Learnings/user-ordering-vs-algorithmic-sort.md
@@ -1,0 +1,52 @@
+# User-Controllable Ordering Is Meaningful Only Where Algorithmic Signals Tie
+
+> **Area:** UI | Architecture | Data
+> **Date:** 2026-05-07
+
+## Context
+
+Issue #39 wanted drag-reorder on the queue. The `QueueItems` table has a `Position INT` column already used as a sort tiebreaker. The naive read is "Position drives order — drag changes Position — drag works on every tab." Reality is subtler: `GetQueueAsync` sorts by **four** keys in this order:
+
+1. `Status` (Watching → WantToWatch → Finished → NotForMe)
+2. `LatestEpisodeDate >= NOW() - INTERVAL '7 days'` (fresh-episode bucket)
+3. `LatestEpisodeDate DESC`
+4. `Position`
+
+So `Position` only decides ordering when the first three keys all tie. On the Watching tab, recency dominates and a user's drag would either look invisible (snap back) or require us to suppress the recency sort — which is itself a desirable feature. On the All tab, Status dominates and dragging across statuses snaps back. Position is the *primary* sort signal in practice only on **WantToWatch**, where items typically share a null `LatestEpisodeDate` (user hasn't started watching) and collapse into one big tier.
+
+## Learning
+
+**Before exposing a "let the user customize sort order" affordance, find the algorithmic sort tiers and ask: at which tier does the user's input actually decide ordering?** That's the only tier where the affordance has a visible effect; expose it there and hide it elsewhere. Don't fight the algorithmic signals — they exist for a reason (recency, freshness, type-priority) and the user values them too.
+
+Concretely, when adding a user-controlled ranking feature:
+
+1. Read every `ORDER BY` against the relevant table — most apps have several, in different endpoints.
+2. Map where the user-controlled column appears in each: primary key, secondary, tiebreaker, ignored.
+3. Audit every surface that renders the same data — list page, home rows, summary cards, admin views — and identify whether each uses the same query or a different sort altogether.
+4. Scope the affordance (drag handle, "set priority" button, etc.) to the surfaces where the user-controlled key dominates. Hide it elsewhere (don't disable — *absent* is better than disabled, because disabled invites "why doesn't this work?").
+5. Decide explicitly what cross-surface semantics mean: the user changing rank in surface A may or may not propagate visibly to surface B. Document the answer in the plan.
+
+This is not just about drag-reorder. It applies to:
+
+- **Pinning / "show me first"** — pinning is meaningful only where the pin column outranks the algorithmic sort.
+- **Custom watchlists / saved orderings** — only useful if the rendering surface uses the saved ordering, not its own algorithm.
+- **AI-curated ordering vs. user override** — the AI score is one tier; user preference is another; pick which wins.
+
+## Anti-pattern: "let the user reorder everywhere, snap back where it doesn't fit"
+
+Tempting (one global Position column, drag handle on every list) but produces the worst UX: the user drags, the row snaps somewhere unexpected, they conclude the feature is broken. Better to *not show* the drag affordance than to show it where it doesn't bite.
+
+## Anti-pattern: per-status / per-context Position columns to make drag "work everywhere"
+
+Adds schema complexity (one Position column per context, renumbering on transitions) just to give drag the *appearance* of working — but it still fights the algorithmic signal in those contexts. If recency-of-new-episodes is the right Watching-tab sort, the user's drag in that tab is *meaningless* even with a separate position column. The right answer is "drag is the wrong feature for this surface," not "let's re-engineer the data model so drag can pretend to work here."
+
+## Concrete file pointers from #39
+
+- `HurrahTv.Api/Services/DbService.cs` — `GetQueueAsync` (the 4-key ORDER BY)
+- `HurrahTv.Client/Pages/Queue.razor` — drag handle gated on `_activeTab == WantToWatchTab`
+- `HurrahTv.Client/Pages/Home.razor` — uses its own client-side sort modes (`date` / `sentiment` / `queue`) — Position is at most a tertiary key, so drag-reorder propagates there only in `queue` mode and that's coherent
+- `Plans/issue-39-queue-drag-drop-reorder.md` — full audit of every queue-rendering surface
+
+## Generalization
+
+The deeper rule: *a user-controlled signal is only as visible as the lowest sort tier it occupies.* If your column is tier-N and tiers 1..N-1 have non-trivial discriminators on the rendered subset, the user can't see their input. Find tiers where the higher discriminators tie on the visible subset, and surface the control only there.

--- a/Learnings/visual-only-controls-aria-hidden-not-tabindex.md
+++ b/Learnings/visual-only-controls-aria-hidden-not-tabindex.md
@@ -1,0 +1,65 @@
+# Visual-Only Controls: Use `aria-hidden`, Not `<button tabindex="-1">`
+
+> **Area:** UI | Accessibility
+> **Date:** 2026-05-07
+
+## Context
+
+The drag handle on the queue's WantToWatch tab is mouse/touch-only at v1 — keyboard reorder is deferred. The first implementation rendered it as:
+
+```html
+<button class="drag-handle ..." aria-label="Reorder @item.Title" tabindex="-1">
+    <span class="icon-[heroicons--bars-3] w-5 h-5 block"></span>
+</button>
+```
+
+Reasoning at the time: "It's a button-like affordance, give it a button element and an aria-label so screen readers know what it is." Surfaced by a Copilot review on PR #65 as an a11y regression.
+
+## Learning
+
+`<button tabindex="-1" aria-label="Reorder ...">` is worst-of-both-worlds:
+
+- The `<button>` element + `aria-label` advertise an interactive, labeled control to assistive tech.
+- The `tabindex="-1"` removes it from the keyboard tab order.
+- Result: AT users hear "Reorder Show Title, button" but cannot reach or activate it. There is no keyboard equivalent.
+
+This is worse than no a11y surface at all. AT users can perceive a feature exists but discover they can't use it.
+
+### Two correct alternatives
+
+**Option A — visual-only affordance, no a11y surface:**
+
+```html
+<div class="drag-handle ..." aria-hidden="true">
+    <span class="icon-[heroicons--bars-3] w-5 h-5 block"></span>
+</div>
+```
+
+Use this when the gesture is genuinely mouse/touch-only at v1 and a keyboard equivalent will be added in a follow-on. AT users see the rest of the row (title, status badge, remove button) and use those — they don't get drag-reorder, but they aren't promised something they can't have.
+
+**Option B — full keyboard support:**
+
+```html
+<button class="drag-handle ..." aria-label="Reorder @item.Title"
+        @onkeydown="HandleReorderKey">
+    <span class="icon-[heroicons--bars-3] w-5 h-5 block"></span>
+</button>
+```
+
+With Up/Down arrows handled in C# to call the same reorder JSInvokable, plus an `aria-live="polite"` region announcing each move. This is the "do it right" path; ship it when the time investment matches the priority.
+
+### When you might be tempted to use the broken pattern
+
+- "I want the visual treatment a button gives me." Use `role="presentation"` on a `<div>` and style it however you like.
+- "I want a focusable element so my CSS focus state highlights it for sighted keyboard users." If sighted keyboard users genuinely benefit, you owe AT users actual keyboard support — go to Option B.
+- "I'll add keyboard support later and want the aria-label in place for when I do." File the follow-on; remove the misleading semantics now. A correct future state doesn't excuse a broken current state.
+
+## Generalization
+
+For any control: the element type and ARIA attributes you choose are a **promise** of how AT can interact with it. `<button>`, `<a>`, `role="button"`, `aria-label` — these all say "I am operable." If the control isn't actually operable in the AT user's input modality, those attributes lie.
+
+The honest representation is: **a visual element with `aria-hidden="true"`** (the AT user gets nothing, but is told nothing) — *or* **a real interactive control with real keyboard support** (the AT user gets the same feature). Anything in between is a lie.
+
+## File pointer
+
+`HurrahTv.Client/Pages/Queue.razor` — drag handle row uses `<div aria-hidden="true">`. Keyboard support tracked as issue #66.


### PR DESCRIPTION
## Summary

- Adds drag-to-reorder for queue items, scoped to the **Want to Watch** tab. Position is the 4th sort key in `GetQueueAsync` (after Status → fresh-episode bucket → `LatestEpisodeDate`), so it only dominates ordering on WantToWatch where the higher signals tie. Hiding the handle elsewhere prevents the "I dragged it but it snapped back" feeling. Full audit + decision rationale in `Plans/issue-39-queue-drag-drop-reorder.md` (local-only).
- Wires SortableJS via JS interop (CDN-pinned to v1.15.6), following the existing `hurrahLongPress` lifecycle pattern. Touch coexistence: a `.drag-handle` skip-guard inside `hurrahLongPress.onStart` so QuickActions doesn't fire when a drag begins.
- Optimistic UI with snapshot revert on failure; per-row `_reorderingIds` HashSet dims the handle while a position update is in flight.
- Two follow-on learnings captured in `Learnings/`.

## What changed

| File | Change |
|---|---|
| `HurrahTv.Client/Pages/Queue.razor` | Drag handle column on WantToWatch, `@key` + `data-item-id` on rows, `OnAfterRenderAsync` attach/detach by tab, `[JSInvokable] OnReorder`, `IAsyncDisposable`, `WantToWatchTab` const |
| `HurrahTv.Client/Services/ApiClient.cs` | `UpdateQueuePositionAsync(id, position)` |
| `HurrahTv.Client/wwwroot/index.html` | SortableJS CDN script, `hurrahSortableInit` / `hurrahSortableDispose` interop module, `.drag-handle` guard in `hurrahLongPress.onStart` |
| `HurrahTv.Client/wwwroot/css/app.css` | Tailwind rebuild — `cursor-grab`, `active:cursor-grabbing`, `touch-none` utilities now compiled |
| `Learnings/sortablejs-interop-and-gesture-conflicts.md` | New |
| `Learnings/user-ordering-vs-algorithmic-sort.md` | New |

No backend changes. The existing `PUT /api/queue/{id}/position` and `DbService.ReorderAsync` are sufficient. No DB schema changes.

## Test plan

- [ ] Want to Watch tab: drag a row by the handle → lands where dropped, reload page → order persists
- [ ] All other tabs (All / Watching / Watched / Not For Me): no drag handle visible
- [ ] Mobile (iOS Safari): touch-and-drag from the handle works; long-press on the row body still opens QuickActions; long-press on the drag handle does NOT open QuickActions
- [ ] Force a 5xx on `PUT /api/queue/{id}/position` (DevTools → block / throttle): row snaps back to original position
- [ ] Switch tabs while a drag is in flight: no console errors, no orphaned listeners
- [ ] Empty Want to Watch tab: no drag handle, no SortableJS init
- [ ] Single-item Want to Watch tab: handle visible, drag is a no-op

## Follow-ons filed during this branch

- #62 — Admin: verified checkmark next to user name
- #63 — Add Microsoft Clarity for product analytics
- #64 — Promote queue mutation DTOs to HurrahTv.Shared (consistency pass surfaced by /xsimplify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)