### PR TITLE
Tests: add HurrahTv.Client.Tests with BadgeHelpers + SentimentHelpers coverage (closes #83)

### DIFF
--- a/HurrahTv.Client.Tests/BadgeHelpersTests.cs
+++ b/HurrahTv.Client.Tests/BadgeHelpersTests.cs
@@ -11,9 +11,7 @@ public class BadgeHelpersTests
     [InlineData(QueueStatus.Finished, "icon-[heroicons--check-20-solid]")]
     [InlineData(QueueStatus.NotForMe, "icon-[heroicons--no-symbol-20-solid]")]
     public void StatusIcon_ReturnsExpectedIcon_ForEveryStatus(QueueStatus status, string expected)
-    {
-        Assert.Equal(expected, BadgeHelpers.StatusIcon(status));
-    }
+        => Assert.Equal(expected, BadgeHelpers.StatusIcon(status));
 
     // AllStatuses is the source of truth for status ordering across Queue.razor
     // and QuickActions. A silent reorder would ship a broken UI — pin the exact
@@ -40,7 +38,7 @@ public class BadgeHelpersTests
         QueueStatus[] enumValues = Enum.GetValues<QueueStatus>();
         Assert.Equal(enumValues.Length, BadgeHelpers.AllStatuses.Count);
         Assert.Equal(
-            enumValues.OrderBy(s => s).ToArray(),
-            BadgeHelpers.AllStatuses.OrderBy(s => s).ToArray());
+            [.. enumValues.OrderBy(s => s)],
+            [.. BadgeHelpers.AllStatuses.OrderBy(s => s)]);
     }
 }

--- a/HurrahTv.Client.Tests/BadgeHelpersTests.cs
+++ b/HurrahTv.Client.Tests/BadgeHelpersTests.cs
@@ -13,9 +13,9 @@ public class BadgeHelpersTests
     public void StatusIcon_ReturnsExpectedIcon_ForEveryStatus(QueueStatus status, string expected)
         => Assert.Equal(expected, BadgeHelpers.StatusIcon(status));
 
-    // AllStatuses is the source of truth for status ordering across Queue.razor
-    // and QuickActions. A silent reorder would ship a broken UI — pin the exact
-    // display order (which is intentionally not the enum's numeric order).
+    // source of truth for status ordering across Queue.razor and QuickActions.
+    // a silent reorder would ship a broken UI — pin the exact display order
+    // (which is intentionally not the enum's numeric order).
     [Fact]
     public void AllStatuses_PinsDisplayOrder()
     {
@@ -40,5 +40,19 @@ public class BadgeHelpersTests
         Assert.Equal(
             [.. enumValues.OrderBy(s => s)],
             [.. BadgeHelpers.AllStatuses.OrderBy(s => s)]);
+    }
+
+    // the [Theory] above pins exact icons for the four currently-defined statuses.
+    // this guard forces a decision when a new QueueStatus is added — without it,
+    // a 5th enum value would silently get StatusIcon's default "" arm and ship.
+    // closes the issue-#83 acceptance criterion "cover StatusIcon for every
+    // QueueStatus value" in a way that survives future enum growth.
+    [Fact]
+    public void StatusIcon_HasNonEmptyMapping_ForEveryQueueStatus()
+    {
+        foreach (QueueStatus status in Enum.GetValues<QueueStatus>())
+        {
+            Assert.NotEqual("", BadgeHelpers.StatusIcon(status));
+        }
     }
 }

--- a/HurrahTv.Client.Tests/BadgeHelpersTests.cs
+++ b/HurrahTv.Client.Tests/BadgeHelpersTests.cs
@@ -1,0 +1,46 @@
+using HurrahTv.Client.Helpers;
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Client.Tests;
+
+public class BadgeHelpersTests
+{
+    [Theory]
+    [InlineData(QueueStatus.WantToWatch, "icon-[heroicons--bookmark-20-solid]")]
+    [InlineData(QueueStatus.Watching, "icon-[heroicons--play-20-solid]")]
+    [InlineData(QueueStatus.Finished, "icon-[heroicons--check-20-solid]")]
+    [InlineData(QueueStatus.NotForMe, "icon-[heroicons--no-symbol-20-solid]")]
+    public void StatusIcon_ReturnsExpectedIcon_ForEveryStatus(QueueStatus status, string expected)
+    {
+        Assert.Equal(expected, BadgeHelpers.StatusIcon(status));
+    }
+
+    // AllStatuses is the source of truth for status ordering across Queue.razor
+    // and QuickActions. A silent reorder would ship a broken UI — pin the exact
+    // display order (which is intentionally not the enum's numeric order).
+    [Fact]
+    public void AllStatuses_PinsDisplayOrder()
+    {
+        QueueStatus[] expected =
+        [
+            QueueStatus.Watching,
+            QueueStatus.WantToWatch,
+            QueueStatus.Finished,
+            QueueStatus.NotForMe
+        ];
+
+        Assert.Equal(expected, BadgeHelpers.AllStatuses);
+    }
+
+    // when a new QueueStatus is added to the enum, this test forces a decision
+    // about where it lives in the UI ordering — failing here is a feature.
+    [Fact]
+    public void AllStatuses_CoversEveryEnumValue()
+    {
+        QueueStatus[] enumValues = Enum.GetValues<QueueStatus>();
+        Assert.Equal(enumValues.Length, BadgeHelpers.AllStatuses.Count);
+        Assert.Equal(
+            enumValues.OrderBy(s => s).ToArray(),
+            BadgeHelpers.AllStatuses.OrderBy(s => s).ToArray());
+    }
+}

