### PR TITLE
Tests: cover HasUpcomingThisWeek + HasEpisodeThisMonth + add Testing policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Lean test-first when the rules are spec-able from the issue (date windows, filte
 **Style:**
 - No mocking frameworks. Plain `Assert` calls, no fluent-assertion libraries.
 - Test helpers (`TvItem`, local builder methods) live inside the test class — no shared test-base machinery.
-- Inject time via parameter — never call `DateTime.UtcNow` inside a helper that's tested by date-sensitive specs.
+- Inject time via parameter for extracted static helpers and pipelines (see `WatchlistFilters.Apply` accepting `DateTime todayUtc`). Computed properties on model DTOs (e.g. `QueueItem.HasNewEpisode`) can't take parameters and use `DateTime.UtcNow` inline — that's acceptable for full-day windows where microsecond drift between the test's `UtcNow` and the predicate's `UtcNow` can't cross a boundary; refactor to methods only if you need to test the exact fence.
 - Prefer direct `DateTime` comparisons over signed day-diff integers in predicates (see `Learnings/date-predicates-prefer-typed-comparisons.md`) — a wrong-sign value silently passes `is <= 7`.
 
 **Plans:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,31 @@ PostgreSQL via Dapper (Npgsql). All tables created on startup via `DbService.Ini
 - Prefer `Type variableName` over `var` when type isn't complex
 - Pre-compute per-status/per-tab counts with `GroupBy().ToDictionary()` after data mutations — never run `Count()` per tab inside a render loop (O(N×tabs) per render)
 
+## Testing
+
+`dotnet test` runs via `HurrahTv.slnx`. New test projects must be referenced there. Current coverage lives in `HurrahTv.Shared.Tests/`.
+
+**When tests are required:**
+- New or changed pure logic in `HurrahTv.Shared` — predicates, filters, sort keys, parsers, extension methods. This is where the worst bugs hide (#49 was a stale-date leak caught only at runtime). One named regression test per bug fix, referencing the issue number (e.g. `AvailableLater_Excludes_NextEpisode_In_The_Past` // pins #49/#70).
+
+**When tests are NOT required:**
+- Blazor components, CSS, page wiring, service-DI scaffolding. Verify these in the browser per the system rule for UI changes — tests for these surfaces cost more than they pay back.
+
+**Factor for testability:**
+When a feature mixes pure logic with Blazor state, extract the pure piece into `HurrahTv.Shared` first, then test. Reference pattern: `HurrahTv.Shared/Filters/WatchlistFilters.cs` was extracted from `Home.razor`'s inline filter logic. The helper accepts `DateTime todayUtc` so tests don't drift across midnight UTC, and `Func<QueueStatus, bool> isStatusActive` so callers compose the chip-state rule.
+
+**TDD bias:**
+Lean test-first when the rules are spec-able from the issue (date windows, filter rules). Write the test after for exploratory UI/UX work where the right shape isn't clear yet.
+
+**Style:**
+- No mocking frameworks. Plain `Assert` calls, no fluent-assertion libraries.
+- Test helpers (`TvItem`, local builder methods) live inside the test class — no shared test-base machinery.
+- Inject time via parameter — never call `DateTime.UtcNow` inside a helper that's tested by date-sensitive specs.
+- Prefer direct `DateTime` comparisons over signed day-diff integers in predicates (see `Learnings/date-predicates-prefer-typed-comparisons.md`) — a wrong-sign value silently passes `is <= 7`.
+
+**Plans:**
+`/xplan` output for any feature touching `HurrahTv.Shared` should include a **Tests** bullet per phase. Phases that only touch Razor/CSS may skip it.
+
 ## Context Management
 
 - Use subagents for research, exploration, and parallel analysis

--- a/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
@@ -50,34 +50,6 @@ public class QueueItemDatePredicatesTests
     }
 
     [Fact]
-    public void HasUpcomingThisWeek_IsTrue_WhenNextEpisodeDateIsWithinWindow()
-    {
-        QueueItem item = new() { NextEpisodeDate = DateTime.UtcNow.AddDays(3) };
-        Assert.True(item.HasUpcomingThisWeek);
-    }
-
-    [Fact]
-    public void HasUpcomingThisWeek_IsFalse_WhenNextEpisodeDateIsBeyondWindow()
-    {
-        QueueItem item = new() { NextEpisodeDate = DateTime.UtcNow.AddDays(8) };
-        Assert.False(item.HasUpcomingThisWeek);
-    }
-
-    [Fact]
-    public void HasUpcomingThisWeek_IsFalse_WhenNextEpisodeDateIsInThePast()
-    {
-        QueueItem item = new() { NextEpisodeDate = DateTime.UtcNow.AddDays(-1) };
-        Assert.False(item.HasUpcomingThisWeek);
-    }
-
-    [Fact]
-    public void HasUpcomingThisWeek_IsFalse_WhenNextEpisodeDateIsNull()
-    {
-        QueueItem item = new() { NextEpisodeDate = null };
-        Assert.False(item.HasUpcomingThisWeek);
-    }
-
-    [Fact]
     public void HasEpisodeThisMonth_IsTrue_WhenLatestEpisodeDateIsWithin30Days()
     {
         QueueItem item = new() { LatestEpisodeDate = DateTime.UtcNow.AddDays(-20) };

--- a/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
@@ -48,4 +48,53 @@ public class QueueItemDatePredicatesTests
         QueueItem item = new() { LatestEpisodeDate = DateTime.UtcNow.AddDays(-8) };
         Assert.False(item.HasNewEpisode);
     }
+
+    [Fact]
+    public void HasUpcomingThisWeek_IsTrue_WhenNextEpisodeDateIsWithinWindow()
+    {
+        QueueItem item = new() { NextEpisodeDate = DateTime.UtcNow.AddDays(3) };
+        Assert.True(item.HasUpcomingThisWeek);
+    }
+
+    [Fact]
+    public void HasUpcomingThisWeek_IsFalse_WhenNextEpisodeDateIsBeyondWindow()
+    {
+        QueueItem item = new() { NextEpisodeDate = DateTime.UtcNow.AddDays(8) };
+        Assert.False(item.HasUpcomingThisWeek);
+    }
+
+    [Fact]
+    public void HasUpcomingThisWeek_IsFalse_WhenNextEpisodeDateIsInThePast()
+    {
+        QueueItem item = new() { NextEpisodeDate = DateTime.UtcNow.AddDays(-1) };
+        Assert.False(item.HasUpcomingThisWeek);
+    }
+
+    [Fact]
+    public void HasUpcomingThisWeek_IsFalse_WhenNextEpisodeDateIsNull()
+    {
+        QueueItem item = new() { NextEpisodeDate = null };
+        Assert.False(item.HasUpcomingThisWeek);
+    }
+
+    [Fact]
+    public void HasEpisodeThisMonth_IsTrue_WhenLatestEpisodeDateIsWithin30Days()
+    {
+        QueueItem item = new() { LatestEpisodeDate = DateTime.UtcNow.AddDays(-20) };
+        Assert.True(item.HasEpisodeThisMonth);
+    }
+
+    [Fact]
+    public void HasEpisodeThisMonth_IsFalse_WhenLatestEpisodeDateIsOlderThan30Days()
+    {
+        QueueItem item = new() { LatestEpisodeDate = DateTime.UtcNow.AddDays(-31) };
+        Assert.False(item.HasEpisodeThisMonth);
+    }
+
+    [Fact]
+    public void HasEpisodeThisMonth_IsFalse_WhenLatestEpisodeDateIsNull()
+    {
+        QueueItem item = new() { LatestEpisodeDate = null };
+        Assert.False(item.HasEpisodeThisMonth);
+    }
 }

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -196,8 +196,10 @@ public class WatchlistFiltersTests
     {
         QueueItem movie = new()
         {
-            Id = 1, MediaType = MediaTypes.Movie,
-            Status = QueueStatus.WantToWatch, AvailableOnJson = $"[{Netflix}]"
+            Id = 1,
+            MediaType = MediaTypes.Movie,
+            Status = QueueStatus.WantToWatch,
+            AvailableOnJson = $"[{Netflix}]"
         };
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [movie], Today, MediaTypes.Tv, AllStatusesActive, UserHasNetflix);
@@ -210,8 +212,10 @@ public class WatchlistFiltersTests
     {
         QueueItem movie = new()
         {
-            Id = 1, MediaType = MediaTypes.Movie,
-            Status = QueueStatus.WantToWatch, AvailableOnJson = $"[{Netflix}]"
+            Id = 1,
+            MediaType = MediaTypes.Movie,
+            Status = QueueStatus.WantToWatch,
+            AvailableOnJson = $"[{Netflix}]"
         };
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [movie], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
@@ -229,8 +233,10 @@ public class WatchlistFiltersTests
         QueueItem tv = TvItem(latestEpisode: Today.AddDays(-2));
         QueueItem movie = new()
         {
-            Id = 2, MediaType = MediaTypes.Movie,
-            Status = QueueStatus.WantToWatch, AvailableOnJson = $"[{Netflix}]"
+            Id = 2,
+            MediaType = MediaTypes.Movie,
+            Status = QueueStatus.WantToWatch,
+            AvailableOnJson = $"[{Netflix}]"
         };
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [tv, movie], Today, MediaTypes.Tv, AllStatusesActive, UserHasNetflix);

--- a/HurrahTv.Shared/Models/QueueItem.cs
+++ b/HurrahTv.Shared/Models/QueueItem.cs
@@ -42,11 +42,6 @@ public class QueueItem
     // latest episode aired within the last 30 days
     public bool HasEpisodeThisMonth => LatestEpisodeDate.HasValue
         && LatestEpisodeDate.Value >= DateTime.UtcNow.AddDays(-30);
-
-    // upcoming episode within next 7 days
-    public bool HasUpcomingThisWeek => NextEpisodeDate.HasValue
-        && NextEpisodeDate.Value <= DateTime.UtcNow.AddDays(7)
-        && NextEpisodeDate.Value > DateTime.UtcNow;
 }
 
 public enum QueueStatus


### PR DESCRIPTION
## Summary
- Adds 7 tests for the two `QueueItem` date predicates not yet covered (`HasUpcomingThisWeek`, `HasEpisodeThisMonth`) — completes Phase 1 of #52.
- Adds a **Testing** section to `CLAUDE.md` codifying the policy that pure `HurrahTv.Shared` logic gets tests and Blazor components don't (browser verification is the higher-signal check). Includes the wrong-sign learning from #79 referenced inline.

## Why this is small
Phase 2 of #52 (extract `WatchlistFilters` + pin #49) was already completed by 5554f7f as part of #79 — the regression test is `AvailableLater_Excludes_NextEpisode_In_The_Past` in the existing tests file. After that landed, the only Phase 2 work missing was the predicate tests for the two date predicates that aren't direct inputs to the filter (`HasUpcomingThisWeek` / `HasEpisodeThisMonth` are used by sort logic in `Home.razor`, not the filter pipeline). They were still untested — this PR closes that gap.

## Follow-ups filed
- #82 — Test pure helpers in `QueueItemExtensions.cs`
- #83 — Add `HurrahTv.Client.Tests` project (Phase 3 of #52)
- #84 — Add `HurrahTv.Api.Tests` project (Phase 4 of #52)

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` — 30/30 passing in 48ms
- [x] `dotnet format --verify-no-changes` clean for changed files
- [ ] CI's `CI / build` check green

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)