### PR TITLE
Tests: bootstrap fixture + predicate guard + Shared ordering refactor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,3 +38,10 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# test projects — Assert.Equal(new[] { ... }, actual) is the canonical xUnit idiom;
+# CA1861's "hoist constant array arguments to static readonly fields" misapplies here
+# because [Fact] methods don't run in tight loops and per-test allocation is negligible.
+# Hoisting hurts readability (expected literal next to assertion is the whole point).
+[*Tests.cs]
+dotnet_diagnostic.CA1861.severity = none

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ There's no `priority:*` scheme — `phase:*` does the work. There's no `effort:*
 Surfaced by: /<skill> on YYYY-MM-DD
 ```
 
-**Closing the loop:** commit messages use `closes #NN` / `fixes #NN` syntax — GitHub auto-closes the issue on merge to main. Don't manually close issues that the merge will close for you.
+**Closing the loop:** put `Closes #NN` / `Fixes #NN` keywords in the **PR description** (one per line at the bottom) — GitHub auto-closes the issue on merge to main. Squash-merge discards individual commit messages and replaces them with the PR title + body, so closes-keywords in commit bodies alone won't survive — the PR description is the canonical place. Don't manually close issues that the merge will close for you.
 
 ## Plans Directory
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ PostgreSQL via Dapper (Npgsql). All tables created on startup via `DbService.Ini
 - Auth: `HurrahAuthStateProvider` + `TokenService` (JWT in localStorage) + `AuthMessageHandler` (auto-injects Bearer token)
 - Key components: `PosterCard`, `PosterGrid`, `ContentRow`, `WatchlistRow`, `QuickActions`, `EpisodeBrowser`, `InstallBanner`, `UpdateBanner`
 - UI helpers: `BadgeHelpers.cs` (status colors/icons/labels), `SentimentHelpers.cs` (sentiment colors/icons)
-- `BadgeHelpers.AllStatuses` (`IReadOnlyList<QueueStatus>`) is the shared source of truth for status ordering — used in Queue page and QuickActions
+- `HurrahTv.Shared.Models.QueueStatusOrdering` is the canonical status-ordering rule — `DisplayOrder` (`IReadOnlyList<QueueStatus>`) drives Queue tabs / QuickActions / Home watchlist sort, and `SortPriority(status)` (derived from `DisplayOrder`) gives the C# sort key that matches the Api SQL `CASE` in `DbService.GetQueueAsync`
 - Dark theme, poster-grid layout inspired by Netflix. Mobile bottom tab bar, desktop top nav.
 - State lives on the server — client fetches on page load. No client-side state store.
 - Prefer **self-gating predicates** over caller-supplied visibility flags. If a control's "show me" rule can be expressed from the item's own data (e.g. `status == Watching && latestEpisodeDate within 7 days`), encode it inside the component rather than passing a `showX` boolean from every call site. Self-gating keeps the rule canonical, makes new surfaces safe by default, and makes the intent grep-able.

--- a/HurrahTv.Api.Tests/AdminBootstrapTests.cs
+++ b/HurrahTv.Api.Tests/AdminBootstrapTests.cs
@@ -1,0 +1,38 @@
+using Dapper;
+using Npgsql;
+
+namespace HurrahTv.Api.Tests;
+
+// pins #92 — the admin bootstrap that DbService.InitializeAsync runs on startup
+// must survive ResetAsync. prod's UPDATE-only bootstrap only flips existing rows,
+// so the realistic sequence a test mimics is: insert owner-phone user, then run
+// the bootstrap (= what prod does on the next API restart), then assert admin.
+// without the fixture surfacing SeedAdminAsync this invariant is unreachable from
+// tests and admin-endpoint coverage will produce confusing false negatives.
+[Collection("postgres")]
+public class AdminBootstrapTests(PostgresFixture fx) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fx.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task SeedAdmin_FlipsOwnerPhone_AfterResetAndInsert()
+    {
+        using NpgsqlConnection db = new(fx.ConnectionString);
+        await db.OpenAsync();
+
+        // mimic DbService.GetOrCreateUserAsync — creates the row with IsAdmin = FALSE,
+        // which is the production state until the next API startup runs the bootstrap.
+        await db.ExecuteAsync(
+            "INSERT INTO Users (Id, PhoneNumber, CreatedAt) VALUES (@Id, @Phone, NOW())",
+            new { Id = "owner-after-reset", Phone = "4406228711" });
+
+        await fx.SeedAdminAsync();
+
+        bool isAdmin = await db.QuerySingleAsync<bool>(
+            "SELECT IsAdmin FROM Users WHERE Id = @Id",
+            new { Id = "owner-after-reset" });
+
+        Assert.True(isAdmin);
+    }
+}

--- a/HurrahTv.Api.Tests/PostgresFixture.cs
+++ b/HurrahTv.Api.Tests/PostgresFixture.cs
@@ -4,6 +4,7 @@ using HurrahTv.Api.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 
@@ -93,6 +94,9 @@ public class PostgresFixture : IAsyncLifetime
 
     // truncate user-scoped tables so each test starts from a clean slate.
     // RESTART IDENTITY resets the QueueItems serial so ids are deterministic.
+    // re-applies the admin bootstrap after the truncate so the fixture mirrors
+    // prod startup (DbService.InitializeAsync runs bootstrap on every host build,
+    // but the host is only built once per fixture). pins #92.
     public async Task ResetAsync()
     {
         using NpgsqlConnection db = new(ConnectionString);
@@ -104,6 +108,23 @@ public class PostgresFixture : IAsyncLifetime
                 AIUsage, CurationCache, Users
             RESTART IDENTITY CASCADE
             """);
+        await SeedAdminAsync();
+    }
+
+    // mirrors the admin bootstrap in DbService.InitializeAsync. idempotent UPDATE that
+    // flips IsAdmin on existing Users rows whose phone matches the owner phone or any
+    // entry in Admin:BootstrapPhones. prod runs this on every startup; tests with
+    // admin-aware flows call it after inserting users to mimic that step. if the
+    // bootstrap rule changes in DbService.InitializeAsync, mirror the change here.
+    public async Task SeedAdminAsync()
+    {
+        IConfiguration config = Factory.Services.GetRequiredService<IConfiguration>();
+        string[] bootstrapPhones = ["4406228711", .. config.GetSection("Admin:BootstrapPhones").Get<string[]>() ?? []];
+        using NpgsqlConnection db = new(ConnectionString);
+        await db.OpenAsync();
+        await db.ExecuteAsync(
+            "UPDATE Users SET IsAdmin = TRUE WHERE PhoneNumber = ANY(@Phones) AND IsAdmin = FALSE",
+            new { Phones = bootstrapPhones });
     }
 
     // null-guard Factory in case InitializeAsync threw before Factory was assigned

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -177,6 +177,8 @@ public class DbService(IConfiguration config)
     public async Task<List<QueueItem>> GetQueueAsync(string userId)
     {
         using NpgsqlConnection db = await OpenAsync();
+        // canonical status ordering: see HurrahTv.Shared.Models.QueueStatusOrdering.DisplayOrder
+        // — Client UI sorts share the same rule via QueueStatusOrdering.SortPriority
         IEnumerable<QueueItem> items = await db.QueryAsync<QueueItem>("""
             SELECT * FROM QueueItems WHERE UserId = @UserId
             ORDER BY

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -178,7 +178,10 @@ public class DbService(IConfiguration config)
     {
         using NpgsqlConnection db = await OpenAsync();
         // canonical status ordering: see HurrahTv.Shared.Models.QueueStatusOrdering.DisplayOrder
-        // — Client UI sorts share the same rule via QueueStatusOrdering.SortPriority
+        // — Client UI sorts share the same rule via QueueStatusOrdering.SortPriority.
+        // ELSE 4 matches DisplayOrder.Count so unknown enum values sort after every known one.
+        // Freshness window's upper bound mirrors QueueItem.HasNewEpisode (#86) so a future-stamped
+        // LatestEpisodeDate (TMDb backfill quirk) doesn't sort into the recent bucket.
         IEnumerable<QueueItem> items = await db.QueryAsync<QueueItem>("""
             SELECT * FROM QueueItems WHERE UserId = @UserId
             ORDER BY
@@ -187,8 +190,10 @@ public class DbService(IConfiguration config)
                     WHEN 0 THEN 1  -- WantToWatch second
                     WHEN 2 THEN 2  -- Finished third
                     WHEN 4 THEN 3  -- NotForMe last
+                    ELSE 4         -- unknown sorts last (matches QueueStatusOrdering.SortPriority)
                 END,
-                CASE WHEN LatestEpisodeDate >= NOW() - INTERVAL '7 days' THEN 0 ELSE 1 END,
+                CASE WHEN LatestEpisodeDate >= NOW() - INTERVAL '7 days'
+                      AND LatestEpisodeDate <= NOW() THEN 0 ELSE 1 END,
                 LatestEpisodeDate DESC,
                 Position
             """, new { UserId = userId });

--- a/HurrahTv.Client.Tests/BadgeHelpersTests.cs
+++ b/HurrahTv.Client.Tests/BadgeHelpersTests.cs
@@ -13,35 +13,6 @@ public class BadgeHelpersTests
     public void StatusIcon_ReturnsExpectedIcon_ForEveryStatus(QueueStatus status, string expected)
         => Assert.Equal(expected, BadgeHelpers.StatusIcon(status));
 
-    // source of truth for status ordering across Queue.razor and QuickActions.
-    // a silent reorder would ship a broken UI — pin the exact display order
-    // (which is intentionally not the enum's numeric order).
-    [Fact]
-    public void AllStatuses_PinsDisplayOrder()
-    {
-        QueueStatus[] expected =
-        [
-            QueueStatus.Watching,
-            QueueStatus.WantToWatch,
-            QueueStatus.Finished,
-            QueueStatus.NotForMe
-        ];
-
-        Assert.Equal(expected, BadgeHelpers.AllStatuses);
-    }
-
-    // when a new QueueStatus is added to the enum, this test forces a decision
-    // about where it lives in the UI ordering — failing here is a feature.
-    [Fact]
-    public void AllStatuses_CoversEveryEnumValue()
-    {
-        QueueStatus[] enumValues = Enum.GetValues<QueueStatus>();
-        Assert.Equal(enumValues.Length, BadgeHelpers.AllStatuses.Count);
-        Assert.Equal(
-            [.. enumValues.OrderBy(s => s)],
-            [.. BadgeHelpers.AllStatuses.OrderBy(s => s)]);
-    }
-
     // the [Theory] above pins exact icons for the four currently-defined statuses.
     // this guard forces a decision when a new QueueStatus is added — without it,
     // a 5th enum value would silently get StatusIcon's default "" arm and ship.

--- a/HurrahTv.Client.Tests/BadgeHelpersTests.cs
+++ b/HurrahTv.Client.Tests/BadgeHelpersTests.cs
@@ -55,4 +55,51 @@ public class BadgeHelpersTests
             Assert.NotEqual("", BadgeHelpers.StatusIcon(status));
         }
     }
+
+    [Theory]
+    [InlineData(QueueStatus.WantToWatch, "bg-gray-700/80")]
+    [InlineData(QueueStatus.Watching, "bg-green-600/80")]
+    [InlineData(QueueStatus.Finished, "bg-blue-600/80")]
+    [InlineData(QueueStatus.NotForMe, "bg-gray-600/80")]
+    public void StatusBg_ReturnsExpectedClass_ForEveryStatus(QueueStatus status, string expected)
+        => Assert.Equal(expected, BadgeHelpers.StatusBg(status));
+
+    [Theory]
+    [InlineData(QueueStatus.WantToWatch, "text-accent")]
+    [InlineData(QueueStatus.Watching, "text-green-400")]
+    [InlineData(QueueStatus.Finished, "text-blue-400")]
+    [InlineData(QueueStatus.NotForMe, "text-gray-400")]
+    public void StatusColor_ReturnsExpectedClass_ForEveryStatus(QueueStatus status, string expected)
+        => Assert.Equal(expected, BadgeHelpers.StatusColor(status));
+
+    [Theory]
+    [InlineData(QueueStatus.WantToWatch, "ring-accent")]
+    [InlineData(QueueStatus.Watching, "ring-green-500")]
+    [InlineData(QueueStatus.Finished, "ring-blue-500")]
+    [InlineData(QueueStatus.NotForMe, "ring-gray-500")]
+    public void StatusRing_ReturnsExpectedClass_ForEveryStatus(QueueStatus status, string expected)
+        => Assert.Equal(expected, BadgeHelpers.StatusRing(status));
+
+    // pins the deliberate "Finished" enum → "Watched" UI label translation
+    // (see comment on QueueStatus.Finished in QueueItem.cs). a refactor that
+    // "fixes" the inconsistency by renaming to "Finished" should fail loudly.
+    [Theory]
+    [InlineData(QueueStatus.WantToWatch, "Want")]
+    [InlineData(QueueStatus.Watching, "Watching")]
+    [InlineData(QueueStatus.Finished, "Watched")]
+    [InlineData(QueueStatus.NotForMe, "Nope")]
+    public void StatusShortLabel_ReturnsExpectedLabel_ForEveryStatus(QueueStatus status, string expected)
+        => Assert.Equal(expected, BadgeHelpers.StatusShortLabel(status));
+
+    // StatusShortLabel defaults to "" — unlike the visual-class helpers which fall back
+    // to a gray neutral, a missing label would ship as blank text in the UI. this guard
+    // forces a label decision when a new QueueStatus is added.
+    [Fact]
+    public void StatusShortLabel_HasNonEmptyMapping_ForEveryQueueStatus()
+    {
+        foreach (QueueStatus status in Enum.GetValues<QueueStatus>())
+        {
+            Assert.NotEqual("", BadgeHelpers.StatusShortLabel(status));
+        }
+    }
 }

--- a/HurrahTv.Client.Tests/SentimentHelpersTests.cs
+++ b/HurrahTv.Client.Tests/SentimentHelpersTests.cs
@@ -50,4 +50,26 @@ public class SentimentHelpersTests
             Assert.NotEqual("", SentimentHelpers.Color(level));
         }
     }
+
+    // pins the long-form labels surfaced in the Queue page filter chips and the
+    // sentiment dialog header. "Watched" (not "Finished") and "Not For Me"
+    // (not "NotForMe") are deliberate UI translations of the enum names.
+    [Theory]
+    [InlineData(QueueStatus.WantToWatch, "Want to Watch")]
+    [InlineData(QueueStatus.Watching, "Watching")]
+    [InlineData(QueueStatus.Finished, "Watched")]
+    [InlineData(QueueStatus.NotForMe, "Not For Me")]
+    public void StatusLabel_ReturnsExpectedLabel_ForEveryStatus(QueueStatus status, string expected)
+        => Assert.Equal(expected, SentimentHelpers.StatusLabel(status));
+
+    // StatusLabel defaults to "" — same broken-UI failure mode as
+    // BadgeHelpers.StatusShortLabel. force a label decision on new enum values.
+    [Fact]
+    public void StatusLabel_HasNonEmptyMapping_ForEveryQueueStatus()
+    {
+        foreach (QueueStatus status in Enum.GetValues<QueueStatus>())
+        {
+            Assert.NotEqual("", SentimentHelpers.StatusLabel(status));
+        }
+    }
 }

--- a/HurrahTv.Client.Tests/SentimentHelpersTests.cs
+++ b/HurrahTv.Client.Tests/SentimentHelpersTests.cs
@@ -31,7 +31,7 @@ public class SentimentHelpersTests
 
     // since SentimentLevel is `static class const int` rather than an enum,
     // Enum.GetValues can't enumerate it — reflection over the public static
-    // const fields fills the same role as AllStatuses_CoversEveryEnumValue
+    // const fields fills the same role as DisplayOrder_CoversEveryEnumValue
     // does for QueueStatus. adding `SentimentLevel.Loathe = 4` without
     // updating the helpers fails this test instead of silently shipping a
     // missing icon/color.

--- a/HurrahTv.Client/Components/QuickActions.razor
+++ b/HurrahTv.Client/Components/QuickActions.razor
@@ -43,7 +43,7 @@
             <!-- list status -->
             <div class="text-gray-500 text-[10px] font-medium uppercase tracking-wider mb-2">List Status</div>
             <div class="grid grid-cols-4 gap-2 mb-4">
-                @foreach (QueueStatus status in BadgeHelpers.AllStatuses)
+                @foreach (QueueStatus status in QueueStatusOrdering.DisplayOrder)
                 {
                     bool active = _queueId > 0 && _currentStatus == status;
                     bool isNfm = status == QueueStatus.NotForMe;

--- a/HurrahTv.Client/Helpers/BadgeHelpers.cs
+++ b/HurrahTv.Client/Helpers/BadgeHelpers.cs
@@ -31,14 +31,6 @@ public static class BadgeHelpers
         _ => ""
     };
 
-    public static readonly IReadOnlyList<QueueStatus> AllStatuses =
-    [
-        QueueStatus.Watching,
-        QueueStatus.WantToWatch,
-        QueueStatus.Finished,
-        QueueStatus.NotForMe
-    ];
-
     public static string StatusColor(QueueStatus status) => status switch
     {
         QueueStatus.WantToWatch => "text-accent",

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -633,14 +633,6 @@ else
         _                       => -1
     };
 
-    // Watching→0, WantToWatch→1, Finished→2 (status list order)
-    private static int StatusSortKey(QueueStatus status) => status switch
-    {
-        QueueStatus.Watching    => 0,
-        QueueStatus.WantToWatch => 1,
-        QueueStatus.Finished    => 2,
-        _                       => 3
-    };
 
     private static List<QueueItem> PickRecSeeds(List<QueueItem> allItems, int count, string mediaType = "all")
     {
@@ -679,14 +671,14 @@ else
     private List<QueueItem> SortWatching(IEnumerable<QueueItem> items) => _watchlistSort switch
     {
         "sentiment" => [.. items.OrderByDescending(i => SentimentSortKey(i.Sentiment)).ThenByDescending(i => i.LatestEpisodeDate ?? DateTime.MinValue)],
-        "queue"     => [.. items.OrderBy(i => StatusSortKey(i.Status)).ThenByDescending(i => i.LatestEpisodeDate ?? DateTime.MinValue)],
+        "queue"     => [.. items.OrderBy(i => QueueStatusOrdering.SortPriority(i.Status)).ThenByDescending(i => i.LatestEpisodeDate ?? DateTime.MinValue)],
         _           => [.. items.OrderByDescending(i => i.HasEpisodeThisMonth ? 1 : 0).ThenByDescending(i => i.LatestEpisodeDate ?? DateTime.MinValue).ThenBy(i => i.Position)]
     };
 
     private List<QueueItem> SortUpcoming(IEnumerable<QueueItem> items) => _watchlistSort switch
     {
         "sentiment" => [.. items.OrderByDescending(i => SentimentSortKey(i.Sentiment)).ThenBy(i => i.NextEpisodeDate ?? DateTime.MaxValue)],
-        "queue"     => [.. items.OrderBy(i => StatusSortKey(i.Status)).ThenBy(i => i.NextEpisodeDate ?? DateTime.MaxValue)],
+        "queue"     => [.. items.OrderBy(i => QueueStatusOrdering.SortPriority(i.Status)).ThenBy(i => i.NextEpisodeDate ?? DateTime.MaxValue)],
         _           => [.. items.OrderBy(i => i.NextEpisodeDate ?? DateTime.MaxValue)]
     };
 

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -633,7 +633,6 @@ else
         _                       => -1
     };
 
-
     private static List<QueueItem> PickRecSeeds(List<QueueItem> allItems, int count, string mediaType = "all")
     {
         // prefer items with positive sentiment, fallback to Finished; filter by active media type

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -185,7 +185,7 @@ else
                         @if (_expandedStatusId == item.Id)
                         {
                             <div class="flex items-center gap-1">
-                                @foreach (QueueStatus s in BadgeHelpers.AllStatuses)
+                                @foreach (QueueStatus s in QueueStatusOrdering.DisplayOrder)
                                 {
                                     <button class="@($"w-8 h-8 rounded-full flex items-center justify-center transition-all {(item.Status == s ? BadgeHelpers.StatusColor(s) + " bg-surface-200 scale-110" : "text-gray-500 hover:text-white hover:bg-surface-100")}")"
                                             @onclick="() => SelectStatus(item, s)"

--- a/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
@@ -49,6 +49,16 @@ public class QueueItemDatePredicatesTests
         Assert.False(item.HasNewEpisode);
     }
 
+    // pins #86 — wrong-sign LatestEpisodeDate (TMDb backfill quirk) must not pass the
+    // window. Home hero billboard (Home.razor:754) and Queue card badge (Queue.razor:137)
+    // both gate UI on this predicate; future-stamped items would feature unaired episodes.
+    [Fact]
+    public void HasNewEpisode_IsFalse_WhenLatestEpisodeDateIsInTheFuture()
+    {
+        QueueItem item = new() { LatestEpisodeDate = DateTime.UtcNow.AddDays(5) };
+        Assert.False(item.HasNewEpisode);
+    }
+
     [Fact]
     public void HasEpisodeThisMonth_IsTrue_WhenLatestEpisodeDateIsWithin30Days()
     {
@@ -67,6 +77,16 @@ public class QueueItemDatePredicatesTests
     public void HasEpisodeThisMonth_IsFalse_WhenLatestEpisodeDateIsNull()
     {
         QueueItem item = new() { LatestEpisodeDate = null };
+        Assert.False(item.HasEpisodeThisMonth);
+    }
+
+    // pins #86 — Home.razor:683 uses HasEpisodeThisMonth as a sort key in the default
+    // watchlist sort; a future-stamped item without an upper bound would otherwise
+    // sort to the top alongside legitimate recent-episode items.
+    [Fact]
+    public void HasEpisodeThisMonth_IsFalse_WhenLatestEpisodeDateIsInTheFuture()
+    {
+        QueueItem item = new() { LatestEpisodeDate = DateTime.UtcNow.AddDays(10) };
         Assert.False(item.HasEpisodeThisMonth);
     }
 }

--- a/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
@@ -134,6 +134,6 @@ public class QueueItemExtensionsTests
         QueueItem item = new() { AvailableOnJson = "[9,8]" };
         List<StreamingService> visible = item.VisibleServicesFor([8, 9]);
         int[] actualIds = [.. visible.Select(s => s.TmdbProviderId)];
-        Assert.Equal(new[] { 9, 8 }, actualIds);
+        Assert.Equal([9, 8], actualIds);
     }
 }

--- a/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
@@ -1,0 +1,139 @@
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Shared.Tests;
+
+// pins #82 — pure helpers in QueueItemExtensions had zero coverage. The Days* helpers
+// normalize the UTC-Kind drift that surfaced in #49/#70; the AvailableOn helpers gate
+// every streaming-service logo rendered on a poster card.
+public class QueueItemExtensionsTests
+{
+    private static readonly DateTime TodayUtc = new(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void DaysUntilNextEpisode_PositiveOffset_ReturnsDayCount()
+    {
+        QueueItem item = new() { NextEpisodeDate = TodayUtc.AddDays(3) };
+        Assert.Equal(3, item.DaysUntilNextEpisode(TodayUtc));
+    }
+
+    [Fact]
+    public void DaysUntilNextEpisode_SameDay_ReturnsZero()
+    {
+        QueueItem item = new() { NextEpisodeDate = TodayUtc };
+        Assert.Equal(0, item.DaysUntilNextEpisode(TodayUtc));
+    }
+
+    // a wrong-sign (past) NextEpisodeDate is the #49/#70 failure shape — must surface
+    // as a negative integer so predicate writers can guard against it explicitly.
+    [Fact]
+    public void DaysUntilNextEpisode_NegativeOffset_ReturnsNegativeDayCount()
+    {
+        QueueItem item = new() { NextEpisodeDate = TodayUtc.AddDays(-2) };
+        Assert.Equal(-2, item.DaysUntilNextEpisode(TodayUtc));
+    }
+
+    [Fact]
+    public void DaysUntilNextEpisode_Null_ReturnsNull()
+    {
+        QueueItem item = new() { NextEpisodeDate = null };
+        Assert.Null(item.DaysUntilNextEpisode(TodayUtc));
+    }
+
+    [Fact]
+    public void DaysSinceLatestEpisode_PositiveOffset_ReturnsDayCount()
+    {
+        QueueItem item = new() { LatestEpisodeDate = TodayUtc.AddDays(-3) };
+        Assert.Equal(3, item.DaysSinceLatestEpisode(TodayUtc));
+    }
+
+    [Fact]
+    public void DaysSinceLatestEpisode_SameDay_ReturnsZero()
+    {
+        QueueItem item = new() { LatestEpisodeDate = TodayUtc };
+        Assert.Equal(0, item.DaysSinceLatestEpisode(TodayUtc));
+    }
+
+    // future-stamped LatestEpisodeDate (sibling of #86) must surface as a negative
+    // day-diff — the wrong-sign value is the leak path for the typed-comparison rule.
+    [Fact]
+    public void DaysSinceLatestEpisode_NegativeOffset_ReturnsNegativeDayCount()
+    {
+        QueueItem item = new() { LatestEpisodeDate = TodayUtc.AddDays(2) };
+        Assert.Equal(-2, item.DaysSinceLatestEpisode(TodayUtc));
+    }
+
+    [Fact]
+    public void DaysSinceLatestEpisode_Null_ReturnsNull()
+    {
+        QueueItem item = new() { LatestEpisodeDate = null };
+        Assert.Null(item.DaysSinceLatestEpisode(TodayUtc));
+    }
+
+    [Fact]
+    public void ParseAvailableOnProviderIds_ValidJsonList_ReturnsIds()
+    {
+        QueueItem item = new() { AvailableOnJson = "[8,9,15]" };
+        Assert.Equal(new[] { 8, 9, 15 }, item.ParseAvailableOnProviderIds());
+    }
+
+    [Fact]
+    public void ParseAvailableOnProviderIds_SingleIntPayload_ReturnsSingletonList()
+    {
+        QueueItem item = new() { AvailableOnJson = "[15]" };
+        Assert.Equal(new[] { 15 }, item.ParseAvailableOnProviderIds());
+    }
+
+    [Fact]
+    public void ParseAvailableOnProviderIds_EmptyString_ReturnsEmptyList()
+    {
+        QueueItem item = new() { AvailableOnJson = "" };
+        Assert.Empty(item.ParseAvailableOnProviderIds());
+    }
+
+    // malformed payload must surface as an empty list, not a crash — the parser is
+    // best-effort because AvailableOnJson lands here from a Postgres text column.
+    [Fact]
+    public void ParseAvailableOnProviderIds_MalformedJson_ReturnsEmptyList()
+    {
+        QueueItem item = new() { AvailableOnJson = "not json" };
+        Assert.Empty(item.ParseAvailableOnProviderIds());
+    }
+
+    [Fact]
+    public void VisibleServicesFor_EmptyUserServices_ReturnsEmpty()
+    {
+        QueueItem item = new() { AvailableOnJson = "[8,9]" };
+        Assert.Empty(item.VisibleServicesFor([]));
+    }
+
+    // 999 is not a known TMDb provider; even if a user "subscribes" to it the result
+    // must skip it rather than try to render an unknown logo.
+    [Fact]
+    public void VisibleServicesFor_UnknownProviderIds_AreSkipped()
+    {
+        QueueItem item = new() { AvailableOnJson = "[999,8]" };
+        List<StreamingService> visible = item.VisibleServicesFor([999, 8]);
+        Assert.Single(visible);
+        Assert.Equal(8, visible[0].TmdbProviderId);
+    }
+
+    [Fact]
+    public void VisibleServicesFor_MaxCap_LimitsResultLength()
+    {
+        QueueItem item = new() { AvailableOnJson = "[8,9,15]" };
+        List<StreamingService> visible = item.VisibleServicesFor([8, 9, 15], max: 2);
+        Assert.Equal(2, visible.Count);
+    }
+
+    // AvailableOnJson stores provider IDs in the order TMDb returned; the result
+    // must mirror that order, NOT the userServices ordering. Pins the implicit
+    // contract the implementation's `foreach (int id in parsed)` encodes.
+    [Fact]
+    public void VisibleServicesFor_PreservesProviderIdOrderFromQueueItem()
+    {
+        QueueItem item = new() { AvailableOnJson = "[9,8]" };
+        List<StreamingService> visible = item.VisibleServicesFor([8, 9]);
+        int[] actualIds = [.. visible.Select(s => s.TmdbProviderId)];
+        Assert.Equal(new[] { 9, 8 }, actualIds);
+    }
+}

--- a/HurrahTv.Shared.Tests/QueueStatusOrderingTests.cs
+++ b/HurrahTv.Shared.Tests/QueueStatusOrderingTests.cs
@@ -1,0 +1,59 @@
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Shared.Tests;
+
+// pins #91 — the queue-status ordering rule moved from Client/Helpers/BadgeHelpers to
+// HurrahTv.Shared so both the Client UI (Queue.razor tabs, QuickActions, Home sort)
+// and the Api SQL (DbService.GetQueueAsync ORDER BY CASE) sort by the same list.
+// Tests live in Shared.Tests because the invariant is no longer Client-only.
+public class QueueStatusOrderingTests
+{
+    // source of truth for status ordering across all UI surfaces and the SQL CASE.
+    // a silent reorder would ship a broken UI — pin the exact display order
+    // (which is intentionally not the enum's numeric order).
+    [Fact]
+    public void DisplayOrder_PinsExactOrdering()
+    {
+        QueueStatus[] expected =
+        [
+            QueueStatus.Watching,
+            QueueStatus.WantToWatch,
+            QueueStatus.Finished,
+            QueueStatus.NotForMe
+        ];
+
+        Assert.Equal(expected, QueueStatusOrdering.DisplayOrder);
+    }
+
+    // when a new QueueStatus is added to the enum, this test forces a decision
+    // about where it lives in the UI ordering — failing here is a feature.
+    [Fact]
+    public void DisplayOrder_CoversEveryEnumValue()
+    {
+        QueueStatus[] enumValues = Enum.GetValues<QueueStatus>();
+        Assert.Equal(enumValues.Length, QueueStatusOrdering.DisplayOrder.Count);
+        Assert.Equal(
+            [.. enumValues.OrderBy(s => s)],
+            [.. QueueStatusOrdering.DisplayOrder.OrderBy(s => s)]);
+    }
+
+    // SortPriority is derived from DisplayOrder via a dictionary — this test verifies
+    // the derivation invariant so a refactor that uncouples them (e.g. hardcoding the
+    // switch) loudly fails. DisplayOrder.IndexOf is the spec.
+    [Fact]
+    public void SortPriority_MatchesDisplayOrderIndex_ForEveryStatus()
+    {
+        for (int i = 0; i < QueueStatusOrdering.DisplayOrder.Count; i++)
+        {
+            QueueStatus status = QueueStatusOrdering.DisplayOrder[i];
+            Assert.Equal(i, QueueStatusOrdering.SortPriority(status));
+        }
+    }
+
+    // Watching is the highest-priority status — pinning this independently means a
+    // reorder of DisplayOrder that accidentally demotes Watching would fail two tests
+    // (this one and DisplayOrder_PinsExactOrdering), making the regression unambiguous.
+    [Fact]
+    public void SortPriority_Watching_IsZero()
+        => Assert.Equal(0, QueueStatusOrdering.SortPriority(QueueStatus.Watching));
+}

--- a/HurrahTv.Shared/Models/QueueItem.cs
+++ b/HurrahTv.Shared/Models/QueueItem.cs
@@ -32,16 +32,20 @@ public class QueueItem
     public string PosterUrl(string size = "w342") => TmdbImage.Url(PosterPath, size);
     public string BackdropUrl(string size = "w1280") => TmdbImage.Url(BackdropPath, size);
 
+    // upper bound guards against TMDb backfill quirks that future-stamp LatestEpisodeDate;
+    // without it, an unaired episode would silently classify as "new" (#86).
     public bool HasNewEpisode => LatestEpisodeDate.HasValue
-        && LatestEpisodeDate.Value >= DateTime.UtcNow.AddDays(-7);
+        && LatestEpisodeDate.Value >= DateTime.UtcNow.AddDays(-7)
+        && LatestEpisodeDate.Value <= DateTime.UtcNow;
 
     public bool HasUpcomingEpisode => NextEpisodeDate.HasValue
         && NextEpisodeDate.Value <= DateTime.UtcNow.AddDays(7)
         && NextEpisodeDate.Value > DateTime.UtcNow;
 
-    // latest episode aired within the last 30 days
+    // latest episode aired within the last 30 days — upper bound mirrors HasNewEpisode (#86)
     public bool HasEpisodeThisMonth => LatestEpisodeDate.HasValue
-        && LatestEpisodeDate.Value >= DateTime.UtcNow.AddDays(-30);
+        && LatestEpisodeDate.Value >= DateTime.UtcNow.AddDays(-30)
+        && LatestEpisodeDate.Value <= DateTime.UtcNow;
 }
 
 public enum QueueStatus

--- a/HurrahTv.Shared/Models/QueueStatusOrdering.cs
+++ b/HurrahTv.Shared/Models/QueueStatusOrdering.cs
@@ -1,0 +1,25 @@
+namespace HurrahTv.Shared.Models;
+
+// canonical queue-status ordering. Both the Client UI (Queue.razor tabs, QuickActions,
+// Home watchlist sort) and the Api SQL (DbService.GetQueueAsync ORDER BY CASE) sort by
+// this rule — promoted here so neither side can drift. SQL keeps a literal CASE for
+// readability; its comment references this type so a grep on either name finds both.
+public static class QueueStatusOrdering
+{
+    public static readonly IReadOnlyList<QueueStatus> DisplayOrder =
+    [
+        QueueStatus.Watching,
+        QueueStatus.WantToWatch,
+        QueueStatus.Finished,
+        QueueStatus.NotForMe
+    ];
+
+    // SortPriority is derived from DisplayOrder so the list is the only place the rule
+    // is written down — reordering DisplayOrder automatically reorders the sort keys.
+    private static readonly Dictionary<QueueStatus, int> _priority =
+        DisplayOrder.Select((s, i) => (s, i)).ToDictionary(t => t.s, t => t.i);
+
+    // 0 = first in display order; unknown statuses sort after every known value.
+    public static int SortPriority(QueueStatus status) =>
+        _priority.TryGetValue(status, out int p) ? p : DisplayOrder.Count;
+}

--- a/HurrahTv.Shared/Models/QueueStatusOrdering.cs
+++ b/HurrahTv.Shared/Models/QueueStatusOrdering.cs
@@ -6,13 +6,18 @@ namespace HurrahTv.Shared.Models;
 // readability; its comment references this type so a grep on either name finds both.
 public static class QueueStatusOrdering
 {
-    public static readonly IReadOnlyList<QueueStatus> DisplayOrder =
+    // Array.AsReadOnly returns a ReadOnlyCollection<T> whose runtime type is NOT the
+    // underlying array — a down-cast to QueueStatus[] throws, so callers can't mutate
+    // even via reflection-free casts. Required in long-lived Blazor WASM processes
+    // where a corrupted static persists for the entire browser session.
+    // See: Learnings/blazor-wasm-static-mutable-arrays.md
+    public static readonly IReadOnlyList<QueueStatus> DisplayOrder = Array.AsReadOnly<QueueStatus>(
     [
         QueueStatus.Watching,
         QueueStatus.WantToWatch,
         QueueStatus.Finished,
         QueueStatus.NotForMe
-    ];
+    ]);
 
     // SortPriority is derived from DisplayOrder so the list is the only place the rule
     // is written down — reordering DisplayOrder automatically reorders the sort keys.

--- a/Learnings/blazor-wasm-static-mutable-arrays.md
+++ b/Learnings/blazor-wasm-static-mutable-arrays.md
@@ -4,19 +4,19 @@
 > **Date:** 2026-04-08
 
 ## Context
-`BadgeHelpers.AllStatuses` was initially declared as `public static readonly QueueStatus[]`. The `readonly` modifier prevents reassigning the reference, but not mutating the array elements. In a server context this would be a per-request risk; in Blazor WASM it's worse.
+`QueueStatusOrdering.DisplayOrder` (formerly `BadgeHelpers.AllStatuses`, promoted to `HurrahTv.Shared` in #91) was initially declared as `public static readonly QueueStatus[]`. The `readonly` modifier prevents reassigning the reference, but not mutating the array elements. In a server context this would be a per-request risk; in Blazor WASM it's worse.
 
 ## Learning
-Blazor WASM runs in a single long-lived browser process. There are no per-request resets, no AppDomain recycling, no worker process restarts. A `static readonly T[]` is effectively a singleton for the entire browser session — if any caller does `AllStatuses[0] = QueueStatus.NotForMe`, every component that iterates the array picks up the corruption immediately and for the rest of the session.
+Blazor WASM runs in a single long-lived browser process. There are no per-request resets, no AppDomain recycling, no worker process restarts. A `static readonly T[]` is effectively a singleton for the entire browser session — if any caller does `DisplayOrder[0] = QueueStatus.NotForMe`, every component that iterates the array picks up the corruption immediately and for the rest of the session.
 
 Use `IReadOnlyList<T>` for any shared static collection that multiple components consume:
 
 ```csharp
 // wrong — elements are mutable despite readonly reference