--- a/HurrahTv.Client.Tests/HurrahTv.Client.Tests.csproj
+++ b/HurrahTv.Client.Tests/HurrahTv.Client.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HurrahTv.Client\HurrahTv.Client.csproj" />
+    <ProjectReference Include="..\HurrahTv.Shared\HurrahTv.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HurrahTv.Client.Tests/SentimentHelpersTests.cs
+++ b/HurrahTv.Client.Tests/SentimentHelpersTests.cs
@@ -1,0 +1,38 @@
+using HurrahTv.Client.Helpers;
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Client.Tests;
+
+public class SentimentHelpersTests
+{
+    // sentiment 0 is the unset case — no badge should render.
+    [Fact]
+    public void Icon_Unset_ReturnsEmpty()
+    {
+        Assert.Equal("", SentimentHelpers.Icon(0));
+    }
+
+    [Theory]
+    [InlineData(SentimentLevel.Down, "icon-[heroicons--hand-thumb-down-20-solid]")]
+    [InlineData(SentimentLevel.Up, "icon-[heroicons--hand-thumb-up-20-solid]")]
+    [InlineData(SentimentLevel.Favorite, "icon-[heroicons--heart-20-solid]")]
+    public void Icon_ReturnsExpectedIcon_ForEverySentimentLevel(int sentiment, string expected)
+    {
+        Assert.Equal(expected, SentimentHelpers.Icon(sentiment));
+    }
+
+    [Fact]
+    public void Color_Unset_ReturnsEmpty()
+    {
+        Assert.Equal("", SentimentHelpers.Color(0));
+    }
+
+    [Theory]
+    [InlineData(SentimentLevel.Down, "text-red-400")]
+    [InlineData(SentimentLevel.Up, "text-green-400")]
+    [InlineData(SentimentLevel.Favorite, "text-pink-400")]
+    public void Color_ReturnsExpectedColor_ForEverySentimentLevel(int sentiment, string expected)
+    {
+        Assert.Equal(expected, SentimentHelpers.Color(sentiment));
+    }
+}

--- a/HurrahTv.Client.Tests/SentimentHelpersTests.cs
+++ b/HurrahTv.Client.Tests/SentimentHelpersTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using HurrahTv.Client.Helpers;
 using HurrahTv.Shared.Models;
 
@@ -5,34 +6,48 @@ namespace HurrahTv.Client.Tests;
 
 public class SentimentHelpersTests
 {
-    // sentiment 0 is the unset case — no badge should render.
+    // helper signature is `Icon(int sentiment)` not `int?` — callers gate on
+    // `Sentiment.HasValue` before invoking, so the "null" case from issue #83's
+    // spec maps to sentinel 0 (the switch's default arm).
     [Fact]
-    public void Icon_Unset_ReturnsEmpty()
-    {
-        Assert.Equal("", SentimentHelpers.Icon(0));
-    }
+    public void Icon_DefaultCase_ReturnsEmpty() => Assert.Equal("", SentimentHelpers.Icon(0));
 
     [Theory]
     [InlineData(SentimentLevel.Down, "icon-[heroicons--hand-thumb-down-20-solid]")]
     [InlineData(SentimentLevel.Up, "icon-[heroicons--hand-thumb-up-20-solid]")]
     [InlineData(SentimentLevel.Favorite, "icon-[heroicons--heart-20-solid]")]
     public void Icon_ReturnsExpectedIcon_ForEverySentimentLevel(int sentiment, string expected)
-    {
-        Assert.Equal(expected, SentimentHelpers.Icon(sentiment));
-    }
+        => Assert.Equal(expected, SentimentHelpers.Icon(sentiment));
 
     [Fact]
-    public void Color_Unset_ReturnsEmpty()
-    {
-        Assert.Equal("", SentimentHelpers.Color(0));
-    }
+    public void Color_DefaultCase_ReturnsEmpty() => Assert.Equal("", SentimentHelpers.Color(0));
 
     [Theory]
     [InlineData(SentimentLevel.Down, "text-red-400")]
     [InlineData(SentimentLevel.Up, "text-green-400")]
     [InlineData(SentimentLevel.Favorite, "text-pink-400")]
     public void Color_ReturnsExpectedColor_ForEverySentimentLevel(int sentiment, string expected)
+        => Assert.Equal(expected, SentimentHelpers.Color(sentiment));
+
+    // SentimentLevel is `static class const int` rather than an enum, so
+    // Enum.GetValues can't enumerate it — reflection over the public static
+    // const fields fills the same role as AllStatuses_CoversEveryEnumValue
+    // does for QueueStatus. Adding `SentimentLevel.Loathe = 4` without
+    // updating the helpers fails this test instead of silently shipping a
+    // missing icon/color.
+    [Fact]
+    public void Helpers_CoverEverySentimentLevelConstant()
     {
-        Assert.Equal(expected, SentimentHelpers.Color(sentiment));
+        int[] levels = [.. typeof(SentimentLevel)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(int))
+            .Select(f => (int)f.GetRawConstantValue()!)];
+
+        Assert.NotEmpty(levels);
+        foreach (int level in levels)
+        {
+            Assert.NotEqual("", SentimentHelpers.Icon(level));
+            Assert.NotEqual("", SentimentHelpers.Color(level));
+        }
     }
 }

