### PR TITLE
Trailers: YouTube embed on Details page (refs #106)

### DIFF
--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -1,6 +1,8 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Caching.Memory;
+using HurrahTv.Shared.Filters;
 using HurrahTv.Shared.Models;
 
 namespace HurrahTv.Api.Services;
@@ -224,7 +226,7 @@ public class TmdbService
         if (_cache.TryGetValue(cacheKey, out ShowDetails? cached))
             return cached;
 
-        string url = $"{mediaType}/{tmdbId}?api_key={_apiKey}&append_to_response=watch/providers&language=en-US";
+        string url = $"{mediaType}/{tmdbId}?api_key={_apiKey}&append_to_response=watch/providers,videos&language=en-US";
         JsonElement? raw = await GetAsync<JsonElement?>(url);
         if (raw == null) return null;
 
@@ -301,6 +303,13 @@ public class TmdbService
             details.AvailableOn = ParseProviders(us);
         }
 
+        if (json.TryGetProperty("videos", out JsonElement videos) &&
+            videos.TryGetProperty("results", out JsonElement videoResults) &&
+            videoResults.ValueKind == JsonValueKind.Array)
+        {
+            details.Trailers = TrailerFilters.PickTop(ParseTrailers(videoResults));
+        }
+
         _cache.Set(cacheKey, details, TimeSpan.FromHours(6));
         return details;
     }
@@ -324,6 +333,34 @@ public class TmdbService
 
         _cache.Set(cacheKey, providers, TimeSpan.FromHours(12));
         return providers;
+    }
+
+    private static List<TrailerDto> ParseTrailers(JsonElement videoResults)
+    {
+        List<TrailerDto> trailers = [];
+        foreach (JsonElement v in videoResults.EnumerateArray())
+        {
+            DateTime? publishedAt = null;
+            // invariant culture + assume/adjust universal so the sort is deterministic
+            // regardless of host timezone or culture — TMDb sends ISO-8601 'Z' timestamps
+            if (v.TryGetProperty("published_at", out JsonElement pa) && pa.ValueKind == JsonValueKind.String
+                && DateTime.TryParse(pa.GetString(), CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime parsed))
+            {
+                publishedAt = parsed;
+            }
+
+            trailers.Add(new TrailerDto
+            {
+                Key = v.TryGetProperty("key", out JsonElement k) ? k.GetString() ?? "" : "",
+                Name = v.TryGetProperty("name", out JsonElement n) ? n.GetString() ?? "" : "",
+                Site = v.TryGetProperty("site", out JsonElement s) ? s.GetString() ?? "" : "",
+                Type = v.TryGetProperty("type", out JsonElement t) ? t.GetString() ?? "" : "",
+                Official = v.TryGetProperty("official", out JsonElement off) && off.ValueKind == JsonValueKind.True,
+                PublishedAt = publishedAt
+            });
+        }
+        return trailers;
     }
 
     private static List<AvailableService> ParseProviders(JsonElement usData)

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -88,6 +88,63 @@ else if (_details != null)
             </div>
         </div>
 
