### PR TITLE
Queue page improvements (filters, a11y, mobile) + DTO refactor

### DIFF
--- a/.claude/skills/compound/skill.md
+++ b/.claude/skills/compound/skill.md
@@ -34,6 +34,7 @@ Format each learning file:
 
 > **Area:** WASM | API | Data | TMDb | Auth | UI | Deployment
 > **Date:** YYYY-MM-DD
+> **Resolves:** mkerchenski/hurrah-tv#NN  (only when an issue triggered this learning — see below)
 
 ## Context
 [What situation led to this discovery]
@@ -44,6 +45,14 @@ Format each learning file:
 ## Example
 [Code snippet or concrete example if applicable]
 ```
+
+**Cross-reference resolved issues** — when a learning came out of debugging or implementing a tracked issue, link it from the frontmatter so future readers can trace context. Scan recent commits for issue references:
+
+```bash
+git log --grep='#' -20 --oneline
+```
+
+If a recent commit closed/fixed an issue and that issue surfaced this learning, add the `> **Resolves:** mkerchenski/hurrah-tv#NN` line. Opt-in only — don't fabricate links.
 
 ### Step 5: Deduplicate
 Before writing, check:

--- a/.claude/skills/deploy/skill.md
+++ b/.claude/skills/deploy/skill.md
@@ -36,7 +36,18 @@ Single App Service serves both the Blazor WASM client (static files) and the .NE
    ```bash
    curl -sk https://hurrahtv-api.azurewebsites.net/api/health
    ```
-4. Report status in a table.
+4. **List active issues** so the user can see what's currently in-flight before swapping. Hurrah.Tv is label-driven (see CLAUDE.md "Issue Tracking"), so use `phase:now` as the In Progress proxy:
+   ```bash
+   gh issue list --repo mkerchenski/hurrah-tv --label "phase:now" --state open --limit 20
+   ```
+   Display alongside the health table:
+   ```
+   In flight (phase:now):
+     #66 Queue keyboard support for drag-reorder (a11y)
+     #67 Add share button on Details view
+   ```
+   This is **read-only** — do not mutate any labels from this skill. The user reviews and decides whether the swap is safe.
+5. Report status in a table.
 
 **`/deploy now`**
 1. Check staging health first. If unhealthy, warn and stop.

--- a/.claude/skills/xplan/skill.md
+++ b/.claude/skills/xplan/skill.md
@@ -55,9 +55,17 @@ Run these in parallel:
 
 1. **Scan learnings** — `Glob Learnings/**/*.md` then read any whose title bears on the feature area (Blazor lifecycle, WASM datetime, TMDb, AI curation, Postgres, etc.).
 2. **Check existing plans** — `Glob Plans/*.md`. **If a plan in the same area already exists, prefer updating it over creating a new one.** Note related plans for the system plan skill to reference.
-3. **Read CLAUDE.md** at the repo root for architectural constraints.
-4. **Check Memory** — read relevant memory files for project context, user preferences, and past learnings.
-5. **Identify affected projects** — which of `HurrahTv.Api`, `HurrahTv.Client`, `HurrahTv.Shared` does this touch?
+3. **Check existing GitHub issues** — query `mkerchenski/hurrah-tv` so the plan can link to or replace already-tracked work:
+   ```bash
+   # broad keyword search
+   gh issue list --repo mkerchenski/hurrah-tv --state open --search "<feature keyword>"
+   # narrow by area when known (api/client/auth/ai-curation/tmdb/design/docs/infra)
+   gh issue list --repo mkerchenski/hurrah-tv --label "area:<slice>" --state open
+   ```
+   If a tracking issue already exists, capture `mkerchenski/hurrah-tv#<num>` for the plan's front-matter `Tracking issue:` line. If multiple matches, surface them so the user can pick.
+4. **Read CLAUDE.md** at the repo root for architectural constraints.
+5. **Check Memory** — read relevant memory files for project context, user preferences, and past learnings.
+6. **Identify affected projects** — which of `HurrahTv.Api`, `HurrahTv.Client`, `HurrahTv.Shared` does this touch?
 
 #### 1.2 Propose via plan mode
 
@@ -120,11 +128,46 @@ After plan mode exits (user approved), append these Hurrah.tv-specific sections 
 - After landing: invoke `/compound` to capture non-obvious learnings
 - After AI prompt changes: clear `CurationCache` server-side or just bump the cache key
 
-#### 1.4 Save
+#### 1.4 Decide on a tracking issue
 
-Save the augmented plan to `Plans/<feature-name>.md`. The approval already happened inside plan mode — this step writes the durable artifact (referenceable across sessions).
+Before saving, decide whether the plan needs a GitHub tracking issue. Use `AskUserQuestion` to present three options:
 
