### PR TITLE
Tests: add HurrahTv.Api.Tests with WebApplicationFactory + queue auth coverage (closes #84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ jobs:
     name: build
     runs-on: ubuntu-latest
 
+    # Postgres service container for HurrahTv.Api.Tests (WebApplicationFactory + real DB).
+    # Trust auth keeps the test connection string identical to the local-dev default,
+    # so the test fixture's default `Host=localhost;Username=postgres` works in both places.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,9 @@ PostgreSQL via Dapper (Npgsql). All tables created on startup via `DbService.Ini
 
 ## Testing
 
-`dotnet test` runs via `HurrahTv.slnx`. New test projects must be referenced there. Current coverage lives in `HurrahTv.Shared.Tests/`.
+`dotnet test` runs via `HurrahTv.slnx`. New test projects must be referenced there. Test projects: `HurrahTv.Shared.Tests/` (pure logic), `HurrahTv.Api.Tests/` (`WebApplicationFactory<Program>` + real Postgres).
+
+**Local setup for Api.Tests:** the fixture connects to local Postgres on `localhost:5432` as user `postgres` and auto-creates the `hurrahtv_test` database on first run. Override with `HURRAHTV_TEST_CONNECTION` env var if your local creds differ. CI uses a `postgres:16-alpine` service container with trust auth so the default works there too.
 
 **When tests are required:**
 - New or changed pure logic in `HurrahTv.Shared` — predicates, filters, sort keys, parsers, extension methods. This is where the worst bugs hide (#49 was a stale-date leak caught only at runtime). One named regression test per bug fix, referencing the issue number (e.g. `AvailableLater_Excludes_NextEpisode_In_The_Past` // pins #49/#70).

--- a/HurrahTv.Api.Tests/HurrahTv.Api.Tests.csproj
+++ b/HurrahTv.Api.Tests/HurrahTv.Api.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Dapper" Version="2.1.79" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Npgsql" Version="10.0.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HurrahTv.Api\HurrahTv.Api.csproj" />
+    <ProjectReference Include="..\HurrahTv.Shared\HurrahTv.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HurrahTv.Api.Tests/JwtAuthTests.cs
+++ b/HurrahTv.Api.Tests/JwtAuthTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace HurrahTv.Api.Tests;
+
+// uses /api/queue as the canary protected endpoint — its [Authorize] gate is
+// the same one every other endpoint group inherits, so a 401 here is a 401
+// everywhere.
+[Collection("postgres")]
+public class JwtAuthTests(PostgresFixture fx)
+{
+    [Fact]
+    public async Task ProtectedEndpoint_WithoutToken_Returns401()
+    {
+        HttpClient client = fx.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/queue");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithExpiredToken_Returns401()
+    {
+        HttpClient client = fx.Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", TestAuth.IssueExpiredToken(fx, "user-expired"));
+
+        HttpResponseMessage response = await client.GetAsync("/api/queue");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithValidToken_Returns200()
+    {
+        await fx.ResetAsync();
+        HttpClient client = TestAuth.CreateClient(fx, "user-valid");
+
+        HttpResponseMessage response = await client.GetAsync("/api/queue");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/HurrahTv.Api.Tests/PostgresFixture.cs
+++ b/HurrahTv.Api.Tests/PostgresFixture.cs
@@ -1,0 +1,98 @@
+using System.Security.Cryptography;
+using Dapper;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Npgsql;
+
+namespace HurrahTv.Api.Tests;
+
+// shared across the whole assembly via [Collection("postgres")] so we pay
+// the schema init exactly once. Each test class derives its own scope by
+// calling ResetAsync() to truncate user-scoped tables.
+//
+// connection string discovery (first match wins):
+//   1. env var HURRAHTV_TEST_CONNECTION — set in CI to point at the service container
+//   2. fallback: Host=localhost;Database=hurrahtv_test;Username=postgres
+//      (matches the appsettings.json convention; works against the brew-managed
+//      Postgres on a dev machine with trust auth)
+//
+// the test database is auto-created on first run if missing, so `dotnet test`
+// after a fresh clone needs nothing more than a running Postgres on localhost.
+public class PostgresFixture : IAsyncLifetime
+{
+    private const string TestDbName = "hurrahtv_test";
+
+    private static readonly string EnvConnection
+        = Environment.GetEnvironmentVariable("HURRAHTV_TEST_CONNECTION") ?? string.Empty;
+
+    public string ConnectionString { get; } = string.IsNullOrEmpty(EnvConnection)
+        ? $"Host=localhost;Database={TestDbName};Username=postgres"
+        : EnvConnection;
+
+    public WebApplicationFactory<Program> Factory { get; private set; } = null!;
+
+    public const string JwtIssuer = "HurrahTvTest";
+
+    public string JwtKey { get; } = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    public async Task InitializeAsync()
+    {
+        await EnsureTestDatabaseExistsAsync();
+
+        // Program.cs snapshots builder.Configuration["Jwt:Key"] into a local at the
+        // top of WebApplication.CreateBuilder(args). InMemory providers registered via
+        // ConfigureAppConfiguration land AFTER that snapshot, so they don't win.
+        // Env vars (ASPNETCORE_ prefix + __ as separator) are read during the default
+        // config load, BEFORE Program.cs captures the value — so they do win.
+        Environment.SetEnvironmentVariable("ASPNETCORE_ConnectionStrings__Default", ConnectionString);
+        Environment.SetEnvironmentVariable("ASPNETCORE_Jwt__Key", JwtKey);
+        Environment.SetEnvironmentVariable("ASPNETCORE_Jwt__Issuer", JwtIssuer);
+        Environment.SetEnvironmentVariable("ASPNETCORE_Twilio__AccountSid", null);
+        Environment.SetEnvironmentVariable("ASPNETCORE_AI__Enabled", "false");
+
+        Factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder => builder.UseEnvironment("Testing"));
+
+        // force the host to build so DbService.InitializeAsync runs the schema setup
+        _ = Factory.Server;
+    }
+
+    // truncate user-scoped tables so each test starts from a clean slate.
+    // RESTART IDENTITY resets the QueueItems serial so ids are deterministic.
+    public async Task ResetAsync()
+    {
+        using NpgsqlConnection db = new(ConnectionString);
+        await db.OpenAsync();
+        await db.ExecuteAsync("""
+            TRUNCATE
+                QueueItems, OtpCodes, UserServices, UserGenres, UserSettings,
+                SeasonSentiments, EpisodeSentiments, WatchedEpisodes,
+                AIUsage, CurationCache, Users
+            RESTART IDENTITY CASCADE
+            """);
+    }
+
+    public async Task DisposeAsync() => await Factory.DisposeAsync();
+
+    // connects to the maintenance "postgres" DB to CREATE DATABASE if hurrahtv_test
+    // doesn't exist yet. idempotent — safe to call on every test run.
+    private async Task EnsureTestDatabaseExistsAsync()
+    {
+        NpgsqlConnectionStringBuilder b = new(ConnectionString) { Database = "postgres" };
+        using NpgsqlConnection admin = new(b.ConnectionString);
+        await admin.OpenAsync();
+
+        bool exists = await admin.QuerySingleAsync<bool>(
+            "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = @Name)",
+            new { Name = TestDbName });
+
+        if (!exists)
+        {
+            // CREATE DATABASE can't be parameterized; identifier is a known constant.
+            await admin.ExecuteAsync($"CREATE DATABASE \"{TestDbName}\"");
+        }
+    }
+}
+
+[CollectionDefinition("postgres")]
+public class PostgresCollection : ICollectionFixture<PostgresFixture> { }

--- a/HurrahTv.Api.Tests/PostgresFixture.cs
+++ b/HurrahTv.Api.Tests/PostgresFixture.cs
@@ -1,7 +1,10 @@
 using System.Security.Cryptography;
 using Dapper;
+using HurrahTv.Api.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 
 namespace HurrahTv.Api.Tests;
@@ -20,20 +23,39 @@ namespace HurrahTv.Api.Tests;
 // after a fresh clone needs nothing more than a running Postgres on localhost.
 public class PostgresFixture : IAsyncLifetime
 {
-    private const string TestDbName = "hurrahtv_test";
+    private const string DefaultTestDbName = "hurrahtv_test";
 
     private static readonly string EnvConnection
         = Environment.GetEnvironmentVariable("HURRAHTV_TEST_CONNECTION") ?? string.Empty;
 
     public string ConnectionString { get; } = string.IsNullOrEmpty(EnvConnection)
-        ? $"Host=localhost;Database={TestDbName};Username=postgres"
+        ? $"Host=localhost;Database={DefaultTestDbName};Username=postgres"
         : EnvConnection;
+
+    // derived from ConnectionString rather than hardcoded — if HURRAHTV_TEST_CONNECTION
+    // overrides the connection string to point at a different DB, the create/reset/run
+    // paths all agree on the same target database.
+    private string TestDbName => new NpgsqlConnectionStringBuilder(ConnectionString).Database
+        ?? DefaultTestDbName;
 
     public WebApplicationFactory<Program> Factory { get; private set; } = null!;
 
     public const string JwtIssuer = "HurrahTvTest";
 
     public string JwtKey { get; } = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    // env-var keys set in InitializeAsync; we unset each in DisposeAsync so a
+    // multi-assembly `dotnet test` invocation doesn't leak the test JwtKey /
+    // connection string / Twilio override into a sibling assembly that builds
+    // its own WebApplicationFactory<Program> later in the same process.
+    private static readonly string[] OverriddenEnvKeys =
+    [
+        "ASPNETCORE_ConnectionStrings__Default",
+        "ASPNETCORE_Jwt__Key",
+        "ASPNETCORE_Jwt__Issuer",
+        "ASPNETCORE_Twilio__AccountSid",
+        "ASPNETCORE_AI__Enabled",
+    ];
 
     public async Task InitializeAsync()
     {
@@ -44,14 +66,26 @@ public class PostgresFixture : IAsyncLifetime
         // ConfigureAppConfiguration land AFTER that snapshot, so they don't win.
         // Env vars (ASPNETCORE_ prefix + __ as separator) are read during the default
         // config load, BEFORE Program.cs captures the value — so they do win.
+        //
+        // Twilio:AccountSid is overridden to "" rather than null, because appsettings.json
+        // ships with a non-null placeholder ("YOUR_TWILIO_ACCOUNT_SID") that would otherwise
+        // win and trip SmsService into TwilioClient.Init with garbage creds.
         Environment.SetEnvironmentVariable("ASPNETCORE_ConnectionStrings__Default", ConnectionString);
         Environment.SetEnvironmentVariable("ASPNETCORE_Jwt__Key", JwtKey);
         Environment.SetEnvironmentVariable("ASPNETCORE_Jwt__Issuer", JwtIssuer);
-        Environment.SetEnvironmentVariable("ASPNETCORE_Twilio__AccountSid", null);
+        Environment.SetEnvironmentVariable("ASPNETCORE_Twilio__AccountSid", "");
         Environment.SetEnvironmentVariable("ASPNETCORE_AI__Enabled", "false");
 
         Factory = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(builder => builder.UseEnvironment("Testing"));
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+                // intercept TmdbService's HttpClient so GET /api/queue's
+                // fire-and-forget RefreshStaleItemsInBackground doesn't hit
+                // api.themoviedb.org during integration tests.
+                builder.ConfigureTestServices(services => services.AddHttpClient<TmdbService>()
+                    .ConfigurePrimaryHttpMessageHandler(() => new StubTmdbHandler()));
+            });
 
         // force the host to build so DbService.InitializeAsync runs the schema setup
         _ = Factory.Server;
@@ -72,24 +106,37 @@ public class PostgresFixture : IAsyncLifetime
             """);
     }
 
-    public async Task DisposeAsync() => await Factory.DisposeAsync();
+    // null-guard Factory in case InitializeAsync threw before Factory was assigned
+    // (e.g. Postgres unreachable in EnsureTestDatabaseExistsAsync). Otherwise the
+    // NRE here masks the real connection-refused error.
+    public async Task DisposeAsync()
+    {
+        if (Factory is not null)
+            await Factory.DisposeAsync();
 
-    // connects to the maintenance "postgres" DB to CREATE DATABASE if hurrahtv_test
+        foreach (string key in OverriddenEnvKeys)
+            Environment.SetEnvironmentVariable(key, null);
+    }
+
+    // connects to the maintenance "postgres" DB to CREATE DATABASE if the target
     // doesn't exist yet. idempotent — safe to call on every test run.
     private async Task EnsureTestDatabaseExistsAsync()
     {
+        string targetDb = TestDbName;
         NpgsqlConnectionStringBuilder b = new(ConnectionString) { Database = "postgres" };
         using NpgsqlConnection admin = new(b.ConnectionString);
         await admin.OpenAsync();
 
         bool exists = await admin.QuerySingleAsync<bool>(
             "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = @Name)",
-            new { Name = TestDbName });
+            new { Name = targetDb });
 
         if (!exists)
         {
-            // CREATE DATABASE can't be parameterized; identifier is a known constant.
-            await admin.ExecuteAsync($"CREATE DATABASE \"{TestDbName}\"");
+            // CREATE DATABASE can't be parameterized; identifier is sourced from the
+            // connection string (controlled by HURRAHTV_TEST_CONNECTION or default).
+            // Quote with double-quotes so non-ASCII / case-sensitive names work.
+            await admin.ExecuteAsync($"CREATE DATABASE \"{targetDb.Replace("\"", "\"\"")}\"");
         }
     }
 }

--- a/HurrahTv.Api.Tests/QueueEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/QueueEndpointsTests.cs
@@ -27,6 +27,7 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         // add a second item so position reorder has somewhere to move
         QueueItem second = NewQueueItem(tmdbId: 60625, title: "Rick and Morty");
         HttpResponseMessage addResp2 = await client.PostAsJsonAsync("/api/queue", second);
+        Assert.Equal(HttpStatusCode.Created, addResp2.StatusCode);
         QueueItem secondAdded = (await addResp2.Content.ReadFromJsonAsync<QueueItem>())!;
         Assert.True(secondAdded.Position > added.Position);
 
@@ -68,8 +69,10 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         HttpClient userA = TestAuth.CreateClient(fx, "user-A");
         HttpClient userB = TestAuth.CreateClient(fx, "user-B");
 
-        await userA.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1, title: "A's show"));
-        await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 2, title: "B's show"));
+        HttpResponseMessage aPost = await userA.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1, title: "A's show"));
+        HttpResponseMessage bPost = await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 2, title: "B's show"));
+        Assert.Equal(HttpStatusCode.Created, aPost.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, bPost.StatusCode);
 
         QueueResponse? aList = await userA.GetFromJsonAsync<QueueResponse>("/api/queue");
         QueueResponse? bList = await userB.GetFromJsonAsync<QueueResponse>("/api/queue");
@@ -87,6 +90,7 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         HttpClient userB = TestAuth.CreateClient(fx, "user-B");
 
         HttpResponseMessage addResp = await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1, title: "B's show"));
+        Assert.Equal(HttpStatusCode.Created, addResp.StatusCode);
         QueueItem bItem = (await addResp.Content.ReadFromJsonAsync<QueueItem>())!;
 
         HttpResponseMessage attack = await userA.PutAsJsonAsync(
@@ -109,6 +113,7 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         HttpClient userB = TestAuth.CreateClient(fx, "user-B");
 
         HttpResponseMessage addResp = await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1, title: "B's show"));
+        Assert.Equal(HttpStatusCode.Created, addResp.StatusCode);
         QueueItem bItem = (await addResp.Content.ReadFromJsonAsync<QueueItem>())!;
 
         HttpResponseMessage attack = await userA.DeleteAsync($"/api/queue/{bItem.Id}");

--- a/HurrahTv.Api.Tests/QueueEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/QueueEndpointsTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Net.Http.Json;
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Api.Tests;
+
+[Collection("postgres")]
+public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fx.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task QueueCrud_HappyPath_AddListUpdateDelete()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "user-1");
+
+        // add — POST /api/queue
+        QueueItem payload = NewQueueItem(tmdbId: 1399, title: "Game of Thrones");
+        HttpResponseMessage addResp = await client.PostAsJsonAsync("/api/queue", payload);
+        Assert.Equal(HttpStatusCode.Created, addResp.StatusCode);
+        QueueItem? added = await addResp.Content.ReadFromJsonAsync<QueueItem>();
+        Assert.NotNull(added);
+        Assert.True(added!.Id > 0);
+        Assert.Equal(1399, added.TmdbId);
+
+        // add a second item so position reorder has somewhere to move
+        QueueItem second = NewQueueItem(tmdbId: 60625, title: "Rick and Morty");
+        HttpResponseMessage addResp2 = await client.PostAsJsonAsync("/api/queue", second);
+        QueueItem secondAdded = (await addResp2.Content.ReadFromJsonAsync<QueueItem>())!;
+        Assert.True(secondAdded.Position > added.Position);
+
+        // list — GET /api/queue returns both items
+        QueueResponse? list = await client.GetFromJsonAsync<QueueResponse>("/api/queue");
+        Assert.NotNull(list);
+        Assert.Equal(2, list!.Items.Count);
+
+        // update status — PUT /api/queue/{id}/status
+        HttpResponseMessage statusResp = await client.PutAsJsonAsync(
+            $"/api/queue/{added.Id}/status",
+            new QueueStatusUpdate(QueueStatus.Watching));
+        Assert.Equal(HttpStatusCode.OK, statusResp.StatusCode);
+        QueueItem? statusUpdated = await statusResp.Content.ReadFromJsonAsync<QueueItem>();
+        Assert.Equal(QueueStatus.Watching, statusUpdated!.Status);
+
+        // update position — PUT /api/queue/{id}/position (move second item to position 1)
+        HttpResponseMessage posResp = await client.PutAsJsonAsync(
+            $"/api/queue/{secondAdded.Id}/position",
+            new PositionUpdate(1));
+        Assert.Equal(HttpStatusCode.OK, posResp.StatusCode);
+
+        // delete — DELETE /api/queue/{id}
+        HttpResponseMessage delResp = await client.DeleteAsync($"/api/queue/{added.Id}");
+        Assert.Equal(HttpStatusCode.OK, delResp.StatusCode);
+
+        QueueResponse? afterDelete = await client.GetFromJsonAsync<QueueResponse>("/api/queue");
+        Assert.Single(afterDelete!.Items);
+        Assert.Equal(secondAdded.Id, afterDelete.Items[0].Id);
+    }
+
+    // authorization is the highest-blast-radius bug class for this API.
+    // every queue mutation is scoped by sub-claim UserId — these tests pin
+    // that scoping so a regression (e.g. forgetting the AND UserId = clause
+    // in a UPDATE/DELETE) shows up in CI, not in prod.
+    [Fact]
+    public async Task UserA_CannotSee_UserB_QueueItems()
+    {
+        HttpClient userA = TestAuth.CreateClient(fx, "user-A");
+        HttpClient userB = TestAuth.CreateClient(fx, "user-B");
+
+        await userA.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1, title: "A's show"));
+        await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 2, title: "B's show"));
+
+        QueueResponse? aList = await userA.GetFromJsonAsync<QueueResponse>("/api/queue");
+        QueueResponse? bList = await userB.GetFromJsonAsync<QueueResponse>("/api/queue");
+
+        Assert.Single(aList!.Items);
+        Assert.Single(bList!.Items);
+        Assert.Equal(1, aList.Items[0].TmdbId);
+        Assert.Equal(2, bList.Items[0].TmdbId);
+    }
+
+    [Fact]
+    public async Task UserA_CannotUpdate_UserB_QueueItem()
+    {
+        HttpClient userA = TestAuth.CreateClient(fx, "user-A");
+        HttpClient userB = TestAuth.CreateClient(fx, "user-B");
+
+        HttpResponseMessage addResp = await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1, title: "B's show"));
+        QueueItem bItem = (await addResp.Content.ReadFromJsonAsync<QueueItem>())!;
+
+        HttpResponseMessage attack = await userA.PutAsJsonAsync(
+            $"/api/queue/{bItem.Id}/status",
+            new QueueStatusUpdate(QueueStatus.Finished));
+
+        // 404, not 403 — UPDATE ... WHERE Id = @Id AND UserId = @UserId matches
+        // zero rows for user A, so the endpoint reports "not found". the important
+        // bit is "not 200" — user B's item must remain unchanged.
+        Assert.Equal(HttpStatusCode.NotFound, attack.StatusCode);
+
+        QueueResponse? bList = await userB.GetFromJsonAsync<QueueResponse>("/api/queue");
+        Assert.Equal(QueueStatus.WantToWatch, bList!.Items[0].Status);
+    }
+
+    [Fact]
+    public async Task UserA_CannotDelete_UserB_QueueItem()
+    {
+        HttpClient userA = TestAuth.CreateClient(fx, "user-A");
+        HttpClient userB = TestAuth.CreateClient(fx, "user-B");
+
+        HttpResponseMessage addResp = await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1, title: "B's show"));
+        QueueItem bItem = (await addResp.Content.ReadFromJsonAsync<QueueItem>())!;
+
+        HttpResponseMessage attack = await userA.DeleteAsync($"/api/queue/{bItem.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, attack.StatusCode);
+
+        QueueResponse? bList = await userB.GetFromJsonAsync<QueueResponse>("/api/queue");
+        Assert.Single(bList!.Items);
+    }
+
+    private static QueueItem NewQueueItem(int tmdbId, string title) => new()
+    {
+        TmdbId = tmdbId,
+        MediaType = MediaTypes.Tv,
+        Title = title,
+        PosterPath = "/poster.jpg",
+        BackdropPath = "",
+        Status = QueueStatus.WantToWatch,
+        AvailableOnJson = "[]"
+    };
+}

--- a/HurrahTv.Api.Tests/StubTmdbHandler.cs
+++ b/HurrahTv.Api.Tests/StubTmdbHandler.cs
@@ -1,0 +1,16 @@
+using System.Net;
+
+namespace HurrahTv.Api.Tests;
+
+// no-op handler that intercepts all TmdbService HTTP calls in tests so we don't
+// hit api.themoviedb.org. RefreshStaleItemsInBackground has per-item try/catch,
+// so a 404 here just gets swallowed and logged at warning — no live network
+// dependency in CI, no rate-limit risk against our real TMDb key.
+internal sealed class StubTmdbHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("{}")
+        });
+}

--- a/HurrahTv.Api.Tests/TestAuth.cs
+++ b/HurrahTv.Api.Tests/TestAuth.cs
@@ -1,0 +1,47 @@
+using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace HurrahTv.Api.Tests;
+
+// mints JWTs for tests using the same key/issuer the test API is configured with.
+// keeps the test surface tight by bypassing the SMS/OTP flow — auth endpoints aren't
+// what's being tested here, the protected endpoints downstream of the JWT are.
+public static class TestAuth
+{
+    public static string IssueToken(PostgresFixture fx, string userId, TimeSpan? lifetime = null)
+    {
+        SymmetricSecurityKey key = new(Convert.FromBase64String(fx.JwtKey));
+        JsonWebTokenHandler handler = new();
+        return handler.CreateToken(new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity([new Claim("sub", userId), new Claim("phone", "+15555550100")]),
+            Expires = DateTime.UtcNow.Add(lifetime ?? TimeSpan.FromMinutes(30)),
+            Issuer = PostgresFixture.JwtIssuer,
+            SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature)
+        });
+    }
+
+    public static string IssueExpiredToken(PostgresFixture fx, string userId)
+    {
+        SymmetricSecurityKey key = new(Convert.FromBase64String(fx.JwtKey));
+        JsonWebTokenHandler handler = new();
+        return handler.CreateToken(new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity([new Claim("sub", userId)]),
+            // backdated so the token is already expired when minted
+            NotBefore = DateTime.UtcNow.AddHours(-2),
+            Expires = DateTime.UtcNow.AddHours(-1),
+            Issuer = PostgresFixture.JwtIssuer,
+            SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature)
+        });
+    }
+
+    public static HttpClient CreateClient(PostgresFixture fx, string userId)
+    {
+        HttpClient client = fx.Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", IssueToken(fx, userId));
+        return client;
+    }
+}

--- a/HurrahTv.Api/Services/SmsService.cs
+++ b/HurrahTv.Api/Services/SmsService.cs
@@ -17,7 +17,9 @@ public class SmsService
         _fromNumber = config["Twilio:FromNumber"];
         _logger = logger;
 
-        if (_accountSid != null && _authToken != null)
+        // IsNullOrEmpty (not != null) so the appsettings.json placeholder values
+        // are treated as "not configured" — same guard runs in SendCodeAsync below.
+        if (!string.IsNullOrEmpty(_accountSid) && !string.IsNullOrEmpty(_authToken))
         {
             TwilioClient.Init(_accountSid, _authToken);
         }
@@ -25,7 +27,7 @@ public class SmsService
 
     public async Task SendCodeAsync(string phoneNumber, string code)
     {
-        if (_accountSid == null)
+        if (string.IsNullOrEmpty(_accountSid))
         {
             _logger.LogWarning("Twilio not configured — OTP for {Phone}: {Code}", phoneNumber, code);
             return;

--- a/HurrahTv.slnx
+++ b/HurrahTv.slnx
@@ -6,6 +6,7 @@
     <File Path="README.md" />
   </Folder>
   <Project Path="HurrahTv.Api/HurrahTv.Api.csproj" />
+  <Project Path="HurrahTv.Api.Tests/HurrahTv.Api.Tests.csproj" />
   <Project Path="HurrahTv.Client/HurrahTv.Client.csproj" />
   <Project Path="HurrahTv.Shared/HurrahTv.Shared.csproj" />
   <Project Path="HurrahTv.Shared.Tests/HurrahTv.Shared.Tests.csproj" />


### PR DESCRIPTION
## Summary

Phase 4 of #52 — integration tests for the Minimal API using `WebApplicationFactory<Program>` against a real Postgres. Covers the two highest-blast-radius bug classes:

- **JWT validation** — missing/expired/valid token against a protected endpoint
- **Queue authorization** — user A cannot read, update, or delete user B's items
- **Queue CRUD happy path** — add → list → status → reorder → delete

7 tests, ~340ms locally. CI service container adds ~5s. Well inside the 5-min budget.

## DB strategy: local Postgres (not Testcontainers)

The issue listed Testcontainers vs dedicated test DB as an upfront decision. Took the dedicated-test-DB path:

- Docker isn't installed on the dev machine; brew-managed Postgres already is. Adding Docker just for hermetic tests was extra surface for no win.
- Tests connect to `localhost:5432` as `postgres`, auto-creating `hurrahtv_test` on first run. Override with `HURRAHTV_TEST_CONNECTION` env var if local creds differ.
- CI uses `postgres:16-alpine` as a service container with `POSTGRES_HOST_AUTH_METHOD: trust` so the fixture's default connection string works in both places without env-var gymnastics.

## Config wiring gotcha (in case future-Claude hits it)

`PostgresFixture` pumps the test JWT key / connection string via `ASPNETCORE_*` env vars, **not** via `ConfigureAppConfiguration(AddInMemoryCollection(...))`. Reason: `Program.cs` snapshots `builder.Configuration["Jwt:Key"]` into a local during `WebApplication.CreateBuilder(args)`, and `WebApplicationFactory`'s `ConfigureAppConfiguration` callbacks land **after** that snapshot — so InMemory overrides silently lose to whatever was in `appsettings.Development.json`. Env vars are read by the default `AddEnvironmentVariables` provider during the early config load, so they win.

## Out of scope

- `/api/auth/*` endpoints — they need Twilio + DB integration that adds surface area without protecting a high-blast-radius bug class. JWT validation is exercised at the gate where it matters; every protected endpoint inherits the same auth setup.

## Test plan

- [x] `dotnet test HurrahTv.slnx` — 33/33 passing locally
- [x] `dotnet format --verify-no-changes --severity info` clean
- [ ] CI `CI / build` green (validates the service-container approach works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)