### PR TITLE
UX batch: hero CTA, queue filter URLs, share button

### DIFF
--- a/.github/workflows/main_hurrahtv.yml
+++ b/.github/workflows/main_hurrahtv.yml
@@ -71,10 +71,16 @@ jobs:
       - name: Stamp build version into appsettings
         run: |
           SHORT_SHA=${GITHUB_SHA::8}
-          # merge BuildVersion into existing appsettings.json
+          # merge BuildVersion into the API's appsettings.json
           jq --arg v "$SHORT_SHA" '. + {BuildVersion: $v}' api-output/appsettings.json > api-output/appsettings.tmp \
             && mv api-output/appsettings.tmp api-output/appsettings.json \
-            || { rm -f api-output/appsettings.tmp; echo "Failed to stamp build version"; exit 1; }
+            || { rm -f api-output/appsettings.tmp; echo "Failed to stamp api BuildVersion"; exit 1; }
+          # also stamp into the WASM client's appsettings.json — IConfiguration on the
+          # client reads from wwwroot/appsettings.json, not the API's, so without this
+          # step ShareService's cache-bust import (?v={sha}) silently no-ops in prod.
+          jq --arg v "$SHORT_SHA" '. + {BuildVersion: $v}' api-output/wwwroot/appsettings.json > api-output/wwwroot/appsettings.tmp \
+            && mv api-output/wwwroot/appsettings.tmp api-output/wwwroot/appsettings.json \
+            || { rm -f api-output/wwwroot/appsettings.tmp; echo "Failed to stamp client BuildVersion"; exit 1; }
 
       - name: Remove dev config from client output
         run: rm -f api-output/wwwroot/appsettings.Development.json

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -2,7 +2,6 @@
 @attribute [Authorize]
 @implements IDisposable
 @inject ApiClient Api
-@inject NavigationManager Nav
 @inject IJSRuntime JS
 @inject QuickActionService QuickActionSvc
 @inject ShareService Share