-Tell the user: "Plan saved to `Plans/{feature-name}.md`. Start Phase 1 now, or revisit later?" — don't auto-start; multi-phase work often picks up in a future session.
+1. **Link to an existing issue** — paste `mkerchenski/hurrah-tv#<num>` (typically one surfaced during pre-research step 3). The plan's front matter `Tracking issue:` line gets that value.
+2. **Create a new tracking issue** — for plans large enough to span sessions. Show the user the proposed title / body / labels BEFORE creating. On approval:
+   ```bash
+   gh issue create --repo mkerchenski/hurrah-tv \
+     --title "<plan title — typically matches the plan filename>" \
+     --body "$(cat <<'EOF'
+   ## Plan
+   See \`Plans/<feature-name>.md\` for the phased breakdown.
+
+   ## Why
+   <1-2 sentences from the plan's Context section>
+
+   ## Acceptance criteria
+   - [ ] All phases shipped per the plan
+   - [ ] Verification steps from the plan completed
+
+   Surfaced by: /xplan on $(date +%Y-%m-%d)
+   EOF
+   )" \
+     --label "type:<feature|enhancement|refactor|chore>,area:<api|client|auth|ai-curation|tmdb|design|docs|infra>,phase:next,difficulty:<starter|intermediate|advanced>"
+   ```
+   No project-board step — Hurrah.Tv is label-driven (per CLAUDE.md "Issue Tracking" section). `phase:next` is the default; bump to `phase:now` only when about to start.
+3. **Skip** — for internal-only plans (e.g., research notes that won't produce a deliverable). Front-matter line stays as `Tracking issue: (none — internal plan)`.
+
+The plan's front matter must end up with one of these three forms:
+```markdown
+> **Tracking issue:** mkerchenski/hurrah-tv#69
+> **Tracking issue:** (none — internal plan)
+> **Tracking issue:** mkerchenski/hurrah-tv#69 (created via /xplan on YYYY-MM-DD)
+```
+
+#### 1.5 Save
+
+Save the augmented plan to `Plans/<feature-name>.md` with the tracking-issue front-matter line populated. The approval already happened inside plan mode — this step writes the durable artifact (referenceable across sessions, surfaced from the GitHub issue when one was created or linked).
+
+Tell the user: "Plan saved to `Plans/{feature-name}.md`. Tracking: `{issue ref or 'none'}`. Start Phase 1 now, or revisit later?" — don't auto-start; multi-phase work often picks up in a future session.
 
 ---
 

--- a/.claude/skills/xreview/skill.md
+++ b/.claude/skills/xreview/skill.md
@@ -76,6 +76,13 @@ Also gather:
 - `git diff --name-only [range]` for changed files
 - The CLAUDE.md content
 - Any `Learnings/*.md` in scope of the diff
+- **Linked GitHub issues** (only when scope is `--unpushed` or includes commits): parse commit messages for `#NNN` references and pull each issue's body so reviewer agents can compare the diff against acceptance criteria. Hurrah.Tv conventionally uses `closes #NN` / `fixes #NN` to auto-close on merge:
+  ```bash
+  git log <range> --format=%B | grep -oE '#[0-9]+' | sort -u
+  # for each match:
+  gh issue view <num> --repo mkerchenski/hurrah-tv --json title,body,labels,state
+  ```
+  Treat any issue's "Acceptance criteria" checklist as a hard checklist for the diff. If a commit says `closes #NN` but the diff doesn't appear to satisfy the criteria, that's a high-severity finding.
 
 #### 2. Run dotnet format (auto-fix at info severity)
 
@@ -259,6 +266,22 @@ Verify `README.md` accurately reflects the current state:
 - Architecture diagram/table matches current project layout
 
 If out of date, flag as an issue (count toward the score-50+ list) and offer to update.
+
+#### 7a. Linked-issue comment (optional, opt-in only)
+
+Skip entirely if no `#NNN` references were found in step 1's commit-message scan. Otherwise, after the README check and before the Fix prompt, offer to post a one-line comment on each linked issue summarizing the review state. **Default = no.** Per Output Rule "NEVER post to GitHub automatically," this requires explicit confirmation.
+
+Use `AskUserQuestion` with three options:
+- **Comment on all linked issues**
+- **Pick which to comment on**
+- **Skip** (Recommended default for routine reviews)
+
+If picked, format per issue:
+```bash
+gh issue comment <num> --repo mkerchenski/hurrah-tv --body "/xreview ($(date +%Y-%m-%d), <range>): <one-line state>. Findings: <N issues at score ≥ 50, or 'clean'>."
+```
+
+If a linked issue's commit said `closes #NN` but the diff doesn't satisfy the issue's acceptance criteria (a reviewer agent flagged this), do NOT post automatically — surface to the user as a high-severity finding and let them decide whether to comment, fix the diff, or rewrite the issue body.
 
 #### 8. Fix
 

--- a/.claude/skills/xsimplify/skill.md
+++ b/.claude/skills/xsimplify/skill.md
@@ -20,7 +20,38 @@ Skill(skill="simplify")
 
 Let it complete its full review-and-fix workflow on the recently-changed code before continuing. This skill adds an elevation lens on top — it does not replace simplify's reuse / quality / efficiency review.
 
-### Step 2 — Determine the diff scope
+### Step 2 — Surface skipped findings as tracking issues
+
+The system simplify pass deliberately skips findings that don't justify inline cleanup — refactor-scoped items that would balloon scope, scope-creep across the rest of the file/module, low-severity micro-optimizations, and "out of scope for this branch" judgement calls. Those skipped items are exactly what tends to get lost.
+
+Before continuing to the Shared elevation pass, look back at what Step 1 reported but did *not* fix, and ask the user whether any deserve a tracking issue. Show the proposed title / body / labels before running. Issue body follows the CLAUDE.md "Issue body shape":
+
+```bash
+gh issue create --repo mkerchenski/hurrah-tv \
+  --title "<short, imperative title naming the smell>" \
+  --body "## What
+<one-line summary of the smell lifted from the simplify finding>
+
+## Why
+<reviewer agent's reasoning + file:line that surfaced it>
+
+## Acceptance criteria
+- [ ] <concrete fix>
+- [ ] Build clean, smoke-test affected surface
+
+Surfaced by: /xsimplify on $(date +%Y-%m-%d)" \
+  --label "type:refactor,area:<api|client|auth|ai-curation|tmdb|design|docs|infra>,phase:next,difficulty:<intermediate|advanced>"
+```
+
+Default to `phase:next` (per CLAUDE.md Issue Tracking section). Use `type:refactor` for code-quality smells, `type:enhancement` for performance wins, `type:bug` only if the skipped item was a latent correctness issue.
+
+**Skip filing when:**
+
+- The smell is trivial (a comment trim, a one-line rename — just do it inline, don't file)
+- An existing open issue already covers it (search first: `gh issue list --repo mkerchenski/hurrah-tv --search "<keywords>" --state open`)
+- It's a generic micro-optimization with no measurable impact
+
+### Step 3 — Determine the diff scope
 
 Same as `/xreview` — branch-agnostic so it works on main too:
 
@@ -31,11 +62,11 @@ git diff HEAD                  # working tree (unstaged + staged)
 
 Union of those two = the elevation surface. If both empty → "No changes to elevate" and stop.
 
-### Step 3 — Scan relevant learnings
+### Step 4 — Scan relevant learnings
 
 Before deciding on elevation, glob `Learnings/**/*.md` for any past discoveries that bear on what should or shouldn't live in Shared. Read anything related to DTO contracts, JSON serialization, WASM datetime handling, or app-specific patterns that turned out to be deliberately non-shared. If a learning warns against promoting a shape, respect it.
 
-### Step 4 — HurrahTv.Shared elevation pass
+### Step 5 — HurrahTv.Shared elevation pass
 
 For each piece of changed code in `HurrahTv.Api/` or `HurrahTv.Client/`, ask:
 
@@ -63,7 +94,7 @@ Subfolder placement matches the existing organization in `HurrahTv.Shared/Models
 - Captures HTTP request state or DB connection state
 - Single call-site with no plausible second consumer on the other side of the wire
 
-### Step 5 — Apply hurrah-tv-specific constraints
+### Step 6 — Apply hurrah-tv-specific constraints
 
 - **Shared is a netstandard-friendly contract layer.** Both Api (.NET 10 / ASP.NET) and Client (Blazor WASM) reference it. Anything platform-specific breaks one side.
 - **Public-API stability isn't critical** since Shared isn't a published NuGet — it's a project reference. Renames are fine if you update both consumers in the same commit.
@@ -71,7 +102,7 @@ Subfolder placement matches the existing organization in `HurrahTv.Shared/Models
 - **JSON serialization round-trips.** Anything Shared crosses the wire as JSON; nullable fields, default values, and enum representations all matter. Avoid `ref` / `out` parameters in DTOs.
 - **No DI in Shared.** Shared types are POCOs / static helpers; if you need a service, it lives in the consuming project.
 
-### Step 6 — Report findings, await confirmation
+### Step 7 — Report findings, await confirmation
 
 ```
 ## HurrahTv.Shared Elevation Candidates

--- a/.claude/skills/xsimplify/skill.md
+++ b/.claude/skills/xsimplify/skill.md
@@ -86,6 +86,32 @@ Subfolder placement matches the existing organization in `HurrahTv.Shared/Models
 
 Wait for confirmation before moving anything.
 
+If a candidate's migration shape is **"fresh extraction"** OR it touches **both Api and Client** in non-trivial ways, the elevation is multi-day work — offer to file a `type:refactor` issue on `mkerchenski/hurrah-tv` so the work is tracked across sessions. Show the user the proposed body before running:
+
+```bash
+gh issue create --repo mkerchenski/hurrah-tv \
+  --title "Promote <component> from <Api|Client> to HurrahTv.Shared" \
+  --body "## What
+<one-line summary lifted from the candidate>
+
+## Why
+Both sides of the wire need to agree on this shape (or pure helper used in both).
+
+## Migration shape
+<fresh extraction | move + thin reference>
+
+## Acceptance criteria
+- [ ] Code moved to \`HurrahTv.Shared/Models/<file>\`
+- [ ] Original Api/Client call sites updated (or thin forwarder kept)
+- [ ] Build clean across all three projects
+- [ ] No platform-specific dependencies leaked into Shared
+
+Surfaced by: /xsimplify on $(date +%Y-%m-%d)" \
+  --label "type:refactor,area:<api or client>,phase:next,difficulty:<intermediate|advanced>"
+```
+
+Single-file, in-place simplifications stay inline — they're the system simplify skill's domain, not worth an issue.
+
 ## When to use
 
 - **After every meaningful change, before committing.** The default cadence — runs cheap, catches most simplification opportunities while the code is still warm.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,45 @@ PostgreSQL via Dapper (Npgsql). All tables created on startup via `DbService.Ini
 - Externalize state to files — plans, findings, intermediate results
 - One task per subagent for focused execution
 
+## Issue Tracking
+
+Issues live in **GitHub Issues** on the [`mkerchenski/hurrah-tv`](https://github.com/mkerchenski/hurrah-tv/issues) repo. There's no project board — the label scheme is the tracker (`gh issue list --label "phase:now"` is the "In Progress" view).
+
+**Label conventions** (already installed; visible via `gh label list --repo mkerchenski/hurrah-tv`):
+
+| Dimension | Prefix | Values |
+|---|---|---|
+| Type | `type:` | `bug`, `feature`, `enhancement`, `chore`, `refactor`, `docs` |
+| Area | `area:` | `api`, `client`, `auth`, `ai-curation`, `tmdb`, `design`, `docs`, `infra` |
+| Difficulty | `difficulty:` | `starter`, `intermediate`, `advanced` |
+| Phase | `phase:` | `now`, `next`, `future` |
+| Bare state | — | `bug`, `enhancement`, `good first issue`, `help wanted`, `wontfix`, `duplicate` |
+
+There's no `priority:*` scheme — `phase:*` does the work. There's no `effort:*` scheme — `difficulty:*` does the work.
+
+**When skills create issues:**
+- Default new issues to `phase:next` (Backlog equivalent). Use `phase:now` only if the user is about to act on it.
+- Always set at least one `area:*`. Skills writing API or Client code should match the architectural slice.
+- `from:audit` / `from:sentry` labels do NOT exist in this repo — use the body's "Surfaced by:" footer instead.
+
+**Issue body shape** (used by all skills):
+
+```markdown
+## What
+<one-line summary>
+
+## Why
+<motivation, evidence, or the workflow that surfaced it>
+
+## Acceptance criteria
+- [ ] <measurable outcome 1>
+- [ ] <measurable outcome 2>
+
+Surfaced by: /<skill> on YYYY-MM-DD
+```
+
+**Closing the loop:** commit messages use `closes #NN` / `fixes #NN` syntax — GitHub auto-closes the issue on merge to main. Don't manually close issues that the merge will close for you.
+
 ## Plans Directory
 
 Design documents and implementation plans stored in `Plans/` at repo root. Excluded from git (local only).

--- a/HurrahTv.Api/Endpoints/QueueEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/QueueEndpoints.cs
@@ -201,10 +201,4 @@ public static class QueueEndpoints
             return true; // malformed payload — don't hide
         }
     }