-public static readonly QueueStatus[] AllStatuses = [...];
+public static readonly QueueStatus[] DisplayOrder = [...];
 
 // correct — elements are not settable
-public static readonly IReadOnlyList<QueueStatus> AllStatuses = [...];
+public static readonly IReadOnlyList<QueueStatus> DisplayOrder = [...];
 ```
 
 `ReadOnlySpan<T>` is safer still but cannot be stored as a static field. `IReadOnlyList<T>` is the idiomatic fix with zero allocation overhead.

--- a/Learnings/ca1861-suppress-in-test-projects.md
+++ b/Learnings/ca1861-suppress-in-test-projects.md
@@ -1,0 +1,46 @@
+# CA1861 Misapplies to xUnit Assertions — Suppress in Test Projects
+
+> **Area:** Tooling | Build
+> **Date:** 2026-05-22
+> **Resolves:** mkerchenski/hurrah-tv#82 (surfaced during CI failure on PR #93)
+
+## Context
+
+Running `dotnet format analyzers HurrahTv.slnx --severity info --no-restore` on a PR that added `QueueItemExtensionsTests.cs` (16 facts using `Assert.Equal(new[] { 8, 9, 15 }, item.ParseAvailableOnProviderIds())`) produced two problematic outcomes:
+
+1. **The analyzer auto-applied a fix** that hoisted `new[] { 8, 9, 15 }` into a class-level `private static readonly int[] expected = new[] { 8, 9, 15 };` field — used by exactly one test, with a generic lowercase name. The result was strictly worse code: the expected literal was no longer next to the assertion that referenced it.
+2. **CI's `dotnet format --verify-no-changes` rejected the un-applied diagnostics** when I reverted the field hoist back to inline form, blocking the merge.
+
+The rule is CA1861: "Avoid constant arrays as arguments. Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array."
+
+## Learning
+
+CA1861's premise — "called repeatedly, allocation-heavy" — is wrong for xUnit `[Fact]` and `[Theory]` methods. Each test runs **once per invocation**, not in a hot loop. Hoisting the expected literal away from the assertion site destroys the readability that `Assert.Equal(expected, actual)` is designed around: the entire xUnit idiom places the expected value next to the assertion so the test reads as a single thought.
+
+**Suppress CA1861 for test projects via `.editorconfig`** rather than fighting the analyzer at every PR.
+
+## Editorconfig glob trap (the actually-non-obvious part)
+
+Editorconfig section globs are subtly different from gitignore globs. Three patterns failed before one worked:
+
+| Pattern | Behavior |
+|---|---|
+| `[**/*Tests/**.cs]` | Didn't match — `**.cs` is ambiguous; the analyzer engine didn't interpret it as "any .cs in any subdir" |
+| `[{HurrahTv.Shared.Tests,HurrahTv.Client.Tests,HurrahTv.Api.Tests}/**/*.cs]` | Didn't match — `**/*.cs` after the brace expansion requires at least one intermediate path segment between the project dir and the file. Our test files live directly in the project root (`HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs`), so this glob effectively required `<project>/<subdir>/<file>.cs` and skipped flat files. |
+| `[*Tests.cs]` | **Worked.** Basename-suffix pattern (no `/`) matches across all directories. Safe in this repo because no production file is named `*Tests.cs`. |
+
+The deeper rule: when an editorconfig glob isn't matching, drop to a basename-only pattern (no `/`) before reaching for `**`. It's blunter but unambiguous. The risk is unintended matches in production code — verify with `grep -r "Tests.cs"` (or equivalent file listing) before committing the glob.
+
+## Example
+
+```ini
+# .editorconfig
+[*Tests.cs]
+dotnet_diagnostic.CA1861.severity = none
+```
+
+This silences CA1861 for any file whose basename ends in `Tests.cs`, regardless of which directory it lives in. Production code keeps the rule (where the "called repeatedly" premise actually applies — e.g., a hot-path method with a constant array argument should hoist).
+
+## Related gotcha: `dotnet format analyzers` is not always mechanical
+
+Most `dotnet format` rules (whitespace, brace style, expression-bodied member preferences) are stylistic transformations that produce equivalent code. CA-rule autofixes are different: they can be **opinionated refactors** that change code organization (CA1861 hoists to fields; CA1822 makes methods static; etc.). Treat the `analyzers` sub-command's output as a **proposal**, not a mechanical reformatting. Always diff the changes before committing.

--- a/Learnings/shared-promotion-semantic-audit.md
+++ b/Learnings/shared-promotion-semantic-audit.md
@@ -1,0 +1,59 @@
+# Promoting Rules to Shared: Audit Semantic Consumers Across Languages
+
+> **Area:** Architecture | Data
+> **Date:** 2026-05-22
+> **Resolves:** mkerchenski/hurrah-tv#86, mkerchenski/hurrah-tv#91
+
+## Context
+
+PR #93 closed two related issues in the same diff:
+
+- **#86** added `<= DateTime.UtcNow` upper bounds to `QueueItem.HasNewEpisode` and `HasEpisodeThisMonth`. The acceptance criterion read: *"Audit consumers of `HasNewEpisode` and `HasEpisodeThisMonth` to confirm none rely on future-date inclusion."*
+- **#91** promoted the `Watching → WantToWatch → Finished → NotForMe` ordering rule from `BadgeHelpers.AllStatuses` (Client) to `QueueStatusOrdering.DisplayOrder` (Shared), with `SortPriority` derived from it.
+
+The "audit consumers" criterion for #86 was satisfied — I checked every C# caller of the predicates (`Home.razor`, `Queue.razor`, `PosterCard`) and confirmed none of them benefited from future-date inclusion. The PR shipped.
+
+The multi-agent review (`/xreview`) on the PR independently flagged two further problems that the original audit had missed:
+
+1. **`DbService.GetQueueAsync` SQL** had a freshness-classifier `CASE WHEN LatestEpisodeDate >= NOW() - INTERVAL '7 days' THEN 0 ELSE 1 END` — the **exact same one-sided window** as the C# predicate I just fixed, implemented directly in SQL against the underlying column.
+2. **The same SQL had a status `CASE`** that mirrored `QueueStatusOrdering.SortPriority` but lacked an `ELSE` clause — so when (not if) a new `QueueStatus` enum value gets added, SQL falls through to NULL while C# returns `DisplayOrder.Count`. The two sides diverge on the next enum addition.
+
+Three of four reviewer agents flagged at least one of these. Copilot's automated review caught the missing `ELSE` independently.
+
+## Learning
+
+**When promoting a rule to Shared — or fixing a bug in a predicate — the "audit consumers" step must cover semantic consumers across languages, not just callers in the same language.**
+
+A SQL `CASE` expression that classifies the same input by the same window is *the same rule* as the C# predicate, even though no static analyzer or call-site grep will link them. The C# compiler knows nothing about the SQL string literal embedded in `DbService.GetQueueAsync`; a refactor of the C# rule leaves the SQL silently parallel-implementing the old version.
+
+The deeper principle: **rules have a *semantic identity* that's independent of the language they're expressed in**. Once a rule is named (e.g., "an episode is 'new' if it aired in the last 7 days"), every parallel implementation of it — SQL CASE, JavaScript helper, Razor template condition, AI-prompt instruction, even a comment that documents an expected behavior — is a consumer that must be audited together.
+
+## How to audit semantic consumers
+
+The mechanical "find all callers" tools find only one half of the surface. The other half lives in:
+
+1. **SQL strings** — `Endpoints/*.cs`, `Services/*.cs`. Grep for the underlying column names the predicate touches (e.g., `LatestEpisodeDate`, `Status`) and read every `CASE`, `WHERE`, `ORDER BY` that mentions them.
+2. **Razor templates** — `Pages/*.razor`, `Components/*.razor`. Grep for the column names and inline arithmetic that might re-implement the rule (e.g., a `@if (item.LatestEpisodeDate.HasValue && item.LatestEpisodeDate > DateTime.UtcNow.AddDays(-7))` would be a re-implementation).
+3. **AI prompts** — `Services/AIPromptBuilder.cs` or wherever prompt strings live. A prompt that tells the model "an episode is new if it aired in the last week" is a semantic consumer.
+4. **Comments** — comments that document the rule are *also* consumers in the sense that a refactor must keep them honest.
+5. **Tests** — tests that pin the rule against specific dates are consumers; if the rule changes, the tests must change too.
+
+The grep target is the **underlying column or signal**, not the predicate name. A predicate that hasn't been promoted yet is being parallel-implemented somewhere; grep `LatestEpisodeDate`, not `HasNewEpisode`.
+
+## Example
+
+When fixing #86 the right audit would have been:
+
+```bash
+# don't grep the predicate name
+grep -r "HasNewEpisode" --include="*.cs" --include="*.razor"
+
+# grep the underlying signal — this is what catches semantic consumers
+grep -rn "LatestEpisodeDate" --include="*.cs" --include="*.razor"
+```
+
+The second command would have surfaced `DbService.cs:189` (the SQL freshness CASE) as a one-sided window that needed the same upper bound. The fix that ultimately landed in commit `bb37373` added `AND LatestEpisodeDate <= NOW()` to the SQL — the exact mirror of the C# `<= DateTime.UtcNow` fix.
+
+## When this matters most
+
+The audit step is cheapest at the moment of the rule's first promotion (or first bugfix). Once a rule lives in two implementations that drift apart, every future contributor has to figure out *which one is canonical* — and the answer is "they were supposed to be the same but aren't anymore." Promoting to Shared with a comment-pointer (`-- canonical: see HurrahTv.Shared.Models.QueueStatusOrdering.DisplayOrder`) is the cheapest forcing function: it makes the link grep-able even from inside a SQL string.


### PR DESCRIPTION
## Summary

Five small issues bundled — all test-infrastructure / test-coverage work that builds on PRs #88 (Client.Tests) and #89 (Api.Tests), plus one Shared-elevation refactor:

- **#92** — `PostgresFixture.ResetAsync` re-applies the admin bootstrap that `DbService.InitializeAsync` runs on startup, so future admin endpoint tests don't trip on missing `IsAdmin` state. New `AdminBootstrapTests` pins the invariant.
- **#86** — `QueueItem.HasNewEpisode` and `HasEpisodeThisMonth` gain `<= DateTime.UtcNow` upper bounds. A future-stamped `LatestEpisodeDate` (TMDb backfill quirk) no longer silently classifies an unaired episode as already-aired. Wrong-sign regression tests added.
- **#82** — New `QueueItemExtensionsTests` (16 facts) covering `DaysUntilNextEpisode`, `DaysSinceLatestEpisode`, `ParseAvailableOnProviderIds`, and `VisibleServicesFor`.
- **#90** — `BadgeHelpersTests` and `SentimentHelpersTests` gain `[Theory]` coverage for the remaining helper surface (`StatusBg`, `StatusColor`, `StatusRing`, `StatusShortLabel`, `StatusLabel`), plus `HasNonEmptyMapping` guards on the two label methods whose default arm is `""`.
- **#91** — Queue-status ordering rule promoted from `BadgeHelpers.AllStatuses` to `HurrahTv.Shared.Models.QueueStatusOrdering` so both Client UI and Api SQL agree on the canonical list. `Home.razor`'s private `StatusSortKey` switch (a hidden third encoding of the same rule) folded into `QueueStatusOrdering.SortPriority`, derived from `DisplayOrder` via a static dictionary so the list is the only place the rule is written down.

Tests: 28 → 92 (+64) across the three test assemblies. No platform-specific dependencies leaked into Shared.

## Test plan

- [x] `dotnet test` passes locally — 92 tests, 0 failures
- [ ] CI green on push (Postgres service container, all assemblies)
- [ ] Smoke-test Queue page: status tabs render in Watching → WantToWatch → Finished → NotForMe order
- [ ] Smoke-test Home page in "queue" sort mode: items group in the same status order
- [ ] Smoke-test QuickActions modal: status grid reads left-to-right in the same order

Closes #82
Closes #86
Closes #90
Closes #91
Closes #92