@@ -380,7 +379,8 @@ else
     {
         if (_details is null) return;
         string text = !string.IsNullOrEmpty(_details.Tagline) ? _details.Tagline! : "Check this out on Hurrah.tv";
-        // share the canonical production URL, not Nav.Uri (which is localhost in dev, staging.hurrah.tv from staging)
+        // ShareService prepends the canonical production origin so the link is correct
+        // regardless of whether the user is on localhost, staging.hurrah.tv, or prod
         ShareOutcome outcome = await Share.ShareOrCopyAsync(_details.Title, text, $"/details/{MediaType}/{TmdbId}");
         string? notice = outcome switch
         {

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -393,7 +393,8 @@ else
 
     private async Task ShowShareToastAsync(string message)
     {
-        _shareToastCts?.Cancel();
+        if (_disposed) return;
+        try { _shareToastCts?.Cancel(); } catch (ObjectDisposedException) { }
         _shareToastCts?.Dispose();
         CancellationTokenSource cts = new();
         _shareToastCts = cts;

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -5,6 +5,7 @@
 @inject NavigationManager Nav
 @inject IJSRuntime JS
 @inject QuickActionService QuickActionSvc
+@inject ShareService Share
 
 <PageTitle>@(_details?.Title ?? "Loading...") - Hurrah.tv</PageTitle>
 
@@ -28,16 +29,29 @@ else if (_details != null)
                     @onclick="GoBack" title="Go back">
                 <span class="icon-[heroicons--arrow-left] w-5 h-5"></span>
             </button>
+            <!-- share button mirrors the back button on the right -->
+            <button class="absolute top-3 right-3 md:top-4 md:right-4 bg-black/50 hover:bg-black/70 text-white
+                           rounded-full w-10 h-10 flex items-center justify-center transition-colors backdrop-blur-sm"
+                    @onclick="ShareDetails" title="Share" aria-label="Share">
+                <span class="icon-[heroicons--share] w-5 h-5"></span>
+            </button>
         </div>
     }
     else
     {
-        <!-- back button when no backdrop -->
-        <button class="mb-3 text-gray-400 hover:text-white flex items-center gap-1.5 text-sm transition-colors"
-                @onclick="GoBack">
-            <span class="icon-[heroicons--arrow-left] w-4 h-4"></span>
-            Back
-        </button>
+        <!-- back + share when no backdrop -->
+        <div class="flex items-center justify-between mb-3">
+            <button class="text-gray-400 hover:text-white flex items-center gap-1.5 text-sm transition-colors"
+                    @onclick="GoBack">
+                <span class="icon-[heroicons--arrow-left] w-4 h-4"></span>
+                Back
+            </button>
+            <button class="text-gray-400 hover:text-white flex items-center gap-1.5 text-sm transition-colors"
+                    @onclick="ShareDetails" aria-label="Share">
+                <span class="icon-[heroicons--share] w-4 h-4"></span>
+                Share
+            </button>
+        </div>
     }
 
     <div class="@(!string.IsNullOrEmpty(_details.BackdropUrl()) ? "-mt-24 md:-mt-32 relative z-10" : "") fade-in">
@@ -83,6 +97,14 @@ else if (_details != null)
 else
 {
     <div class="text-center py-20 text-gray-500">Content not found.</div>
+}
+
+@if (!string.IsNullOrEmpty(_shareNotice))
+{
+    <div class="fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 bg-surface-200 text-white px-4 py-2 rounded-lg shadow-lg fade-in z-50 text-sm"
+         role="status" aria-live="polite">
+        @_shareNotice
+    </div>
 }
 
 @{
@@ -297,6 +319,8 @@ else
     private bool _matchLoading;
     private bool _disposed;
     private CancellationTokenSource? _matchCts;
+    private string? _shareNotice;
+    private CancellationTokenSource? _shareToastCts;
 
     private static readonly (QueueStatus status, string label, string icon)[] _listOptions =
     [
@@ -311,6 +335,8 @@ else
         _disposed = true;
         _matchCts?.Cancel();
         _matchCts?.Dispose();
+        _shareToastCts?.Cancel();
+        _shareToastCts?.Dispose();
     }
 
     protected override async Task OnParametersSetAsync()
@@ -349,6 +375,38 @@ else
     }
 
     private async Task GoBack() => await JS.InvokeVoidAsync("history.back");
+
+    private async Task ShareDetails()
+    {
+        if (_details is null) return;
+        string text = !string.IsNullOrEmpty(_details.Tagline) ? _details.Tagline! : "Check this out on Hurrah.tv";
+        ShareOutcome outcome = await Share.ShareOrCopyAsync(_details.Title, text, Nav.Uri);
+        string? notice = outcome switch
+        {
+            ShareOutcome.Copied      => "Link copied",
+            ShareOutcome.Unsupported => "Couldn't share — copy the URL from the address bar",
+            ShareOutcome.Error       => "Couldn't share — try again",
+            _                        => null // shared / cancelled: stay silent
+        };
+        if (notice is not null) await ShowShareToastAsync(notice);
+    }
+
+    private async Task ShowShareToastAsync(string message)
+    {
+        _shareToastCts?.Cancel();
+        _shareToastCts?.Dispose();
+        CancellationTokenSource cts = new();
+        _shareToastCts = cts;
+        _shareNotice = message;
+        StateHasChanged();
+        try { await Task.Delay(2500, cts.Token); }
+        catch (TaskCanceledException) { return; }
+        if (cts == _shareToastCts && !_disposed)
+        {
+            _shareNotice = null;
+            StateHasChanged();
+        }
+    }
 
     private async Task SetListStatus(QueueStatus status)
     {

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -380,7 +380,8 @@ else
     {
         if (_details is null) return;
         string text = !string.IsNullOrEmpty(_details.Tagline) ? _details.Tagline! : "Check this out on Hurrah.tv";
-        ShareOutcome outcome = await Share.ShareOrCopyAsync(_details.Title, text, Nav.Uri);
+        // share the canonical production URL, not Nav.Uri (which is localhost in dev, staging.hurrah.tv from staging)
+        ShareOutcome outcome = await Share.ShareOrCopyAsync(_details.Title, text, $"/details/{MediaType}/{TmdbId}");
         string? notice = outcome switch
         {
             ShareOutcome.Copied      => "Link copied",

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -33,7 +33,7 @@ else if (_details != null)
             <button class="absolute top-3 right-3 md:top-4 md:right-4 bg-black/50 hover:bg-black/70 text-white
                            rounded-full w-10 h-10 flex items-center justify-center transition-colors backdrop-blur-sm"
                     @onclick="ShareDetails" title="Share" aria-label="Share">
-                <span class="icon-[heroicons--share] w-5 h-5"></span>
+                <span class="icon-[heroicons--arrow-up-tray] w-5 h-5"></span>
             </button>
         </div>
     }
@@ -48,7 +48,7 @@ else if (_details != null)
             </button>
             <button class="text-gray-400 hover:text-white flex items-center gap-1.5 text-sm transition-colors"
                     @onclick="ShareDetails" aria-label="Share">
-                <span class="icon-[heroicons--share] w-4 h-4"></span>
+                <span class="icon-[heroicons--arrow-up-tray] w-4 h-4"></span>
                 Share
             </button>
         </div>

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -735,7 +735,7 @@ else
                 Overview: null,
                 TmdbId: watching.TmdbId,
                 MediaType: watching.MediaType,
-                PrimaryLabel: "Resume",
+                PrimaryLabel: watching.MediaType == MediaTypes.Tv ? "Go to show" : "Go to movie",
                 PrimaryAction: HomeHero.HeroAction.Resume);
         }
 

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -411,21 +411,28 @@ else
 
     private void ClearAllFilters()
     {
-        bool anyChanged = false;
-        if (_activeTab != "all") { _activeTab = "all"; anyChanged = true; }
-        if (_selectedServiceId is not null) { _selectedServiceId = null; anyChanged = true; }
-        if (MediaFilter.MediaType != MediaTypes.All)
-        {
-            // page-local clear: don't write 'all' through to the user's persisted preference
-            MediaFilter.Set(MediaTypes.All, persist: false);
-            anyChanged = true;
-        }
-        if (!anyChanged) return;
+        bool tabOrServiceChanged = false;
+        if (_activeTab != "all") { _activeTab = "all"; tabOrServiceChanged = true; }
+        if (_selectedServiceId is not null) { _selectedServiceId = null; tabOrServiceChanged = true; }
+        bool mediaChanged = MediaFilter.MediaType != MediaTypes.All;
+
+        if (!tabOrServiceChanged && !mediaChanged) return;
+
         _expandedStatusId = null;
         _grabbedItemId = null;
-        UpdateCounts();
-        RecomputeVisible();
-        UpdateUrl();
+
+        if (mediaChanged)
+        {
+            // OnMediaFilterChanged will recompute counts/visible items and call UpdateUrl
+            // after Set fires OnChanged — don't double-fire the same trio synchronously.
+            MediaFilter.Set(MediaTypes.All, persist: false);
+        }
+        else
+        {
+            UpdateCounts();
+            RecomputeVisible();
+            UpdateUrl();
+        }
     }
 
     private void OnMediaFilterChanged() => InvokeAsync(() =>

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -340,7 +340,7 @@ else
     {
         string newTab = NormalizeStatus(StatusQ);
         int? newService = NormalizeService(ServiceQ);
-        string newMedia = NormalizeMedia(MediaQ);
+        string? newMedia = NormalizeMedia(MediaQ);
 
         bool changed = false;
         if (_activeTab != newTab)
@@ -356,9 +356,11 @@ else
             _expandedStatusId = null;
             changed = true;
         }
-        if (MediaFilter.MediaType != newMedia)
+        // only override the global MediaFilter when the URL has an explicit valid value —
+        // missing/garbage ?media must NOT reset a user's persisted MediaType preference
+        if (newMedia is not null && MediaFilter.MediaType != newMedia)
         {
-            MediaFilter.Set(newMedia);
+            MediaFilter.Set(newMedia, persist: false);
         }
         return changed;
     }
@@ -368,7 +370,7 @@ else
         if (string.IsNullOrEmpty(key)) return "all";
         foreach ((string k, _) in _tabs)
         {
-            if (k == key) return key;
+            if (string.Equals(k, key, StringComparison.OrdinalIgnoreCase)) return k;
         }
         return "all";
     }
@@ -376,12 +378,18 @@ else
     private static int? NormalizeService(int? id) =>
         id is int v && StreamingService.ById.ContainsKey(v) ? v : null;
 
-    private static string NormalizeMedia(string? type) => type switch
+    // returns null for missing/invalid so ApplyQueryToState leaves the global filter alone
+    private static string? NormalizeMedia(string? type)
     {
-        MediaTypes.Tv => MediaTypes.Tv,
-        MediaTypes.Movie => MediaTypes.Movie,
-        _ => MediaTypes.All
-    };
+        string normalized = (type ?? "").Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            MediaTypes.Tv    => MediaTypes.Tv,
+            MediaTypes.Movie => MediaTypes.Movie,
+            MediaTypes.All   => MediaTypes.All,
+            _                => null
+        };
+    }
 
     private bool HasActiveFilters =>
         _activeTab != "all" || _selectedServiceId is not null || MediaFilter.MediaType != MediaTypes.All;