-
-    public record QueueStatusUpdate(QueueStatus Status);
-    public record PositionUpdate(int Position);
-    public record SentimentUpdate(int? Sentiment);
-    public record ProgressUpdate(int? Season, int? Episode);
-    public record SeenRequest(int TmdbId, string MediaType, string Title, string PosterPath, string AvailableOnJson, string BackdropPath = "");
 }

--- a/HurrahTv.Client/Components/WatchlistRow.razor
+++ b/HurrahTv.Client/Components/WatchlistRow.razor
@@ -202,33 +202,25 @@
 
     private string FormatAirBadge(QueueItem item)
     {
-        // episode dates come from Postgres TIMESTAMPTZ (Kind=Utc); compare in UTC calendar days
-        // for Kind-consistency. See Learnings/wasm-datetime-source-matters.md
         DateTime todayUtc = DateTime.UtcNow.Date;
 
         if (RowMode == "upcoming")
         {
-            if (!item.NextEpisodeDate.HasValue) return "";
-            int daysUntil = (int)(item.NextEpisodeDate.Value.Date - todayUtc).TotalDays;
-            // Home.razor's Upcoming filter guarantees daysUntil >= 0 — defensive clamp only.
-            if (daysUntil < 0) return "";
-            return daysUntil switch
+            return item.DaysUntilNextEpisode(todayUtc) switch
             {
-                0 => "today",
-                1 => "1d",
-                _ => $"{daysUntil}d"
+                null or < 0 => "",
+                0           => "today",
+                1           => "1d",
+                int d       => $"{d}d"
             };
         }
 
-        // watching mode: show how long ago the latest episode aired
-        if (!item.LatestEpisodeDate.HasValue) return "";
-        int daysAgo = (int)(todayUtc - item.LatestEpisodeDate.Value.Date).TotalDays;
-        if (daysAgo < 0 || daysAgo > 30) return "";
-        return daysAgo switch
+        return item.DaysSinceLatestEpisode(todayUtc) switch
         {
-            0 => "today",
-            1 => "1d ago",
-            _ => $"{daysAgo}d ago"
+            null or < 0 or > 30 => "",
+            0                   => "today",
+            1                   => "1d ago",
+            int d               => $"{d}d ago"
         };
     }
 }

--- a/HurrahTv.Client/Components/WatchlistRow.razor
+++ b/HurrahTv.Client/Components/WatchlistRow.razor
@@ -210,9 +210,14 @@
         {
             if (!item.NextEpisodeDate.HasValue) return "";
             int daysUntil = (int)(item.NextEpisodeDate.Value.Date - todayUtc).TotalDays;
-            // Home.razor's Upcoming filter guarantees daysUntil >= 1 — defensive clamp only.
-            if (daysUntil < 1) return "";
-            return daysUntil == 1 ? "1d" : $"{daysUntil}d";
+            // Home.razor's Upcoming filter guarantees daysUntil >= 0 — defensive clamp only.
+            if (daysUntil < 0) return "";
+            return daysUntil switch
+            {
+                0 => "today",
+                1 => "1d",
+                _ => $"{daysUntil}d"
+            };
         }
 
         // watching mode: show how long ago the latest episode aired

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -520,7 +520,8 @@ else
 
         // continue watching: Watching always shows; WantToWatch/Finished need date activity
         // Finished: recently aired only (7d window) — upcoming Finished go to Upcoming row