+        <!-- trailer: rendered ONCE outside RenderMetadata. RenderMetadata is called
+             twice (desktop right-column + mobile-below-poster) and CSS hides one,
+             but display:none does NOT unload iframes — duplicating would mount two
+             YouTube embeds with autoplay=1 and play audio twice. Keep this single. -->
+        @if (_details.Trailers.Count > 0)
+        {
+            TrailerDto active = _details.Trailers[Math.Clamp(_activeTrailerIndex, 0, _details.Trailers.Count - 1)];
+            <div class="mb-4 md:mb-6">
+                <h3 class="text-sm font-semibold text-gray-400 mb-2 uppercase tracking-wider">Trailer</h3>
+                <div class="relative aspect-video bg-black rounded-lg overflow-hidden">
+                    @if (_trailerPlaying)
+                    {
+                        <iframe @key="active.Key" class="w-full h-full"
+                                src="@($"https://www.youtube-nocookie.com/embed/{Uri.EscapeDataString(active.Key)}?autoplay=1&rel=0")"
+                                title="@(string.IsNullOrEmpty(active.Name) ? "Trailer" : active.Name)"
+                                referrerpolicy="strict-origin-when-cross-origin"
+                                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                                allowfullscreen></iframe>
+                    }
+                    else
+                    {
+                        <button type="button" class="group block w-full h-full cursor-pointer"
+                                @onclick="PlayTrailer" aria-label="@($"Play {(string.IsNullOrEmpty(active.Name) ? "trailer" : active.Name)}")">
+                            <img src="@($"https://img.youtube.com/vi/{Uri.EscapeDataString(active.Key)}/hqdefault.jpg")"
+                                 alt="" loading="lazy"
+                                 class="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity" />
+                            <div class="absolute inset-0 flex items-center justify-center">
+                                <div class="bg-black/60 group-hover:bg-accent rounded-full w-16 h-16 md:w-20 md:h-20
+                                            flex items-center justify-center transition-colors shadow-2xl">
+                                    <span class="icon-[heroicons--play-solid] w-8 h-8 md:w-10 md:h-10 text-white ml-1"></span>
+                                </div>
+                            </div>
+                            <div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-3">
+                                <p class="text-sm md:text-base text-white font-medium truncate">@active.Name</p>
+                            </div>
+                        </button>
+                    }
+                </div>
+                @if (_details.Trailers.Count > 1)
+                {
+                    <div class="flex gap-2 mt-2 overflow-x-auto pb-1">
+                        @for (int i = 0; i < _details.Trailers.Count; i++)
+                        {
+                            int idx = i;
+                            TrailerDto t = _details.Trailers[idx];
+                            bool isActive = idx == _activeTrailerIndex;
+                            <button type="button" aria-pressed="@isActive"
+                                    class="@($"flex-shrink-0 text-left text-xs px-3 py-1.5 rounded-md transition-colors border {(isActive ? "border-accent bg-accent/20 text-white" : "border-surface-200 bg-surface-50 text-gray-400 hover:text-gray-200 hover:border-gray-500")}")"
+                                    @onclick="() => SelectTrailer(idx)">
+                                @t.Name
+                            </button>
+                        }
+                    </div>
+                }
+            </div>
+        }
+
         <!-- mobile: metadata below poster -->
         <div class="md:hidden">
             @{ RenderMetadata(); }
@@ -311,6 +368,8 @@ else
     private bool _matchLoading;
     private bool _disposed;
     private CancellationTokenSource? _matchCts;
+    private int _activeTrailerIndex;
+    private bool _trailerPlaying;
 
     private static readonly (QueueStatus status, string label, string icon)[] _listOptions =
     [
@@ -335,6 +394,8 @@ else
         _queueItem = null;
         _showMatch = null;
         _matchLoading = false;
+        _activeTrailerIndex = 0;
+        _trailerPlaying = false;
         _loading = true;
         StateHasChanged();
 
@@ -363,6 +424,13 @@ else
     }
 
     private async Task GoBack() => await JS.InvokeVoidAsync("history.back");