@@ -408,7 +416,8 @@ else
         if (_selectedServiceId is not null) { _selectedServiceId = null; anyChanged = true; }
         if (MediaFilter.MediaType != MediaTypes.All)
         {
-            MediaFilter.Set(MediaTypes.All);
+            // page-local clear: don't write 'all' through to the user's persisted preference
+            MediaFilter.Set(MediaTypes.All, persist: false);
             anyChanged = true;
         }
         if (!anyChanged) return;
@@ -431,10 +440,14 @@ else
     {
         _userServices = UserServicesCache.TryGetCached();
         // selected service may have just been removed from the user's active set
+        int? priorService = _selectedServiceId;
         if (_selectedServiceId is int svcId && !_userServices.Contains(svcId)) _selectedServiceId = null;
         UpdateItemServices();
         UpdateCounts();
         RecomputeVisible();
+        // if we just nulled out a now-invalid service, strip ?service=N from the URL
+        // so it doesn't snap back on the next OnParametersSet
+        if (_initialized && priorService != _selectedServiceId) UpdateUrl();
         InvokeAsync(StateHasChanged);
     }
 

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -5,12 +5,22 @@
 @inject MediaFilterService MediaFilter
 @inject UserServicesCache UserServicesCache
 @inject QuickActionService QuickActionSvc
+@inject NavigationManager Nav
 @inject IJSRuntime JS
 
 <PageTitle>My List - Hurrah.tv</PageTitle>
 
 <div class="flex items-center justify-between mb-4 md:mb-6">
     <h1 class="text-xl md:text-2xl font-bold">My List</h1>
+    @if (HasActiveFilters)
+    {
+        <button @onclick="ClearAllFilters"
+                class="flex items-center gap-1 px-2.5 py-1 rounded-full bg-surface-50 hover:bg-surface-100 text-gray-400 hover:text-white text-xs transition-colors"
+                aria-label="Clear all filters">
+            <span class="icon-[heroicons--x-mark] w-3 h-3"></span>
+            Clear filters
+        </button>
+    }
 </div>
 
 @if (!_loading && _items.Count > 0)
@@ -220,6 +230,13 @@ else
 }
 
 @code {
+    // URL-bound filter params. The URL is the source of truth — no localStorage.
+    // _activeTab / _selectedServiceId / MediaFilter.MediaType mirror these; round-tripping
+    // happens via Nav.NavigateTo(..., replace: true) → SetParametersAsync → OnParametersSet.
+    [Parameter, SupplyParameterFromQuery(Name = "status")] public string? StatusQ { get; set; }
+    [Parameter, SupplyParameterFromQuery(Name = "service")] public int? ServiceQ { get; set; }
+    [Parameter, SupplyParameterFromQuery(Name = "media")] public string? MediaQ { get; set; }
+
     private List<QueueItem> _items = [];
     private List<QueueItem> _visibleItems = [];
     private Dictionary<string, int> _statusCounts = [];
@@ -228,6 +245,7 @@ else
     private IReadOnlyList<int> _userServices = [];
     private int _totalCount;
     private bool _loading = true;
+    private bool _initialized;
     private string _activeTab = "all";
     private int? _expandedStatusId;
     private int? _selectedServiceId;
@@ -290,16 +308,124 @@ else
         _loading = true;
         Task<IReadOnlyList<int>> servicesTask = UserServicesCache.GetAsync();
         Task<List<QueueItem>> queueTask = Api.GetQueueAsync();
-        await Task.WhenAll(servicesTask, queueTask);
+        // await MediaFilter hydration before applying URL — otherwise a late settings-load
+        // can clobber a URL-supplied ?media value (URL wins for explicit-link navigations)
+        Task initTask = MediaFilter.InitializeAsync();
+        await Task.WhenAll(servicesTask, queueTask, initTask);
         _userServices = servicesTask.Result;
         _items = queueTask.Result;
         _loading = false;
         UpdateItemServices();
+        ApplyQueryToState();
+        _initialized = true;
         UpdateCounts();
         RecomputeVisible();
     }
 