-        // WantToWatch: recently aired OR upcoming in the next 14 days
+        // WantToWatch: recently aired OR upcoming in the next 14 days. Airs-today items go to
+        // Upcoming (not here) so streaming-service badges sit alongside the "today" label.
         IEnumerable<QueueItem> watching = allItems
             .Where(i => IsStatusActive(i.Status)
                 && i.Status != QueueStatus.NotForMe
@@ -535,16 +536,16 @@ else
 
         _watchingItems = SortWatching(watching);
 
-        // Upcoming: strictly future NextEpisodeDate within the next 14 days. A past NextEpisodeDate
-        // can briefly occur between airtime and the next TMDb refresh — excluding it here keeps
-        // stale items from leaking in with a blank/negative badge, and Watching-status items are
-        // already surfaced by Continue Watching.
+        // upcoming: NextEpisodeDate from today through 14d ahead. `>= todayUtc` (not `>`) so
+        // airs-today shows surface here with a "today" badge; the lower bound still excludes a
+        // briefly-past NextEpisodeDate (between airtime and the next TMDb refresh) so no "-1d"
+        // leaks back — see #49/#70.
         IEnumerable<QueueItem> upcoming = allItems
             .Where(i => i.MediaType == "tv"
                 && i.Status != QueueStatus.NotForMe
                 && IsStatusActive(i.Status)
                 && i.NextEpisodeDate.HasValue
-                && i.NextEpisodeDate.Value.Date > todayUtc
+                && i.NextEpisodeDate.Value.Date >= todayUtc
                 && i.NextEpisodeDate.Value.Date <= fourteenDaysAheadUtc);
 
         _upcomingItems = SortUpcoming(upcoming);

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -507,46 +507,34 @@ else
 
     private void ApplyWatchlistFilters(List<QueueItem> allItems)
     {
-        // LatestEpisodeDate / NextEpisodeDate come from Postgres TIMESTAMPTZ (Kind=Utc) — compare
-        // in UTC calendar days so both operands share the same Kind. See Learnings/wasm-datetime-source-matters.md
         DateTime todayUtc = DateTime.UtcNow.Date;
-        DateTime sevenDaysAgoUtc = todayUtc.AddDays(-7);
-        DateTime fourteenDaysAheadUtc = todayUtc.AddDays(14);
 
-        // pre-filter existence: does the user have any TV/movie watchlist content at all?
-        // used by the section header so it stays visible even when chips filter everything out
+        // pre-filter existence: section header stays visible even when chips filter everything out
         _hasTvWatchlistContent = allItems.Any(i => i.MediaType == "tv" && i.Status != QueueStatus.NotForMe);
         _hasMovieWatchlistContent = allItems.Any(i => i.MediaType == "movie" && i.Status == QueueStatus.WantToWatch);
 
-        // continue watching: Watching always shows; WantToWatch/Finished need date activity
-        // Finished: recently aired only (7d window) — upcoming Finished go to Upcoming row
-        // WantToWatch: recently aired OR upcoming in the next 14 days. Airs-today items go to
-        // Upcoming (not here) so streaming-service badges sit alongside the "today" label.
+        // continue watching: Watching always shows; WantToWatch/Finished need date activity.
+        // Airs-today items route to Upcoming (not here) so streaming-service badges sit
+        // alongside the "today" label — keep strict > today on the NextEpisodeDate branch.
         IEnumerable<QueueItem> watching = allItems
             .Where(i => IsStatusActive(i.Status)
                 && i.Status != QueueStatus.NotForMe
                 && !i.IsLatestEpisodeWatched
                 && (MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType)
                 && (i.Status == QueueStatus.Watching
-                    || (i.LatestEpisodeDate.HasValue && i.LatestEpisodeDate.Value.Date >= sevenDaysAgoUtc)
-                    || (i.Status != QueueStatus.Finished
-                        && i.NextEpisodeDate.HasValue
-                        && i.NextEpisodeDate.Value.Date > todayUtc
-                        && i.NextEpisodeDate.Value.Date <= fourteenDaysAheadUtc)));
+                    || i.DaysSinceLatestEpisode(todayUtc) is <= 7
+                    || (i.Status != QueueStatus.Finished && i.DaysUntilNextEpisode(todayUtc) is >= 1 and <= 14)));
 
         _watchingItems = SortWatching(watching);
 
-        // upcoming: NextEpisodeDate from today through 14d ahead. `>= todayUtc` (not `>`) so
-        // airs-today shows surface here with a "today" badge; the lower bound still excludes a
-        // briefly-past NextEpisodeDate (between airtime and the next TMDb refresh) so no "-1d"
-        // leaks back — see #49/#70.
+        // upcoming: 0..14 days out. Lower bound is 0 (not 1) so airs-today surfaces here with a
+        // "today" badge; a briefly-past NextEpisodeDate between airtime and the next TMDb refresh
+        // still gets excluded — see #49/#70.
         IEnumerable<QueueItem> upcoming = allItems
             .Where(i => i.MediaType == "tv"
                 && i.Status != QueueStatus.NotForMe
                 && IsStatusActive(i.Status)
-                && i.NextEpisodeDate.HasValue
-                && i.NextEpisodeDate.Value.Date >= todayUtc
-                && i.NextEpisodeDate.Value.Date <= fourteenDaysAheadUtc);
+                && i.DaysUntilNextEpisode(todayUtc) is >= 0 and <= 14);
 
         _upcomingItems = SortUpcoming(upcoming);
 

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -111,6 +111,7 @@ else
                             : "text-gray-600 hover:text-gray-300";
                         // mobile padding hits the 44px tap-target minimum; desktop tightens
                         <button type="button"
+                                disabled="@reordering"
                                 class="@($"drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none p-3 -ml-2 md:p-1 md:-ml-1 rounded transition-opacity outline-none focus-visible:ring-2 focus-visible:ring-accent {handleStateClass}")"
                                 aria-label="@($"Reorder {item.Title}")"
                                 aria-pressed="@(grabbed ? "true" : "false")"
@@ -426,8 +427,11 @@ else
             _dotNetRef ??= DotNetObjectReference.Create(this);
             try
             {
+                // limit draggable to data-item-id rows so the aria-live region (a sibling
+                // direct child of _listEl) doesn't shift evt.oldIndex/newIndex by 1
                 _sortableHandle = await JS.InvokeAsync<IJSObjectReference>(
-                    "hurrahSortableInit", _listEl, _dotNetRef, nameof(OnReorder), null);
+                    "hurrahSortableInit", _listEl, _dotNetRef, nameof(OnReorder),
+                    new { draggable = "[data-item-id]" });
             }
             catch
             {
@@ -496,8 +500,10 @@ else
         if (oldIdx < 0 || newIdx < 0 || newIdx >= _visibleItems.Count) return;
 
         QueueItem target = _visibleItems[newIdx];
-        await MoveItemAsync(item, target);
-        _reorderAnnouncement = $"Moved {item.Title} to position {newIdx + 1} of {_visibleItems.Count}.";
+        bool ok = await MoveItemAsync(item, target);
+        _reorderAnnouncement = ok
+            ? $"Moved {item.Title} to position {newIdx + 1} of {_visibleItems.Count}."
+            : $"Move failed. {item.Title} returned to position {oldIdx + 1} of {_visibleItems.Count}.";
     }
 
     private void OnHandleBlur(int itemId)
@@ -520,10 +526,10 @@ else
         return dragged is null ? Task.CompletedTask : MoveItemAsync(dragged, _visibleItems[newIndex]);
     }
 