+
+    private void PlayTrailer() => _trailerPlaying = true;
+
+    // do NOT force _trailerPlaying — preserve user intent. If they hadn't pressed
+    // play yet, switching tabs shouldn't autoplay; if they had, @key on the iframe
+    // remounts under the existing user-gesture context and the new src autoplays.
+    private void SelectTrailer(int index) => _activeTrailerIndex = index;
 
     private async Task ShareDetails()
     {

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -94,7 +94,9 @@ else if (_details != null)
              YouTube embeds with autoplay=1 and play audio twice. Keep this single. -->
         @if (_details.Trailers.Count > 0)
         {
-            TrailerDto active = _details.Trailers[Math.Clamp(_activeTrailerIndex, 0, _details.Trailers.Count - 1)];
+            int activeIdx = Math.Clamp(_activeTrailerIndex, 0, _details.Trailers.Count - 1);
+            TrailerDto active = _details.Trailers[activeIdx];
+            string activeLabel = TrailerLabel(active, activeIdx);
             <div class="mb-4 md:mb-6">
                 <h3 class="text-sm font-semibold text-gray-400 mb-2 uppercase tracking-wider">Trailer</h3>
                 <div class="relative aspect-video bg-black rounded-lg overflow-hidden">
@@ -102,7 +104,7 @@ else if (_details != null)
                     {
                         <iframe @key="active.Key" class="w-full h-full"
                                 src="@($"https://www.youtube-nocookie.com/embed/{Uri.EscapeDataString(active.Key)}?autoplay=1&rel=0")"
-                                title="@(string.IsNullOrEmpty(active.Name) ? "Trailer" : active.Name)"
+                                title="@activeLabel"
                                 referrerpolicy="strict-origin-when-cross-origin"
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 allowfullscreen></iframe>
@@ -110,7 +112,7 @@ else if (_details != null)
                     else
                     {
                         <button type="button" class="group block w-full h-full cursor-pointer"
-                                @onclick="PlayTrailer" aria-label="@($"Play {(string.IsNullOrEmpty(active.Name) ? "trailer" : active.Name)}")">
+                                @onclick="PlayTrailer" aria-label="@($"Play {activeLabel}")">
                             <img src="@($"https://img.youtube.com/vi/{Uri.EscapeDataString(active.Key)}/hqdefault.jpg")"
                                  alt="" loading="lazy"
                                  class="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity" />
@@ -121,7 +123,7 @@ else if (_details != null)
                                 </div>
                             </div>
                             <div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-3">
-                                <p class="text-sm md:text-base text-white font-medium truncate">@active.Name</p>
+                                <p class="text-sm md:text-base text-white font-medium truncate">@activeLabel</p>
                             </div>
                         </button>
                     }
@@ -134,10 +136,11 @@ else if (_details != null)
                             int idx = i;
                             TrailerDto t = _details.Trailers[idx];
                             bool isActive = idx == _activeTrailerIndex;
-                            <button type="button" aria-pressed="@isActive"
+                            string chipLabel = TrailerLabel(t, idx);
+                            <button type="button" aria-pressed="@isActive" aria-label="@chipLabel"
                                     class="@($"flex-shrink-0 text-left text-xs px-3 py-1.5 rounded-md transition-colors border {(isActive ? "border-accent bg-accent/20 text-white" : "border-surface-200 bg-surface-50 text-gray-400 hover:text-gray-200 hover:border-gray-500")}")"
                                     @onclick="() => SelectTrailer(idx)">
-                                @t.Name
+                                @chipLabel
                             </button>
                         }
                     </div>
@@ -427,10 +430,14 @@ else
 
     private void PlayTrailer() => _trailerPlaying = true;
 
-    // do NOT force _trailerPlaying — preserve user intent. If they hadn't pressed
-    // play yet, switching tabs shouldn't autoplay; if they had, @key on the iframe
-    // remounts under the existing user-gesture context and the new src autoplays.
+    // preserves user intent — switching tabs without prior play shouldn't autoplay;
+    // if play was already on, @key on the iframe remounts and the new src autoplays.
     private void SelectTrailer(int index) => _activeTrailerIndex = index;
+
+    // TMDb occasionally returns empty Name (older / less-curated records).
+    // "Trailer N" keeps chips, iframe title, and aria-labels non-blank.
+    private static string TrailerLabel(TrailerDto t, int index) =>
+        string.IsNullOrWhiteSpace(t.Name) ? $"Trailer {index + 1}" : t.Name;
 
     private async Task ShareDetails()
     {

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -78,6 +78,7 @@
     --animate-spin: spin 1s linear infinite;
     --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
     --blur-sm: 8px;
+    --aspect-video: 16 / 9;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -406,6 +407,9 @@
   .mt-1\.5 {
     margin-top: calc(var(--spacing) * 1.5);
   }
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
+  }
   .mt-3 {
     margin-top: calc(var(--spacing) * 3);
   }
@@ -503,6 +507,9 @@
   .aspect-\[3\/4\] {
     aspect-ratio: 3/4;
   }
+  .aspect-video {
+    aspect-ratio: var(--aspect-video);
+  }
   .h-0\.5 {
     height: calc(var(--spacing) * 0.5);
   }
@@ -544,6 +551,9 @@
   }
   .h-14 {
     height: calc(var(--spacing) * 14);
+  }
+  .h-16 {
+    height: calc(var(--spacing) * 16);
   }
   .h-18 {
     height: calc(var(--spacing) * 18);
@@ -971,6 +981,9 @@
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-accent) 20%, transparent);
     }