-    private void OnMediaFilterChanged() => InvokeAsync(() => { UpdateCounts(); RecomputeVisible(); StateHasChanged(); });
+    protected override void OnParametersSet()
+    {
+        // OnInitializedAsync handles the first reconciliation (and gates _initialized so we
+        // don't fight MediaFilter hydration). After that, URL navigations land here.
+        if (!_initialized) return;
+        if (ApplyQueryToState())
+        {
+            UpdateCounts();
+            RecomputeVisible();
+        }
+    }
+
+    // returns true if any axis other than MediaFilter changed (media changes recompute
+    // via OnMediaFilterChanged, so callers don't need to recompute for that case)
+    private bool ApplyQueryToState()
+    {
+        string newTab = NormalizeStatus(StatusQ);
+        int? newService = NormalizeService(ServiceQ);
+        string newMedia = NormalizeMedia(MediaQ);
+
+        bool changed = false;
+        if (_activeTab != newTab)
+        {
+            _activeTab = newTab;
+            _expandedStatusId = null;
+            _grabbedItemId = null;
+            changed = true;
+        }
+        if (_selectedServiceId != newService)
+        {
+            _selectedServiceId = newService;
+            _expandedStatusId = null;
+            changed = true;
+        }
+        if (MediaFilter.MediaType != newMedia)
+        {
+            MediaFilter.Set(newMedia);
+        }
+        return changed;
+    }
+
+    private static string NormalizeStatus(string? key)
+    {
+        if (string.IsNullOrEmpty(key)) return "all";
+        foreach ((string k, _) in _tabs)
+        {
+            if (k == key) return key;
+        }
+        return "all";
+    }
+
+    private static int? NormalizeService(int? id) =>
+        id is int v && StreamingService.ById.ContainsKey(v) ? v : null;
+
+    private static string NormalizeMedia(string? type) => type switch
+    {
+        MediaTypes.Tv => MediaTypes.Tv,
+        MediaTypes.Movie => MediaTypes.Movie,
+        _ => MediaTypes.All
+    };
+
+    private bool HasActiveFilters =>
+        _activeTab != "all" || _selectedServiceId is not null || MediaFilter.MediaType != MediaTypes.All;
+
+    private void UpdateUrl()
+    {
+        Dictionary<string, object?> qs = new()
+        {
+            ["status"] = _activeTab == "all" ? null : _activeTab,
+            ["service"] = _selectedServiceId,
+            ["media"] = MediaFilter.MediaType == MediaTypes.All ? null : MediaFilter.MediaType,
+        };
+        string newUri = Nav.GetUriWithQueryParameters(qs);
+        if (newUri != Nav.Uri)
+        {
+            Nav.NavigateTo(newUri, replace: true);
+        }
+    }
+
+    private void ClearAllFilters()
+    {
+        bool anyChanged = false;
+        if (_activeTab != "all") { _activeTab = "all"; anyChanged = true; }
+        if (_selectedServiceId is not null) { _selectedServiceId = null; anyChanged = true; }
+        if (MediaFilter.MediaType != MediaTypes.All)
+        {
+            MediaFilter.Set(MediaTypes.All);
+            anyChanged = true;
+        }
+        if (!anyChanged) return;
+        _expandedStatusId = null;
+        _grabbedItemId = null;
+        UpdateCounts();
+        RecomputeVisible();
+        UpdateUrl();
+    }
+
+    private void OnMediaFilterChanged() => InvokeAsync(() =>
+    {
+        UpdateCounts();
+        RecomputeVisible();
+        if (_initialized) UpdateUrl();
+        StateHasChanged();
+    });
 
     private void OnServicesChanged()
     {
@@ -329,6 +455,7 @@ else
         _expandedStatusId = null;
         _grabbedItemId = null;
         RecomputeVisible();
+        UpdateUrl();
     }
 
     private void UpdateItemServices()
@@ -379,6 +506,7 @@ else
         _expandedStatusId = null;
         UpdateCounts();
         RecomputeVisible();
+        UpdateUrl();
     }
 
     private async Task SelectStatus(QueueItem item, QueueStatus status)

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -6,7 +6,6 @@
 @inject TokenService TokenService
 @inject HurrahAuthStateProvider AuthState
 @inject ShareService Share