-    private async Task MoveItemAsync(QueueItem dragged, QueueItem target)
+    private async Task<bool> MoveItemAsync(QueueItem dragged, QueueItem target)
     {
         // a drag in flight when the user navigates away can deliver onEnd post-dispose
-        if (_disposed || ReferenceEquals(dragged, target)) return;
+        if (_disposed || ReferenceEquals(dragged, target)) return false;
 
         // ReorderAsync on the server sets dragged.Position = target.Position and shifts the
         // displaced item out of the way. Net effect: dragged lands exactly where target was.
@@ -531,7 +537,7 @@ else
 
         int draggedIdx = _items.IndexOf(dragged);
         int targetIdx = _items.IndexOf(target);
-        if (draggedIdx < 0 || targetIdx < 0) return;
+        if (draggedIdx < 0 || targetIdx < 0) return false;
         bool movingDown = draggedIdx < targetIdx;
 
         // _reorderVersion guards against an in-flight reorder's failure clobbering a newer one:
@@ -540,7 +546,7 @@ else
         List<QueueItem> snapshot = [.._items];
         _items.Remove(dragged);
         int targetInItems = _items.IndexOf(target);
-        if (targetInItems < 0) { _items = snapshot; return; }
+        if (targetInItems < 0) { _items = snapshot; return false; }
         _items.Insert(movingDown ? targetInItems + 1 : targetInItems, dragged);
         _reorderingIds.Add(dragged.Id);
         RecomputeVisible();
@@ -549,8 +555,8 @@ else
         bool shouldRevert = false;
         try
         {
-            bool ok = await Api.UpdateQueuePositionAsync(dragged.Id, targetPos);
-            shouldRevert = !ok;
+            bool apiOk = await Api.UpdateQueuePositionAsync(dragged.Id, targetPos);
+            shouldRevert = !apiOk;
         }
         catch
         {
@@ -566,6 +572,7 @@ else
             _reorderingIds.Remove(dragged.Id);
             await InvokeAsync(StateHasChanged);
         }
+        return !shouldRevert;
     }
 
     public async ValueTask DisposeAsync()

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -15,20 +15,45 @@
 
 @if (!_loading && _items.Count > 0)
 {
-    <!-- filter tabs (scrollable on mobile) -->
-    <div class="flex gap-2 mb-4 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-none">
+    <!-- status tabs (scrollable on mobile) -->
+    <div class="flex gap-2 mb-3 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-none">
         @foreach ((string key, string label) in _tabs)
         {
             int count = key == "all" ? _totalCount : _statusCounts.GetValueOrDefault(key, 0);
             bool active = _activeTab == key;
             <button class="@($"flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-all whitespace-nowrap {(active ? "bg-surface-100 text-white" : "bg-surface-50 text-gray-400 hover:text-white")}")"
-                    @onclick="() => { _activeTab = key; _expandedStatusId = null; }">
+                    @onclick="() => SelectTab(key)">
                 <span class="@TabIcon(key) w-3.5 h-3.5 @(active ? "opacity-90" : "opacity-50")"></span>
                 @label
                 <span class="@(active ? "opacity-60" : "opacity-40") text-xs">@count</span>
             </button>
         }
     </div>
+
+    @if (_userServices.Count > 1)
+    {
+        <!-- service filter (icon-only) -->
+        <div class="flex gap-2 mb-4 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-none">
+            <button class="@($"flex items-center justify-center px-3 py-1.5 rounded-full text-sm transition-all whitespace-nowrap {(_selectedServiceId is null ? "bg-surface-100 text-white" : "bg-surface-50 text-gray-400 hover:text-white")}")"
+                    @onclick="() => SelectService(null)"
+                    aria-pressed="@(_selectedServiceId is null ? "true" : "false")">
+                All
+            </button>
+            @foreach (int providerId in _userServices)
+            {
+                StreamingService? svc = StreamingService.ById.GetValueOrDefault(providerId);
+                if (svc is null) continue;
+                bool active = _selectedServiceId == providerId;
+                <button class="@($"flex items-center justify-center p-1.5 rounded-full transition-all flex-shrink-0 {(active ? "bg-surface-100 ring-2 ring-accent" : "bg-surface-50 hover:bg-surface-100 opacity-60 hover:opacity-100")}")"
+                        @onclick="() => SelectService(providerId)"
+                        title="@svc.Name"
+                        aria-label="@($"Filter by {svc.Name}")"
+                        aria-pressed="@(active ? "true" : "false")">
+                    <img src="@svc.LogoUrl("w45")" alt="" class="w-6 h-6 rounded" />
+                </button>
+            }
+        </div>
+    }
 }
 
 @if (_loading)
@@ -60,35 +85,40 @@ else if (_items.Count == 0)
         </a>
     </div>
 }