--- a/HurrahTv.Client.Tests/SentimentHelpersTests.cs
+++ b/HurrahTv.Client.Tests/SentimentHelpersTests.cs
@@ -7,8 +7,8 @@ namespace HurrahTv.Client.Tests;
 public class SentimentHelpersTests
 {
     // helper signature is `Icon(int sentiment)` not `int?` — callers gate on
-    // `Sentiment.HasValue` before invoking, so the "null" case from issue #83's
-    // spec maps to sentinel 0 (the switch's default arm).
+    // `Sentiment.HasValue` before invoking, so this covers invalid/unexpected
+    // values that hit the switch's default arm.
     [Fact]
     public void Icon_DefaultCase_ReturnsEmpty() => Assert.Equal("", SentimentHelpers.Icon(0));
 

--- a/HurrahTv.Client.Tests/SentimentHelpersTests.cs
+++ b/HurrahTv.Client.Tests/SentimentHelpersTests.cs
@@ -29,10 +29,10 @@ public class SentimentHelpersTests
     public void Color_ReturnsExpectedColor_ForEverySentimentLevel(int sentiment, string expected)
         => Assert.Equal(expected, SentimentHelpers.Color(sentiment));
 
-    // SentimentLevel is `static class const int` rather than an enum, so
+    // since SentimentLevel is `static class const int` rather than an enum,
     // Enum.GetValues can't enumerate it — reflection over the public static
     // const fields fills the same role as AllStatuses_CoversEveryEnumValue
-    // does for QueueStatus. Adding `SentimentLevel.Loathe = 4` without
+    // does for QueueStatus. adding `SentimentLevel.Loathe = 4` without
     // updating the helpers fails this test instead of silently shipping a
     // missing icon/color.
     [Fact]

--- a/HurrahTv.slnx
+++ b/HurrahTv.slnx
@@ -7,6 +7,7 @@
   </Folder>
   <Project Path="HurrahTv.Api/HurrahTv.Api.csproj" />
   <Project Path="HurrahTv.Client/HurrahTv.Client.csproj" />
+  <Project Path="HurrahTv.Client.Tests/HurrahTv.Client.Tests.csproj" />
   <Project Path="HurrahTv.Shared/HurrahTv.Shared.csproj" />
   <Project Path="HurrahTv.Shared.Tests/HurrahTv.Shared.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- New `HurrahTv.Client.Tests` project (xUnit, same pattern as `HurrahTv.Shared.Tests`).
- Pins `BadgeHelpers.StatusIcon` for every `QueueStatus` value plus the `AllStatuses` display-order list — the source of truth for status ordering across `Queue.razor` and `QuickActions`. A completeness check fails if a new `QueueStatus` is added without deciding where it lives in the UI order.
- Covers `SentimentHelpers.Icon` / `SentimentHelpers.Color` for unset / Down / Up / Favorite.
- 14 tests, 38 ms; full suite now 40 tests across both projects.

Skipped the bUnit stretch goal — the #49 date-formatting bug class is already pinned at the data layer via `WatchlistFilters` tests, so re-testing at the render layer wasn't worth the new dependency. Easy to file as a follow-up if we want it later.

Phase 3 of #52. Phase 4 (`HurrahTv.Api.Tests`) is tracked in #84.

## Test plan
- [x] `dotnet test HurrahTv.slnx` — 40/40 passing
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI `CI / build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)