-@inject NavigationManager Nav
 
 <PageTitle>Settings - Hurrah.tv</PageTitle>
 

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -184,7 +184,8 @@
 
     private async Task ShowShareToastAsync(string message)
     {
-        _shareToastCts?.Cancel();
+        if (_disposed) return;
+        try { _shareToastCts?.Cancel(); } catch (ObjectDisposedException) { }
         _shareToastCts?.Dispose();
         CancellationTokenSource cts = new();
         _shareToastCts = cts;

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -94,7 +94,7 @@
         <p class="text-gray-400 text-sm mb-4">Share Hurrah.tv with someone who's tired of juggling streaming queues.</p>
         <button class="bg-accent hover:bg-accent-light text-white font-semibold px-4 py-2 rounded-lg transition-colors flex items-center gap-2"
                 @onclick="ShareApp">
-            <span class="icon-[heroicons--share] w-4 h-4"></span>
+            <span class="icon-[heroicons--arrow-up-tray] w-4 h-4"></span>
             Share Hurrah.tv
         </button>
     </div>

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -171,7 +171,7 @@
         ShareOutcome outcome = await Share.ShareOrCopyAsync(
             title: "Hurrah.tv",
             text: "One smart watchlist across all your streaming services.",
-            url: Nav.BaseUri);
+            relativePath: "/");
         string? notice = outcome switch
         {
             ShareOutcome.Copied      => "Link copied",

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -1,9 +1,12 @@
 @page "/settings"
 @attribute [Authorize]
+@implements IDisposable
 @inject ApiClient Api
 @inject UserServicesCache UserServicesCache
 @inject TokenService TokenService
 @inject HurrahAuthStateProvider AuthState
+@inject ShareService Share
+@inject NavigationManager Nav
 
 <PageTitle>Settings - Hurrah.tv</PageTitle>
 
@@ -86,6 +89,16 @@
         </label>
     </div>
 
+    <div class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4 md:mb-6">
+        <h2 class="text-lg font-semibold mb-2">Tell a friend</h2>
+        <p class="text-gray-400 text-sm mb-4">Share Hurrah.tv with someone who's tired of juggling streaming queues.</p>
+        <button class="bg-accent hover:bg-accent-light text-white font-semibold px-4 py-2 rounded-lg transition-colors flex items-center gap-2"
+                @onclick="ShareApp">
+            <span class="icon-[heroicons--share] w-4 h-4"></span>
+            Share Hurrah.tv
+        </button>
+    </div>
+
     <div class="bg-surface-50 rounded-xl p-4 md:p-6">
         <h2 class="text-lg font-semibold mb-2">About Hurrah.tv</h2>
         <p class="text-gray-400 text-sm">
@@ -94,6 +107,14 @@
         </p>
     </div>
 </div>
+
+@if (!string.IsNullOrEmpty(_shareNotice))
+{
+    <div class="fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 bg-surface-200 text-white px-4 py-2 rounded-lg shadow-lg fade-in z-50 text-sm"
+         role="status" aria-live="polite">
+        @_shareNotice
+    </div>
+}
 
 @code {
     private List<int> _selectedServices = [];
@@ -105,6 +126,9 @@
     private bool _saved;
     private bool _savingName;
     private bool _savedName;
+    private string? _shareNotice;
+    private CancellationTokenSource? _shareToastCts;
+    private bool _disposed;
 
     protected override async Task OnInitializedAsync()
     {
@@ -140,6 +164,46 @@
             _savedName = false;
         }
         finally { _savingName = false; }
+    }
+
+    private async Task ShareApp()
+    {
+        ShareOutcome outcome = await Share.ShareOrCopyAsync(
+            title: "Hurrah.tv",
+            text: "One smart watchlist across all your streaming services.",
+            url: Nav.BaseUri);
+        string? notice = outcome switch
+        {
+            ShareOutcome.Copied      => "Link copied",
+            ShareOutcome.Unsupported => "Couldn't share — copy this page's URL",
+            ShareOutcome.Error       => "Couldn't share — try again",
+            _                        => null
+        };
+        if (notice is not null) await ShowShareToastAsync(notice);
+    }
+
+    private async Task ShowShareToastAsync(string message)
+    {
+        _shareToastCts?.Cancel();
+        _shareToastCts?.Dispose();
+        CancellationTokenSource cts = new();
+        _shareToastCts = cts;
+        _shareNotice = message;
+        StateHasChanged();
+        try { await Task.Delay(2500, cts.Token); }
+        catch (TaskCanceledException) { return; }
+        if (cts == _shareToastCts && !_disposed)
+        {
+            _shareNotice = null;
+            StateHasChanged();
+        }
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _shareToastCts?.Cancel();
+        _shareToastCts?.Dispose();
     }
 
     private async Task Save()

--- a/HurrahTv.Client/Program.cs
+++ b/HurrahTv.Client/Program.cs
@@ -30,6 +30,7 @@ builder.Services.AddScoped<ApiClient>();
 builder.Services.AddScoped<UserServicesCache>();
 builder.Services.AddSingleton<QuickActionService>();
 builder.Services.AddScoped<MediaFilterService>();
+builder.Services.AddScoped<ShareService>();
 // singleton — matches QuickActionService it subscribes to; one in-memory cache per app session
 builder.Services.AddSingleton<CurationCache>();
 

--- a/HurrahTv.Client/Services/MediaFilterService.cs
+++ b/HurrahTv.Client/Services/MediaFilterService.cs
@@ -38,12 +38,16 @@ public class MediaFilterService(ApiClient api)
         }
     }
 
-    public void Set(string type)
+    // persist=false is for URL-driven changes (e.g. Queue's ?media= deep links and the
+    // page-local Clear filters affordance) — the user didn't explicitly opt into changing
+    // their saved global preference, so we mutate the in-memory filter without writing
+    // through to UserSettings. MainLayout's nav toggle uses the default persist=true.
+    public void Set(string type, bool persist = true)
     {
         if (MediaType == type) return;
         MediaType = type;
         OnChanged?.Invoke();
-        _ = PersistAsync(type);
+        if (persist) _ = PersistAsync(type);
     }
 
     private async Task PersistAsync(string type)

--- a/HurrahTv.Client/Services/ShareService.cs
+++ b/HurrahTv.Client/Services/ShareService.cs
@@ -17,11 +17,11 @@ public sealed class ShareService(IJSRuntime js) : IAsyncDisposable
             ShareResult result = await _module.InvokeAsync<ShareResult>("shareOrCopy", new { title, text, url });
             return result.Outcome switch
             {
-                "shared"      => ShareOutcome.Shared,
-                "copied"      => ShareOutcome.Copied,
-                "cancelled"   => ShareOutcome.Cancelled,
+                "shared" => ShareOutcome.Shared,
+                "copied" => ShareOutcome.Copied,
+                "cancelled" => ShareOutcome.Cancelled,
                 "unsupported" => ShareOutcome.Unsupported,
-                _             => ShareOutcome.Error
+                _ => ShareOutcome.Error
             };
         }
         catch (TaskCanceledException) { return ShareOutcome.Cancelled; }