+else if (_visibleItems.Count == 0)
+{
+    <!-- filtered empty state -->
+    <div class="text-center py-12 fade-in">
+        <p class="text-gray-500 text-sm">Nothing here yet</p>
+        <p class="text-gray-600 text-xs mt-1">Items you mark as "@(_tabs.FirstOrDefault(t => t.key == _activeTab).label ?? _activeTab)" will show up here.</p>
+    </div>
+}
 else
 {
-    List<QueueItem> visible = FilteredItems.ToList();
-
-    @if (!visible.Any())
-    {
-        <!-- filtered empty state -->
-        <div class="text-center py-12 fade-in">
-            <p class="text-gray-500 text-sm">Nothing here yet</p>
-            <p class="text-gray-600 text-xs mt-1">Items you mark as "@(_tabs.FirstOrDefault(t => t.key == _activeTab).label ?? _activeTab)" will show up here.</p>
-        </div>
-    }
-    else
-    {
-        <div @ref="_listEl" class="space-y-2 md:space-y-3 fade-in">
-            @foreach (QueueItem item in visible)
-            {
+    <div @ref="_listEl" class="space-y-2 md:space-y-3 fade-in">
+        <div role="status" aria-live="polite" class="sr-only">@_reorderAnnouncement</div>
+        @foreach (QueueItem item in _visibleItems)
+        {
                 <div @key="item.Id" data-item-id="@item.Id"
                      class="flex items-center gap-3 md:gap-4 bg-surface-50 rounded-lg p-2.5 md:p-3 hover:bg-surface-100 transition-colors group">
 
                     @if (_activeTab == WantToWatchTab)
                     {
                         bool reordering = _reorderingIds.Contains(item.Id);
-                        // visual-only drag affordance; SortableJS owns the gesture. aria-hidden
-                        // because v1 is mouse/touch-only — keyboard reorder is a planned follow-on.
-                        <div class="@($"drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1 transition-opacity {(reordering ? "opacity-30 pointer-events-none" : "text-gray-600 hover:text-gray-300")}")"
-                             aria-hidden="true">
+                        bool grabbed = _grabbedItemId == item.Id;
+                        string handleStateClass = reordering ? "opacity-30 pointer-events-none"
+                            : grabbed ? "text-accent ring-2 ring-accent"
+                            : "text-gray-600 hover:text-gray-300";
+                        // mobile padding hits the 44px tap-target minimum; desktop tightens
+                        <button type="button"
+                                class="@($"drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none p-3 -ml-2 md:p-1 md:-ml-1 rounded transition-opacity outline-none focus-visible:ring-2 focus-visible:ring-accent {handleStateClass}")"
+                                aria-label="@($"Reorder {item.Title}")"
+                                aria-pressed="@(grabbed ? "true" : "false")"
+                                @onkeydown="@(e => OnHandleKeyDownAsync(item, e))"
+                                @onkeydown:preventDefault="@grabbed"
+                                @onblur="@(() => OnHandleBlur(item.Id))">
                             <span class="icon-[heroicons--bars-3] w-5 h-5 block"></span>
-                        </div>
+                        </button>
                     }
 
                     <a href="/details/@item.MediaType/@item.TmdbId" class="flex-shrink-0 relative">
@@ -183,21 +213,23 @@ else
                             @onclick="() => Remove(item)" title="Remove from list">
                         <span class="icon-[heroicons--trash] w-4 h-4"></span>
                     </button>
-                </div>
-            }
-        </div>
-    }
+            </div>
+        }
+    </div>
 }
 
 @code {
     private List<QueueItem> _items = [];
+    private List<QueueItem> _visibleItems = [];
     private Dictionary<string, int> _statusCounts = [];
     private Dictionary<int, List<StreamingService>> _itemServices = [];
+    private Dictionary<int, HashSet<int>> _itemProviderIds = [];
     private IReadOnlyList<int> _userServices = [];
     private int _totalCount;
     private bool _loading = true;
     private string _activeTab = "all";
     private int? _expandedStatusId;
+    private int? _selectedServiceId;
 
     // drag-reorder is meaningful only on the WantToWatch tab — Position is the primary
     // sort signal there; other tabs are sorted by recency / status. See Plans/issue-39.
@@ -210,6 +242,9 @@ else
     private readonly HashSet<int> _reorderingIds = [];
     private int _reorderVersion;
     private bool _disposed;
+
+    private int? _grabbedItemId;
+    private string _reorderAnnouncement = "";
 
     private static readonly (string key, string label)[] _tabs =
     [
@@ -238,24 +273,41 @@ else
         _                       => "unknown"
     };
 
-    private IEnumerable<QueueItem> FilteredItems =>
-        (_activeTab == "all" ? _items : _items.Where(i => StatusKey(i.Status) == _activeTab))
-        .Where(i => MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType);
+    // call after any change to _items / _activeTab / MediaFilter / _selectedServiceId / _itemProviderIds
+    private void RecomputeVisible()
+    {
+        _visibleItems = [.. _items
+            .Where(i => _activeTab == "all" || StatusKey(i.Status) == _activeTab)
+            .Where(i => MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType)
+            .Where(i => _selectedServiceId is not int svcId || _itemProviderIds.GetValueOrDefault(i.Id)?.Contains(svcId) == true)];
+    }
 
     protected override async Task OnInitializedAsync()
     {
         MediaFilter.OnChanged += OnMediaFilterChanged;
         UserServicesCache.Changed += OnServicesChanged;
-        _userServices = await UserServicesCache.GetAsync();
-        await LoadQueue();
+        _loading = true;
+        Task<IReadOnlyList<int>> servicesTask = UserServicesCache.GetAsync();
+        Task<List<QueueItem>> queueTask = Api.GetQueueAsync();
+        await Task.WhenAll(servicesTask, queueTask);
+        _userServices = servicesTask.Result;
+        _items = queueTask.Result;
+        _loading = false;
+        UpdateItemServices();
+        UpdateCounts();
+        RecomputeVisible();
     }
 
-    private void OnMediaFilterChanged() => InvokeAsync(() => { UpdateCounts(); StateHasChanged(); });
+    private void OnMediaFilterChanged() => InvokeAsync(() => { UpdateCounts(); RecomputeVisible(); StateHasChanged(); });
 
     private void OnServicesChanged()
     {
         _userServices = UserServicesCache.TryGetCached();
+        // selected service may have just been removed from the user's active set
+        if (_selectedServiceId is int svcId && !_userServices.Contains(svcId)) _selectedServiceId = null;
         UpdateItemServices();
+        UpdateCounts();
+        RecomputeVisible();
         InvokeAsync(StateHasChanged);
     }
 
@@ -264,24 +316,68 @@ else
         _loading = true;
         _items = await Api.GetQueueAsync();
         _loading = false;
-        UpdateCounts();
         UpdateItemServices();
+        UpdateCounts();
+        RecomputeVisible();
+    }
+
+    private void SelectTab(string key)
+    {
+        if (_activeTab == key) return;
+        _activeTab = key;
+        _expandedStatusId = null;
+        _grabbedItemId = null;
+        RecomputeVisible();
     }
 
     private void UpdateItemServices()
     {
-        _itemServices = _items.ToDictionary(i => i.Id, i => i.VisibleServicesFor(_userServices));
+        // single parse of AvailableOnJson per item drives both the full provider-id set
+        // (filter predicate) and the user-visible badge list (capped at 2)
+        HashSet<int> userSet = [.. _userServices];
+        Dictionary<int, List<StreamingService>> itemServices = new(_items.Count);
+        Dictionary<int, HashSet<int>> itemProviderIds = new(_items.Count);
+        foreach (QueueItem item in _items)
+        {
+            List<int> parsed = item.ParseAvailableOnProviderIds();
+            itemProviderIds[item.Id] = [.. parsed];
+
+            List<StreamingService> visible = [];
+            if (userSet.Count > 0)
+            {
+                foreach (int id in parsed)
+                {
+                    if (visible.Count >= 2) break;
+                    if (!userSet.Contains(id)) continue;
+                    if (!StreamingService.ById.TryGetValue(id, out StreamingService? svc)) continue;
+                    visible.Add(svc);
+                }
+            }
+            itemServices[item.Id] = visible;
+        }
+        _itemServices = itemServices;
+        _itemProviderIds = itemProviderIds;
     }
 
     private void UpdateCounts()
     {
-        IEnumerable<QueueItem> scoped = MediaFilter.MediaType == "all"
-            ? _items
-            : _items.Where(i => i.MediaType == MediaFilter.MediaType);
-        _totalCount = scoped.Count();
-        _statusCounts = scoped
+        IEnumerable<QueueItem> scoped = _items
+            .Where(i => MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType)
+            .Where(i => _selectedServiceId is not int svcId || _itemProviderIds.GetValueOrDefault(i.Id)?.Contains(svcId) == true);
+        List<QueueItem> scopedList = [.. scoped];
+        _totalCount = scopedList.Count;
+        _statusCounts = scopedList
             .GroupBy(i => StatusKey(i.Status))
             .ToDictionary(g => g.Key, g => g.Count());
+    }
+
+    private void SelectService(int? providerId)
+    {
+        if (_selectedServiceId == providerId) return;
+        _selectedServiceId = providerId;
+        _expandedStatusId = null;
+        UpdateCounts();
+        RecomputeVisible();
     }
 
     private async Task SelectStatus(QueueItem item, QueueStatus status)
@@ -293,8 +389,7 @@ else
             QueueItem? updated = await Api.UpdateStatusAsync(item.Id, status);
             if (updated != null)
             {
-                // splice the fresh server state into our list and notify listeners (e.g. Home,
-                // if it's still mounted) so they can update in place without a refetch
+                // splice the fresh server state in so Home (if mounted) can update without a refetch
                 int idx = _items.IndexOf(item);
                 if (idx >= 0) _items[idx] = updated;
                 QuickActionSvc.NotifyItemUpdated(updated);
@@ -304,6 +399,7 @@ else
                 item.Status = status; // optimistic fallback
             }
             UpdateCounts();