+  }
+  .bg-black {
+    background-color: var(--color-black);
   }
   .bg-black\/40 {
     background-color: color-mix(in srgb, #000 40%, transparent);
@@ -1480,6 +1493,9 @@
   .opacity-70 {
     opacity: 70%;
   }
+  .opacity-80 {
+    opacity: 80%;
+  }
   .opacity-90 {
     opacity: 90%;
   }
@@ -1592,6 +1608,13 @@
   }
   .poster-card {
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+  .group-hover\:bg-accent {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        background-color: var(--color-accent);
+      }
+    }
   }
   .group-hover\:text-accent {
     &:is(:where(.group):hover *) {
@@ -1812,6 +1835,13 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-accent-light);
+      }
+    }
+  }
+  .hover\:text-gray-200 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-200);
       }
     }
   }
@@ -2111,9 +2141,19 @@
       height: calc(var(--spacing) * 7);
     }
   }
+  .md\:h-10 {
+    @media (width >= 48rem) {
+      height: calc(var(--spacing) * 10);
+    }
+  }
   .md\:h-16 {
     @media (width >= 48rem) {
       height: calc(var(--spacing) * 16);
+    }
+  }
+  .md\:h-20 {
+    @media (width >= 48rem) {
+      height: calc(var(--spacing) * 20);
     }
   }
   .md\:h-24 {
@@ -2134,6 +2174,11 @@
   .md\:w-7 {
     @media (width >= 48rem) {
       width: calc(var(--spacing) * 7);
+    }
+  }
+  .md\:w-10 {
+    @media (width >= 48rem) {
+      width: calc(var(--spacing) * 10);
     }
   }
   .md\:w-16 {

--- a/HurrahTv.Shared.Tests/TrailerFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/TrailerFiltersTests.cs
@@ -1,0 +1,106 @@
+using HurrahTv.Shared.Filters;
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Shared.Tests;
+
+// pins the Details-page trailer rule: YouTube + Type=Trailer only, official before
+// unofficial, newest first, capped at 3. Catches the silent-drop bugs (wrong-site
+// videos sneaking through, sort key inverting on null PublishedAt).
+public class TrailerFiltersTests
+{
+    private static TrailerDto Video(
+        string key = "abc",
+        string name = "Official Trailer",
+        string site = "YouTube",
+        string type = "Trailer",
+        bool official = true,
+        DateTime? publishedAt = null) =>
+        new() { Key = key, Name = name, Site = site, Type = type, Official = official, PublishedAt = publishedAt };
+
+    [Fact]
+    public void Drops_Non_YouTube_Sites()
+    {
+        List<TrailerDto> input = [Video(key: "yt"), Video(key: "vimeo", site: "Vimeo")];
+
+        List<TrailerDto> result = TrailerFilters.PickTop(input);
+
+        Assert.Single(result);
+        Assert.Equal("yt", result[0].Key);
+    }
+
+    [Fact]
+    public void Drops_Non_Trailer_Types()
+    {
+        List<TrailerDto> input =
+        [
+            Video(key: "trailer"),
+            Video(key: "teaser", type: "Teaser"),
+            Video(key: "clip", type: "Clip"),
+            Video(key: "feat", type: "Featurette")
+        ];
+
+        List<TrailerDto> result = TrailerFilters.PickTop(input);
+
+        Assert.Single(result);
+        Assert.Equal("trailer", result[0].Key);
+    }
+
+    [Fact]
+    public void Drops_Entries_With_Empty_Key()
+    {
+        // protects the iframe URL — an empty key would 404 the YouTube embed
+        List<TrailerDto> input = [Video(key: ""), Video(key: "good")];
+
+        List<TrailerDto> result = TrailerFilters.PickTop(input);
+
+        Assert.Single(result);
+        Assert.Equal("good", result[0].Key);
+    }
+
+    [Fact]
+    public void Sorts_Official_Before_Unofficial_Then_Newest_First()
+    {
+        DateTime older = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        DateTime newer = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        List<TrailerDto> input =
+        [
+            Video(key: "unofficial-newer", official: false, publishedAt: newer),
+            Video(key: "official-older", official: true, publishedAt: older),
+            Video(key: "official-newer", official: true, publishedAt: newer),
+        ];
+
+        List<TrailerDto> result = TrailerFilters.PickTop(input);
+
+        Assert.Equal(["official-newer", "official-older", "unofficial-newer"], result.Select(t => t.Key));
+    }
+
+    [Fact]
+    public void Null_PublishedAt_Sorts_Last_Within_Same_Official_Bucket()
+    {
+        // null dates would float to the top if we naively descending-sorted on a nullable —
+        // explicit DateTime.MinValue fallback pins them last
+        DateTime published = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        List<TrailerDto> input =
+        [
+            Video(key: "null-date", publishedAt: null),
+            Video(key: "dated", publishedAt: published),
+        ];
+
+        List<TrailerDto> result = TrailerFilters.PickTop(input);
+
+        Assert.Equal(["dated", "null-date"], result.Select(t => t.Key));
+    }
+
+    [Fact]
+    public void Caps_At_MaxTrailers()
+    {
+        List<TrailerDto> input = [.. Enumerable.Range(0, 10).Select(i => Video(key: $"t{i}"))];
+
+        List<TrailerDto> result = TrailerFilters.PickTop(input);
+
+        Assert.Equal(TrailerFilters.MaxTrailers, result.Count);
+    }
+
+    [Fact]
+    public void Empty_Input_Returns_Empty() => Assert.Empty(TrailerFilters.PickTop([]));
+}

--- a/HurrahTv.Shared/Filters/TrailerFilters.cs
+++ b/HurrahTv.Shared/Filters/TrailerFilters.cs
@@ -1,0 +1,20 @@
+namespace HurrahTv.Shared.Filters;
+
+using HurrahTv.Shared.Models;
+
+public static class TrailerFilters
+{
+    public const int MaxTrailers = 3;
+    public const string YouTubeSite = "YouTube";
+    public const string TrailerType = "Trailer";
+
+    // pick top trailers: YouTube only, Type=Trailer, official first, then newest.
+    // we drop teasers/clips/featurettes so the section is "the official trailer" and
+    // not a grab-bag — single-rule predicate keeps the surface coherent.
+    public static List<TrailerDto> PickTop(IEnumerable<TrailerDto> videos) =>
+        [.. videos
+            .Where(v => v.Site == YouTubeSite && v.Type == TrailerType && !string.IsNullOrEmpty(v.Key))
+            .OrderByDescending(v => v.Official)
+            .ThenByDescending(v => v.PublishedAt ?? DateTime.MinValue)
+            .Take(MaxTrailers)];
+}

--- a/HurrahTv.Shared/Models/ShowDetails.cs
+++ b/HurrahTv.Shared/Models/ShowDetails.cs
@@ -8,6 +8,7 @@ public class ShowDetails : SearchResult
     public int? Runtime { get; set; } // minutes — for movies
     public List<string> Genres { get; set; } = [];
     public List<SeasonInfo> Seasons { get; set; } = [];
+    public List<TrailerDto> Trailers { get; set; } = [];
     public string Status { get; set; } = ""; // "Returning Series", "Ended", "Released", etc.
 
     // latest episode info (TV only)
@@ -19,6 +20,16 @@ public class ShowDetails : SearchResult
     public string? NextEpisodeName { get; set; }
     public int? NextEpisodeSeason { get; set; }
     public int? NextEpisodeNumber { get; set; }
+}
+
+public class TrailerDto
+{
+    public string Key { get; set; } = "";        // youtube video id
+    public string Name { get; set; } = "";       // "Official Trailer", etc.
+    public string Site { get; set; } = "";       // "YouTube" — filter discards anything else
+    public string Type { get; set; } = "";       // "Trailer" — filter discards Teaser/Clip/Featurette
+    public bool Official { get; set; }
+    public DateTime? PublishedAt { get; set; }
 }
 
 public class SeasonInfo


### PR DESCRIPTION
## Summary

Picks up the trailer slice of #106 (Details-page enrichment). The rest of #106 — external links, cast/crew, content rating, recommendations — stays open for follow-up. Verified manually on TV and movie titles in browser.

- **TMDb integration:** `GetDetailsAsync` extended to `append_to_response=watch/providers,videos` (still one round-trip per Details fetch). Parsed with `JsonValueKind.Array` guard and `InvariantCulture + AssumeUniversal|AdjustToUniversal` so sort is host-agnostic.
- **Shared:** new `TrailerDto` on `ShowDetails`. Pure `TrailerFilters.PickTop` (YouTube only, Type=Trailer, Official desc / PublishedAt desc, top 3, drops empty keys) with 7 tests.
- **Client:** single-render trailer section between the desktop layout and mobile metadata blocks (kept outside `RenderMetadata` — that helper is called twice, and a duplicated iframe inside the CSS-hidden copy would still load and play audio). Click-to-play `youtube-nocookie.com/embed` iframe with `@key` for reliable remount on Safari/iOS, `Uri.EscapeDataString` on the key, `referrerpolicy="strict-origin-when-cross-origin"`, `aria-pressed` on selector chips, title/aria-label fallback when name is empty, `Math.Clamp` on the active index.

**Diff:** +288 / -1 across 6 files (2 new, 4 modified).

**Tests:** 109 pass total (added 7 in `TrailerFiltersTests` — case-insensitivity not covered intentionally; TMDb's contract is fixed-case).

## /xsimplify pass

Ran `/xsimplify` before committing — surfaced one real bug I introduced (duplicate iframe via `RenderMetadata` called twice) and several cheap defensive fixes (URL encoding, `@key`, `DateTimeStyles`, `JsonValueKind.Array` guard, `Math.Clamp`, `SelectTrailer` no longer force-autoplays on tab switch). All applied inline.

Skipped findings filed as tracking issues for follow-up:
- #109 — `DetailsEndpoints` mutates `AvailableOn` on the IMemoryCache-shared instance (pre-existing, but trailers extend the surface)
- #110 — `videos` block now rides on every `GetDetailsAsync` call including curation fan-out
- #111 — Thumbnail `onerror` fallback for deleted/private YouTube videos
- #112 — Stale-response race in `Details.razor` when navigating between shows mid-load

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` — 109 pass (55 Shared + 36 Client + 18 Api)
- [x] `npm run build:css` clean (Tailwind picked up new `play-solid` icon + `aspect-video` utility)
- [x] `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` — clean (matches CI's `Verify formatting` step)
- [x] Browser: trailer renders on TV and movie titles, plays via click-to-play, multi-trailer selector swaps between trailers
- [x] Browser: titles with no trailers hide the section entirely (no empty header)

## Refs

Refs #106 — trailer slice only. The rest of #106's enrichment ACs (external links, cast/crew, content rating, recommendations, runtime/tagline meta line) stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)