--- a/HurrahTv.Client/Services/ShareService.cs
+++ b/HurrahTv.Client/Services/ShareService.cs
@@ -5,15 +5,35 @@ namespace HurrahTv.Client.Services;
 
 // wraps wwwroot/js/share.js — the IJSObjectReference is loaded once per session
 // and disposed when DI tears down the scope. Pages just call ShareOrCopyAsync.
-public sealed class ShareService(IJSRuntime js) : IAsyncDisposable
+public sealed class ShareService(IJSRuntime js, IConfiguration config) : IAsyncDisposable
 {
+    // shared links must always point at production, even when running from localhost or
+    // staging.hurrah.tv — per issue #67's acceptance criteria. Callers pass relative paths
+    // ("/details/tv/123") and the service prepends the canonical origin.
+    private const string PublicBaseUrl = "https://hurrah.tv";
+
+    // CI stamps a short SHA into appsettings.json as BuildVersion; appending it as
+    // ?v={sha} to the dynamic import path keeps cached share.js in sync with the
+    // C# ShareResult contract after a deploy. In dev BuildVersion is absent and the
+    // import goes through without a cache-bust (no stale cache to worry about).
+    private readonly string _modulePath = BuildModulePath(config);
+
+    private static string BuildModulePath(IConfiguration config)
+    {
+        string? version = config["BuildVersion"];
+        return string.IsNullOrEmpty(version) ? "./js/share.js" : $"./js/share.js?v={version}";
+    }
+
     private IJSObjectReference? _module;
 
-    public async Task<ShareOutcome> ShareOrCopyAsync(string title, string text, string url)
+    public async Task<ShareOutcome> ShareOrCopyAsync(string title, string text, string relativePath)
     {
         try
         {
-            _module ??= await js.InvokeAsync<IJSObjectReference>("import", "./js/share.js");
+            _module ??= await js.InvokeAsync<IJSObjectReference>("import", _modulePath);
+            string url = relativePath.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? relativePath
+                : PublicBaseUrl + (relativePath.StartsWith('/') ? relativePath : "/" + relativePath);
             ShareResult result = await _module.InvokeAsync<ShareResult>("shareOrCopy", new { title, text, url });
             return result.Outcome switch
             {

--- a/HurrahTv.Client/Services/ShareService.cs
+++ b/HurrahTv.Client/Services/ShareService.cs
@@ -31,9 +31,10 @@ public sealed class ShareService(IJSRuntime js, IConfiguration config) : IAsyncD
         try
         {
             _module ??= await js.InvokeAsync<IJSObjectReference>("import", _modulePath);
-            string url = relativePath.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                ? relativePath
-                : PublicBaseUrl + (relativePath.StartsWith('/') ? relativePath : "/" + relativePath);
+            // always prepend the canonical production origin — no http(s) bypass. The service
+            // guarantees by construction that shared links point at hurrah.tv even from
+            // localhost/staging callers.
+            string url = PublicBaseUrl + (relativePath.StartsWith('/') ? relativePath : "/" + relativePath);
             ShareResult result = await _module.InvokeAsync<ShareResult>("shareOrCopy", new { title, text, url });
             return result.Outcome switch
             {

--- a/HurrahTv.Client/Services/ShareService.cs
+++ b/HurrahTv.Client/Services/ShareService.cs
@@ -1,0 +1,44 @@
+using Microsoft.JSInterop;
+
+namespace HurrahTv.Client.Services;
+
+// wraps wwwroot/js/share.js — the IJSObjectReference is loaded once per session
+// and disposed when DI tears down the scope. Pages just call ShareOrCopyAsync.
+public sealed class ShareService(IJSRuntime js) : IAsyncDisposable
+{
+    private IJSObjectReference? _module;
+
+    public async Task<ShareOutcome> ShareOrCopyAsync(string title, string text, string url)
+    {
+        try
+        {
+            _module ??= await js.InvokeAsync<IJSObjectReference>("import", "./js/share.js");
+            ShareResult result = await _module.InvokeAsync<ShareResult>("shareOrCopy", new { title, text, url });
+            return result.Outcome switch
+            {
+                "shared"      => ShareOutcome.Shared,
+                "copied"      => ShareOutcome.Copied,
+                "cancelled"   => ShareOutcome.Cancelled,
+                "unsupported" => ShareOutcome.Unsupported,
+                _             => ShareOutcome.Error
+            };
+        }
+        catch
+        {
+            return ShareOutcome.Error;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is not null)
+        {
+            try { await _module.DisposeAsync(); } catch { }
+            _module = null;
+        }
+    }
+
+    private sealed record ShareResult(string Outcome);
+}
+
+public enum ShareOutcome { Shared, Copied, Cancelled, Unsupported, Error }

--- a/HurrahTv.Client/Services/ShareService.cs
+++ b/HurrahTv.Client/Services/ShareService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Microsoft.JSInterop;
 
 namespace HurrahTv.Client.Services;
@@ -23,10 +24,8 @@ public sealed class ShareService(IJSRuntime js) : IAsyncDisposable
                 _             => ShareOutcome.Error
             };
         }
-        catch
-        {
-            return ShareOutcome.Error;
-        }
+        catch (TaskCanceledException) { return ShareOutcome.Cancelled; }
+        catch { return ShareOutcome.Error; }
     }
 
     public async ValueTask DisposeAsync()
@@ -38,7 +37,10 @@ public sealed class ShareService(IJSRuntime js) : IAsyncDisposable
         }
     }
 
-    private sealed record ShareResult(string Outcome);
+    // System.Text.Json's Web defaults handle camelCase today, but pinning the name
+    // with the attribute removes the coupling — one [JsonSerializerOptions] change
+    // elsewhere can't quietly break every share by falling through to ShareOutcome.Error
+    private sealed record ShareResult([property: JsonPropertyName("outcome")] string Outcome);
 }
 
 public enum ShareOutcome { Shared, Copied, Cancelled, Unsupported, Error }

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -319,11 +319,17 @@
   .right-2 {
     right: calc(var(--spacing) * 2);
   }