+            RecomputeVisible();
         }
         catch { }
     }
@@ -315,13 +411,14 @@ else
             await Api.RemoveFromQueueAsync(item.Id);
             _items.Remove(item);
             UpdateCounts();
+            RecomputeVisible();
         }
         catch { }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        bool wantSortable = _activeTab == WantToWatchTab && !_loading && FilteredItems.Any();
+        bool wantSortable = _activeTab == WantToWatchTab && !_loading && _visibleItems.Count > 0;
 
         if (wantSortable && _attachedTab != _activeTab)
         {
@@ -357,41 +454,102 @@ else
         _attachedTab = null;
     }
 
-    [JSInvokable]
-    public async Task OnReorder(int itemId, int oldIndex, int newIndex)
+    private async Task OnHandleKeyDownAsync(QueueItem item, KeyboardEventArgs e)
     {
-        // a drag in flight when the user navigates away can deliver onEnd after
-        // the component is gone — do not mutate state on a disposed component
-        if (_disposed || oldIndex == newIndex) return;
+        if (_activeTab != WantToWatchTab) return;
 
-        List<QueueItem> visible = FilteredItems.ToList();
-        if (newIndex < 0 || newIndex >= visible.Count) return;
+        if (e.Key is " " or "Enter")
+        {
+            if (_grabbedItemId == item.Id)
+            {
+                _grabbedItemId = null;
+                _reorderAnnouncement = $"Dropped {item.Title}.";
+            }
+            else
+            {
+                _grabbedItemId = item.Id;
+                int idx = _visibleItems.IndexOf(item);
+                _reorderAnnouncement = $"Picked up {item.Title}. Position {idx + 1} of {_visibleItems.Count}. Use arrow keys to move, space to drop.";
+            }
+            return;
+        }
 
-        QueueItem? dragged = visible.FirstOrDefault(i => i.Id == itemId);
-        QueueItem target = visible[newIndex];
-        if (dragged is null || ReferenceEquals(dragged, target)) return;
+        if (_grabbedItemId != item.Id) return;
 
-        // ReorderAsync sets dragged.Position = target.Position and shifts the displaced
-        // item out of the way. Net effect: dragged lands exactly where target used to be.
+        if (e.Key == "Escape")
+        {
+            _grabbedItemId = null;
+            _reorderAnnouncement = "Exited reorder mode.";
+            return;
+        }
+
+        int delta = e.Key switch
+        {
+            "ArrowUp"   => -1,
+            "ArrowDown" => +1,
+            _           => 0
+        };
+        if (delta == 0) return;
+
+        int oldIdx = _visibleItems.IndexOf(item);
+        int newIdx = oldIdx + delta;
+        if (oldIdx < 0 || newIdx < 0 || newIdx >= _visibleItems.Count) return;
+
+        QueueItem target = _visibleItems[newIdx];
+        await MoveItemAsync(item, target);
+        _reorderAnnouncement = $"Moved {item.Title} to position {newIdx + 1} of {_visibleItems.Count}.";
+    }
+
+    private void OnHandleBlur(int itemId)
+    {
+        // focus leaving the handle while grabbed = abandon — keeps state from leaking
+        // across the page (e.g. user Tabs to a status button mid-reorder)
+        if (_grabbedItemId == itemId)
+        {
+            _grabbedItemId = null;
+            _reorderAnnouncement = "Exited reorder mode.";
+        }
+    }
+
+    [JSInvokable]
+    public Task OnReorder(int itemId, int oldIndex, int newIndex)
+    {
+        if (_disposed || oldIndex == newIndex) return Task.CompletedTask;
+        if (newIndex < 0 || newIndex >= _visibleItems.Count) return Task.CompletedTask;
+        QueueItem? dragged = _visibleItems.FirstOrDefault(i => i.Id == itemId);
+        return dragged is null ? Task.CompletedTask : MoveItemAsync(dragged, _visibleItems[newIndex]);
+    }
+
+    private async Task MoveItemAsync(QueueItem dragged, QueueItem target)
+    {
+        // a drag in flight when the user navigates away can deliver onEnd post-dispose
+        if (_disposed || ReferenceEquals(dragged, target)) return;
+
+        // ReorderAsync on the server sets dragged.Position = target.Position and shifts the
+        // displaced item out of the way. Net effect: dragged lands exactly where target was.
         int targetPos = target.Position;
 
-        // optimistic local rearrange so the UI doesn't snap back during the API call.
-        // _reorderVersion is captured per-call: a later drag bumps the version, so an
-        // older failure won't revert and clobber the newer drag's local mutation.
+        int draggedIdx = _items.IndexOf(dragged);
+        int targetIdx = _items.IndexOf(target);
+        if (draggedIdx < 0 || targetIdx < 0) return;
+        bool movingDown = draggedIdx < targetIdx;
+
+        // _reorderVersion guards against an in-flight reorder's failure clobbering a newer one:
+        // a later move bumps the version so older failure-paths see a mismatch and skip revert.
         int version = ++_reorderVersion;
         List<QueueItem> snapshot = [.._items];
         _items.Remove(dragged);
         int targetInItems = _items.IndexOf(target);
         if (targetInItems < 0) { _items = snapshot; return; }
-        int insertAt = newIndex > oldIndex ? targetInItems + 1 : targetInItems;
-        _items.Insert(insertAt, dragged);
-        _reorderingIds.Add(itemId);
+        _items.Insert(movingDown ? targetInItems + 1 : targetInItems, dragged);
+        _reorderingIds.Add(dragged.Id);
+        RecomputeVisible();
         await InvokeAsync(StateHasChanged);
 
         bool shouldRevert = false;
         try
         {
-            bool ok = await Api.UpdateQueuePositionAsync(itemId, targetPos);
+            bool ok = await Api.UpdateQueuePositionAsync(dragged.Id, targetPos);
             shouldRevert = !ok;
         }
         catch
@@ -400,8 +558,12 @@ else
         }
         finally
         {
-            if (shouldRevert && version == _reorderVersion) _items = snapshot;
-            _reorderingIds.Remove(itemId);
+            if (shouldRevert && version == _reorderVersion)
+            {
+                _items = snapshot;
+                RecomputeVisible();
+            }
+            _reorderingIds.Remove(dragged.Id);
             await InvokeAsync(StateHasChanged);
         }
     }

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -89,25 +89,25 @@ public class ApiClient(HttpClient http)
 
     public async Task<QueueItem?> UpdateStatusAsync(int id, QueueStatus status)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/status", new { Status = status });
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/status", new QueueStatusUpdate(status));
         return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>() : null;
     }
 
     public async Task<QueueItem?> UpdateSentimentAsync(int id, int? sentiment)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/sentiment", new { Sentiment = sentiment });
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/sentiment", new SentimentUpdate(sentiment));
         return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>() : null;
     }
 
     public async Task<bool> UpdateQueuePositionAsync(int id, int position)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/position", new { Position = position });
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/position", new PositionUpdate(position));
         return res.IsSuccessStatusCode;
     }
 
     public async Task<QueueItem?> UpdateProgressAsync(int id, int? season, int? episode)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/progress", new { Season = season, Episode = episode });
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/progress", new ProgressUpdate(season, episode));
         return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>() : null;
     }
 