+  .right-3 {
+    right: calc(var(--spacing) * 3);
+  }
   .right-4 {
     right: calc(var(--spacing) * 4);
   }
   .bottom-0 {
     bottom: calc(var(--spacing) * 0);
+  }
+  .bottom-20 {
+    bottom: calc(var(--spacing) * 20);
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
@@ -333,6 +339,9 @@
   }
   .left-1\.5 {
     left: calc(var(--spacing) * 1.5);
+  }
+  .left-1\/2 {
+    left: calc(1 / 2 * 100%);
   }
   .left-3 {
     left: calc(var(--spacing) * 3);
@@ -664,6 +673,10 @@
   }
   .shrink-0 {
     flex-shrink: 0;
+  }
+  .-translate-x-1\/2 {
+    --tw-translate-x: calc(calc(1 / 2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
     --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
@@ -1478,6 +1491,10 @@
     --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .shadow-lg {
+    --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -1982,6 +1999,16 @@
   .md\:top-4 {
     @media (width >= 48rem) {
       top: calc(var(--spacing) * 4);
+    }
+  }
+  .md\:right-4 {
+    @media (width >= 48rem) {
+      right: calc(var(--spacing) * 4);
+    }
+  }
+  .md\:bottom-6 {
+    @media (width >= 48rem) {
+      bottom: calc(var(--spacing) * 6);
     }
   }
   .md\:left-4 {

--- a/HurrahTv.Client/wwwroot/index.html
+++ b/HurrahTv.Client/wwwroot/index.html
@@ -6,6 +6,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Hurrah.tv</title>
     <base href="/" />
+
+    <!-- site-wide meta + Open Graph + Twitter Card. Blazor WASM doesn't SSR, so iOS Safari
+         / iMessage / Twitter link-preview bots only ever see what's in this static HTML.
+         Per-show OG (using TMDb backdrop + title for /details/{type}/{id}) needs a
+         server-side bot-detect path on the Api project — tracked separately. -->
+    <meta name="description" content="One smart watchlist across all your streaming services. Search what's available on Netflix, Hulu, Disney+ and more — keep one queue, no juggling." />
+    <meta name="theme-color" content="#E50914" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Hurrah.tv" />
+    <meta property="og:title" content="Hurrah.tv — one watchlist across every streaming service" />
+    <meta property="og:description" content="Search what's available on Netflix, Hulu, Disney+ and more. Keep one smart queue, no juggling." />
+    <meta property="og:url" content="https://hurrah.tv/" />
+    <meta property="og:image" content="https://hurrah.tv/icon-512.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Hurrah.tv — one watchlist across every streaming service" />
+    <meta name="twitter:description" content="Search what's available on Netflix, Hulu, Disney+ and more. Keep one smart queue, no juggling." />
+    <meta name="twitter:image" content="https://hurrah.tv/icon-512.png" />
+
     <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="stylesheet" href="css/icons.css" />

--- a/HurrahTv.Client/wwwroot/js/share.js
+++ b/HurrahTv.Client/wwwroot/js/share.js
@@ -10,9 +10,12 @@ export async function shareOrCopy({ title, text, url }) {
             await navigator.share(data);
             return { outcome: 'shared' };
         } catch (e) {
-            // user dismissed the share sheet — not an error, just no-op
-            if (e && e.name === 'AbortError') return { outcome: 'cancelled' };
-            // any other share failure (permission, abort race) falls through to clipboard
+            // any share rejection means the user already saw the sheet (or the API
+            // refused mid-flight on iOS Safari with NotAllowedError, etc.) — DON'T
+            // surprise them by silently overwriting their clipboard. Treat every
+            // share-API rejection as cancelled. Clipboard fallback only kicks in
+            // when navigator.share isn't present at all (e.g. desktop Chrome).
+            return { outcome: 'cancelled' };
         }
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/HurrahTv.Client/wwwroot/js/share.js
+++ b/HurrahTv.Client/wwwroot/js/share.js
@@ -3,19 +3,29 @@
 // This is the first JS module under wwwroot/js/; the broader migration off the
 // inline <script> globals in index.html is tracked in issue #87.
 
+// per issue #67 acceptance criteria: native share sheet on mobile, clipboard fallback elsewhere.
+// navigator.share exists on desktop Chrome/Edge too, but we route those to clipboard so the
+// 'tell a friend' flow on desktop drops a URL ready to paste into the user's chat of choice
+// instead of opening the OS-level share UI that desktop users don't expect.
+function isMobile() {
+    if (navigator.userAgentData?.mobile !== undefined) return navigator.userAgentData.mobile;
+    return /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+}
+
 export async function shareOrCopy({ title, text, url }) {
-    const data = { title, text, url };
-    if (navigator.share) {
+    if (navigator.share && isMobile()) {
         try {
-            await navigator.share(data);
+            await navigator.share({ title, text, url });
             return { outcome: 'shared' };
         } catch (e) {
-            // any share rejection means the user already saw the sheet (or the API
-            // refused mid-flight on iOS Safari with NotAllowedError, etc.) — DON'T
-            // surprise them by silently overwriting their clipboard. Treat every
-            // share-API rejection as cancelled. Clipboard fallback only kicks in
-            // when navigator.share isn't present at all (e.g. desktop Chrome).
-            return { outcome: 'cancelled' };
+            // AbortError = user dismissed the sheet; NotAllowedError = iOS Safari's dismiss
+            // path on some flows — both are silent cancellations, not failures. Anything else
+            // (TypeError from bad payload shape, real permission failure) is a real error and
+            // surfaces to the user via the caller's toast.
+            if (e?.name === 'AbortError' || e?.name === 'NotAllowedError') {
+                return { outcome: 'cancelled' };
+            }
+            return { outcome: 'error' };
         }
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/HurrahTv.Client/wwwroot/js/share.js
+++ b/HurrahTv.Client/wwwroot/js/share.js
@@ -1,0 +1,27 @@
+// share.js — share a URL via the Web Share API, falling back to clipboard.
+// Loaded as an ES module via IJSObjectReference (see Services/ShareService.cs).
+// This is the first JS module under wwwroot/js/; the broader migration off the
+// inline <script> globals in index.html is tracked in issue #87.
+
+export async function shareOrCopy({ title, text, url }) {
+    const data = { title, text, url };
+    if (navigator.share) {
+        try {
+            await navigator.share(data);
+            return { outcome: 'shared' };
+        } catch (e) {
+            // user dismissed the share sheet — not an error, just no-op
+            if (e && e.name === 'AbortError') return { outcome: 'cancelled' };
+            // any other share failure (permission, abort race) falls through to clipboard
+        }
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+            await navigator.clipboard.writeText(url);
+            return { outcome: 'copied' };
+        } catch {
+            return { outcome: 'error' };
+        }
+    }
+    return { outcome: 'unsupported' };
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AI-curated streaming across all your services. One smart watchlist that learns w
 Hurrah.tv is an opinionated streaming platform that curates content across Netflix, Hulu, Disney+, Prime Video, Max, Peacock, Paramount+, and Apple TV+. It learns from your watch history and preferences to build a personalized home feed — like opening one app instead of eight.
 
 - **AI-powered curation** — Claude analyzes your taste (and addresses you by name) to generate themed content rows ("High-Stakes Hospital Nights", "Slow-Burn Thrillers That Hook Fast")
-- **Hero billboard** — Top of Home picks from your Continue Watching, latest aired this week, or top AI rec — whichever fits, with a Netflix-style backdrop and Resume / Watch / Add CTA
+- **Hero billboard** — Top of Home picks from your Continue Watching, latest aired this week, or top AI rec — whichever fits, with a Netflix-style backdrop and Go to show / Watch latest / Add to list CTA
 - **Smart watchlists** — Track what you're watching, want to watch, and have watched. Separate sentiment system (thumbs up/down/favorite) lets you rate shows, seasons, and individual episodes independently from your list.
 - **Optimistic UI** — Marking watched, changing status, or rating closes the modal instantly and updates the watchlist row in place; the API call runs in the background
 - **New episode alerts** — Shows in your list with new or upcoming episodes are flagged automatically with "returning" indicators for shows you've finished
@@ -36,7 +36,7 @@ The home page renders Netflix-style horizontal content rows, each powered by a d
 
 | Row type | Source | Example |
 |----------|--------|---------|
-| Hero Billboard | Continue Watching / latest aired this week / top AI pick (self-gating) | Full-bleed backdrop with Resume / Watch latest / Add to list |
+| Hero Billboard | Continue Watching / latest aired this week / top AI pick (self-gating) | Full-bleed backdrop with Go to show/movie / Watch latest / Add to list |
 | Continue Watching | User's "Watching" list + air dates | Most recently aired first with "Xd ago" badges |
 | Upcoming Episodes | All non-dismissed shows + TMDb air dates | Next 7 days, with "Returning" flag for finished shows |
 | AI-Curated | Claude AI + TMDb discover | "High-Stakes Hospital Nights" |


### PR DESCRIPTION
## Summary

Three independent UX improvements bundled into one PR (single area, similar size, all visible client-side changes):

- **#69** — Home hero "Continue Watching" CTA renamed from misleading "Resume" to media-aware "Go to show" / "Go to movie". The click was never playback, just navigation.
- **#76** — Queue filters (status + service + media-type) now persist in the URL via `[SupplyParameterFromQuery]`. New visible "Clear filters" pill resets all three axes in one click. Establishes the first URL-bound filter pattern in the client.
- **#67** — Share button on Details (overlay on backdrop, inline when no backdrop) and "Tell a friend" card on Settings. New ES-module `wwwroot/js/share.js` loaded via `IJSObjectReference` (first foothold toward #87's migration off `window.hurrah*` globals). Native Web Share sheet on mobile, clipboard fallback elsewhere, with a brief toast confirmation.

## Test plan

- [ ] **#69:** Verify Home hero shows "Go to show" for TV shows and "Go to movie" for movies when Continue Watching renders.
- [ ] **#76:** Visit `/queue?service=8&status=watching&media=tv` — verify all three filters apply on landing. Click chips — verify URL updates without history bloat (back button returns to previous page, not previous filter combo). Click "Clear filters" — verify all three reset and the button disappears.
- [ ] **#67 (mobile):** Tap share on Details — verify native share sheet opens. Cancel — no error/toast shown.
- [ ] **#67 (desktop):** Click share — verify URL copied + "Link copied" toast appears for ~2.5s.
- [ ] **#67 (Settings):** "Share Hurrah.tv" button shares `Nav.BaseUri`.
- [ ] Existing tests: `dotnet test` — 84 tests still green (verified locally).
- [ ] No console errors on `/queue`, `/details/tv/{id}`, or `/settings`.

Closes #69
Closes #76
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)