@@ -132,15 +132,8 @@ public class ApiClient(HttpClient http)
     private async Task<QueueItem?> PostStatusAsync(string endpoint, SearchResult result)
     {
         QueueItem qi = result.ToQueueItem();
-        HttpResponseMessage response = await _http.PostAsJsonAsync(endpoint, new
-        {
-            result.TmdbId,
-            result.MediaType,
-            result.Title,
-            result.PosterPath,
-            result.BackdropPath,
-            qi.AvailableOnJson
-        });
+        SeenRequest request = new(result.TmdbId, result.MediaType, result.Title, result.PosterPath, qi.AvailableOnJson, result.BackdropPath);
+        HttpResponseMessage response = await _http.PostAsJsonAsync(endpoint, request);
         if (response.IsSuccessStatusCode)
             return await response.Content.ReadFromJsonAsync<QueueItem>();
         return null;

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -436,6 +436,9 @@
   .-ml-1 {
     margin-left: calc(var(--spacing) * -1);
   }
+  .-ml-2 {
+    margin-left: calc(var(--spacing) * -2);
+  }
   .ml-0\.5 {
     margin-left: calc(var(--spacing) * 0.5);
   }
@@ -1563,6 +1566,10 @@
     --tw-duration: 200ms;
     transition-duration: 200ms;
   }
+  .outline-none {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
   .poster-card {
     transition: transform 0.2s ease, box-shadow 0.2s ease;
   }
@@ -1851,6 +1858,13 @@
       }
     }
   }
+  .hover\:opacity-100 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 100%;
+      }
+    }
+  }
   .hover\:ring-1 {
     &:hover {
       @media (hover: hover) {
@@ -1879,6 +1893,17 @@
     &:focus {
       --tw-outline-style: none;
       outline-style: none;
+    }
+  }
+  .focus-visible\:ring-2 {
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus-visible\:ring-accent {
+    &:focus-visible {
+      --tw-ring-color: var(--color-accent);
     }
   }
   .active\:cursor-grabbing {
@@ -2016,6 +2041,11 @@
       margin-bottom: calc(var(--spacing) * 12);
     }
   }
+  .md\:-ml-1 {
+    @media (width >= 48rem) {
+      margin-left: calc(var(--spacing) * -1);
+    }
+  }
   .md\:block {
     @media (width >= 48rem) {
       display: block;
@@ -2133,6 +2163,11 @@
   .md\:rounded-xl {
     @media (width >= 48rem) {
       border-radius: var(--radius-xl);
+    }
+  }
+  .md\:p-1 {
+    @media (width >= 48rem) {
+      padding: calc(var(--spacing) * 1);
     }
   }
   .md\:p-3 {

--- a/HurrahTv.Shared/Models/QueueItemExtensions.cs
+++ b/HurrahTv.Shared/Models/QueueItemExtensions.cs
@@ -17,6 +17,15 @@ public static class QueueItemExtensions
         }
     }
 
+    // UTC calendar-day diffs are load-bearing for episode date logic — Postgres TIMESTAMPTZ
+    // is Kind=Utc, so both operands must be UTC dates to avoid the Kind-mismatch drift that
+    // bit us in #49/#70. Centralized here so Home filters and WatchlistRow badges can't drift.
+    public static int? DaysUntilNextEpisode(this QueueItem item, DateTime todayUtc) =>
+        item.NextEpisodeDate is { } d ? (int)(d.Date - todayUtc.Date).TotalDays : null;
+
+    public static int? DaysSinceLatestEpisode(this QueueItem item, DateTime todayUtc) =>
+        item.LatestEpisodeDate is { } d ? (int)(todayUtc.Date - d.Date).TotalDays : null;
+
     // returns known streaming services the user subscribes to, in provider-ID order
     // from the QueueItem's stored list, capped at max. Unknown providers are skipped.
     public static List<StreamingService> VisibleServicesFor(

--- a/HurrahTv.Shared/Models/QueueModels.cs
+++ b/HurrahTv.Shared/Models/QueueModels.cs
@@ -1,0 +1,11 @@
+namespace HurrahTv.Shared.Models;
+
+public record QueueStatusUpdate(QueueStatus Status);
+
+public record PositionUpdate(int Position);
+
+public record SentimentUpdate(int? Sentiment);
+
+public record ProgressUpdate(int? Season, int? Episode);
+
+public record SeenRequest(int TmdbId, string MediaType, string Title, string PosterPath, string AvailableOnJson, string BackdropPath = "");


### PR DESCRIPTION
## Summary

- Service filter chip row on the Queue page — **partially** closes #40 (filter chips + additive combination + responsive layout shipped; URL persistence + visible clear-all deferred to #76)
- Keyboard drag-reorder a11y — closes #66
- Mobile drag-reorder — handle tap target now meets the 44px iOS/Android minimum
- Airs-today fix on Home — closes #70
- Queue mutation DTOs promoted to `HurrahTv.Shared` — closes #64
- Internal cleanup from `/xsimplify`: single-pass JSON parsing, `MoveItemAsync` shared by drag + keyboard, cached `_visibleItems`, parallel first-load fetches, `DaysUntilNextEpisode` / `DaysSinceLatestEpisode` extensions on `QueueItem` so Home filters and `WatchlistRow.FormatAirBadge` can't drift on UTC calendar-day diffs again
- Docs: "Issue Tracking" section added to CLAUDE.md; the five project skills (`xplan`, `xreview`, `xsimplify`, `compound`, `deploy`) updated to participate in the label-driven workflow
- `/xreview` fix-up commit on top: corrected a SortableJS index-shift caused by the new aria-live region (drag-reorder regression), made the drag handle unfocusable during in-flight reorders, and made the keyboard move announcement honest about revert-on-failure

## Follow-on issues filed during this PR

- #73 — Extract a `Chip` primitive (from `/xsimplify` skipped findings)
- #74 — Type Queue tab/status keys as `QueueStatus?` (from `/xsimplify` skipped findings)
- #76 — Queue filters: URL persistence + visible clear-all (split from #40, deferred from this PR's scope)

## Test plan

- [ ] Queue: mouse drag-reorder lands the item in the slot you dropped it into (verify the SortableJS index fix — items should move exactly where you drag them, not one slot off)
- [ ] Queue: touch drag-reorder on a mobile device or DevTools responsive mode
- [ ] Queue: keyboard reorder — Tab to a drag handle, Space to grab, Arrow Up/Down to move, Space/Escape to exit; aria-live region announces grab/move/exit
- [ ] Queue: keyboard reorder during an in-flight drag — handle should be disabled (unfocusable) while the API is in flight
- [ ] Queue: keyboard reorder when the API call fails (e.g. kill the API mid-arrow) — announcement should say "Move failed. X returned to position Y", not the intended position
- [ ] Queue: service filter — chip row appears when the user has 2+ active streaming services; single-select narrows the queue; "All" restores; tab counts update accordingly
- [ ] Queue: status flip, sentiment toggle, progress save, "I've seen this", remove — all still work (exercises the typed DTOs from #64)
- [ ] Home: a TV show airing today appears in the Upcoming row with a "today" badge
- [ ] Home: shows airing tomorrow through 14 days ahead still appear in Upcoming
- [ ] Home: Continue Watching doesn't duplicate airs-today shows
- [ ] Home: WatchlistRow "Xd ago" badge on Continue Watching still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)