### PR TITLE
Details follow-ups: cache isolation, split trailers fetch, request cancellation

### DIFF
--- a/HurrahTv.Api.Tests/DetailsCacheIsolationTests.cs
+++ b/HurrahTv.Api.Tests/DetailsCacheIsolationTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Dapper;
+using HurrahTv.Api.Services;
+using HurrahTv.Shared.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+
+namespace HurrahTv.Api.Tests;
+
+// pins #109 — DetailsEndpoints used to mutate the cached ShowDetails instance via
+// `details.AvailableOn = userMatches`, so a second request for the same tmdbId
+// would see the previous user's filtered provider list instead of the full set.
+// The fix: TmdbService.GetDetailsAsync hands callers a defensive clone, so
+// per-request mutation can't bleed across users.
+[Collection("postgres")]
+public class DetailsCacheIsolationTests(PostgresFixture fx) : IAsyncLifetime
+{
+    private const int NetflixId = 8;
+    private const int HuluId = 15;
+    private const int StubTmdbId = 1234;
+
+    public Task InitializeAsync() => fx.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task TwoUsers_DifferentServices_EachSeesTheirOwnProvider_AcrossSequentialDetailsCalls()
+    {
+        // user A has only Netflix; user B has only Hulu. Both fetch the same tmdbId.
+        // Without the #109 fix the second call would see the first user's filtered
+        // AvailableOn (the cached instance was mutated), so user B would see no
+        // matching service and fall through to the "show all streaming" branch.
+        WebApplicationFactory<Program> factory = fx.Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(services => services.AddHttpClient<TmdbService>()
+                .ConfigurePrimaryHttpMessageHandler(() => new MultiProviderTmdbHandler())));
+
+        await SeedUserServiceAsync("user-A", NetflixId);
+        await SeedUserServiceAsync("user-B", HuluId);
+
+        HttpClient userA = AuthClient(factory, "user-A");
+        HttpClient userB = AuthClient(factory, "user-B");
+
+        // first call warms the cache and filters to Netflix for user A.
+        ShowDetails? aResponse = await userA.GetFromJsonAsync<ShowDetails>($"/api/details/tv/{StubTmdbId}");
+        Assert.NotNull(aResponse);
+        Assert.Single(aResponse!.AvailableOn);
+        Assert.Equal(NetflixId, aResponse.AvailableOn[0].ProviderId);
+
+        // second call hits the cache. The cached entry must still contain both providers
+        // — if user A's filtered list leaked back into the cache, user B would see Netflix
+        // (no Hulu match) and the endpoint would fall through to the "show all streaming"
+        // branch, which still includes Netflix and skips Hulu entirely.
+        ShowDetails? bResponse = await userB.GetFromJsonAsync<ShowDetails>($"/api/details/tv/{StubTmdbId}");
+        Assert.NotNull(bResponse);
+        Assert.Single(bResponse!.AvailableOn);
+        Assert.Equal(HuluId, bResponse.AvailableOn[0].ProviderId);
+
+        // and re-fetch as user A to confirm A's view is still Netflix-only (not
+        // accidentally widened by user B's mutation pushing Hulu into the cache).
+        ShowDetails? aAgain = await userA.GetFromJsonAsync<ShowDetails>($"/api/details/tv/{StubTmdbId}");
+        Assert.NotNull(aAgain);
+        Assert.Single(aAgain!.AvailableOn);
+        Assert.Equal(NetflixId, aAgain.AvailableOn[0].ProviderId);
+    }
+
+    private async Task SeedUserServiceAsync(string userId, int providerId)
+    {
+        using NpgsqlConnection db = new(fx.ConnectionString);
+        await db.OpenAsync();
+        await db.ExecuteAsync(
+            "INSERT INTO UserServices (UserId, ProviderId, IsActive) VALUES (@UserId, @ProviderId, TRUE)",
+            new { UserId = userId, ProviderId = providerId });
+    }
+
+    private HttpClient AuthClient(WebApplicationFactory<Program> factory, string userId)
+    {
+        HttpClient client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", TestAuth.IssueToken(fx, userId));
+        return client;
+    }
+}
+
+// returns TMDb details with Netflix + Hulu in the flatrate watch/providers block,
+// and an empty videos response for the separate /videos call introduced by #110.
+internal sealed class MultiProviderTmdbHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        string path = request.RequestUri?.AbsolutePath ?? "";
+        string body = path.EndsWith("/videos") ? VideosBody : DetailsBody;
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        });
+    }
+
+    private const string VideosBody = "{\"results\":[]}";
+
+    private const string DetailsBody = """
+        {
+            "id": 1234,
+            "name": "Stub Show",
+            "overview": "test",
+            "backdrop_path": "/b.jpg",
+            "poster_path": "/p.jpg",
+            "tagline": "",
+            "vote_average": 8.0,
+            "status": "Returning Series",
+            "genres": [],
+            "seasons": [],
+            "first_air_date": "2022-01-01",
+            "watch/providers": {
+                "results": {
+                    "US": {
+                        "flatrate": [
+                            { "provider_id": 8,  "provider_name": "Netflix", "logo_path": "/n.png" },
+                            { "provider_id": 15, "provider_name": "Hulu",    "logo_path": "/h.png" }
+                        ]
+                    }
+                }
+            }
+        }
+        """;
+}

--- a/HurrahTv.Api/Endpoints/DetailsEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/DetailsEndpoints.cs
@@ -21,12 +21,12 @@ public static class DetailsEndpoints
             Task<List<TrailerDto>> trailersTask = tmdb.GetTrailersAsync(tmdbId, mediaType);
             await Task.WhenAll(detailsTask, trailersTask);
 
-            ShowDetails? details = detailsTask.Result;
+            ShowDetails? details = await detailsTask;
             if (details == null) return Results.NotFound();
 
             // details is already a defensive copy from TmdbService — mutating it here
             // (AvailableOn, Trailers) cannot bleed back into the cache. (#109)
-            details.Trailers = trailersTask.Result;
+            details.Trailers = await trailersTask;
 
             string userId = user.GetUserId();
             List<int> providerIds = await db.GetUserServicesAsync(userId);

--- a/HurrahTv.Api/Endpoints/DetailsEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/DetailsEndpoints.cs
@@ -14,14 +14,24 @@ public static class DetailsEndpoints
             if (!MediaTypes.IsValid(mediaType))
                 return Results.BadRequest("mediaType must be 'movie' or 'tv'");
 
-            ShowDetails? details = await tmdb.GetDetailsAsync(tmdbId, mediaType);
+            // parallel-fetch details + trailers so the user-perceived round-trip stays
+            // single. Trailers live in their own cache so curation fan-out doesn't
+            // pay for the videos block it never reads. (#110)
+            Task<ShowDetails?> detailsTask = tmdb.GetDetailsAsync(tmdbId, mediaType);
+            Task<List<TrailerDto>> trailersTask = tmdb.GetTrailersAsync(tmdbId, mediaType);
+            await Task.WhenAll(detailsTask, trailersTask);
+
+            ShowDetails? details = detailsTask.Result;
             if (details == null) return Results.NotFound();
+
+            // details is already a defensive copy from TmdbService — mutating it here
+            // (AvailableOn, Trailers) cannot bleed back into the cache. (#109)
+            details.Trailers = trailersTask.Result;
 
             string userId = user.GetUserId();
             List<int> providerIds = await db.GetUserServicesAsync(userId);
             HashSet<int> userProviders = [.. providerIds];
 
-            // use providers already fetched by GetDetailsAsync (via append_to_response)
             List<AvailableService> allProviders = details.AvailableOn;
 
             List<AvailableService> streaming = [.. allProviders.Where(s => s.Type is ProviderType.Flatrate or ProviderType.Ads)];

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -335,7 +335,7 @@ public class TmdbService
     {
         string cacheKey = $"providers:{mediaType}:{tmdbId}";
         if (_cache.TryGetValue(cacheKey, out List<AvailableService>? cached))
-            return cached!;
+            return [.. cached!]; // defensive copy — same rationale as ShowDetails.Clone (#109)
 
         string url = $"{mediaType}/{tmdbId}/watch/providers?api_key={_apiKey}";
         JsonElement? raw = await GetAsync<JsonElement?>(url, cancellationToken);
@@ -349,7 +349,7 @@ public class TmdbService
         }
 
         _cache.Set(cacheKey, providers, TimeSpan.FromHours(12));
-        return providers;
+        return [.. providers]; // copy so caller mutation can't reach the cached list (#109)
     }
 
     private static List<TrailerDto> ParseTrailers(JsonElement videoResults)
@@ -482,7 +482,7 @@ public class TmdbService
     {
         string cacheKey = $"season:{tmdbId}:{seasonNumber}";
         if (_cache.TryGetValue(cacheKey, out SeasonDetail? cached))
-            return cached;
+            return cached!.Clone(); // defensive copy — same rationale as ShowDetails.Clone (#109)
 
         string url = $"tv/{tmdbId}/season/{seasonNumber}?api_key={_apiKey}&language=en-US";
         JsonElement? raw = await GetAsync<JsonElement?>(url);
@@ -512,7 +512,7 @@ public class TmdbService
         }
 
         _cache.Set(cacheKey, detail, TimeSpan.FromHours(6));
-        return detail;
+        return detail.Clone();
     }
 
     private static SearchResult MapToSearchResult(TmdbMultiResult r) => new()

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -224,9 +224,9 @@ public class TmdbService
     {
         string cacheKey = $"details:{mediaType}:{tmdbId}";
         if (_cache.TryGetValue(cacheKey, out ShowDetails? cached))
-            return cached;
+            return cached!.Clone(); // hand callers a fresh copy — see ShowDetails.Clone (#109)
 
-        string url = $"{mediaType}/{tmdbId}?api_key={_apiKey}&append_to_response=watch/providers,videos&language=en-US";
+        string url = $"{mediaType}/{tmdbId}?api_key={_apiKey}&append_to_response=watch/providers&language=en-US";
         JsonElement? raw = await GetAsync<JsonElement?>(url);
         if (raw == null) return null;
 
@@ -303,15 +303,32 @@ public class TmdbService
             details.AvailableOn = ParseProviders(us);
         }
 
-        if (json.TryGetProperty("videos", out JsonElement videos) &&
-            videos.TryGetProperty("results", out JsonElement videoResults) &&
+        _cache.Set(cacheKey, details, TimeSpan.FromHours(6));
+        return details.Clone(); // protect cache from caller mutation on cold-miss too (#109)
+    }
+
+    // separate from GetDetailsAsync so curation fan-out (~20 TMDb IDs per row hydration)
+    // doesn't pay for the videos block it never reads. DetailsEndpoints parallel-fetches
+    // this alongside GetDetailsAsync so the user-perceived round-trip stays single. (#110)
+    public async Task<List<TrailerDto>> GetTrailersAsync(int tmdbId, string mediaType)
+    {
+        string cacheKey = $"trailers:{mediaType}:{tmdbId}";
+        if (_cache.TryGetValue(cacheKey, out List<TrailerDto>? cached))
+            return [.. cached!]; // defensive copy — same rationale as ShowDetails.Clone (#109)
+
+        string url = $"{mediaType}/{tmdbId}/videos?api_key={_apiKey}&language=en-US";
+        JsonElement? raw = await GetAsync<JsonElement?>(url);
+        if (raw == null) return [];
+
+        List<TrailerDto> trailers = [];
+        if (raw.Value.TryGetProperty("results", out JsonElement videoResults) &&
             videoResults.ValueKind == JsonValueKind.Array)
         {
-            details.Trailers = TrailerFilters.PickTop(ParseTrailers(videoResults));
+            trailers = TrailerFilters.PickTop(ParseTrailers(videoResults));
         }
 
-        _cache.Set(cacheKey, details, TimeSpan.FromHours(6));
-        return details;
+        _cache.Set(cacheKey, trailers, TimeSpan.FromHours(6));
+        return [.. trailers];
     }
 
     public async Task<List<AvailableService>> GetWatchProvidersAsync(int tmdbId, string mediaType, CancellationToken cancellationToken = default)

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -304,7 +304,7 @@ public class TmdbService
         }
 
         _cache.Set(cacheKey, details, TimeSpan.FromHours(6));
-        return details.Clone(); // protect cache from caller mutation on cold-miss too (#109)
+        return details.Clone();
     }
 
     // separate from GetDetailsAsync so curation fan-out (~20 TMDb IDs per row hydration)

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -415,8 +415,12 @@ else
 
         try
         {
-            _details = await Api.GetDetailsAsync(TmdbId, MediaType, ct);
+            // assign-on-success: if the HTTP call completed a beat before cancel landed,
+            // the early return drops the stale response instead of overwriting state
+            // for the now-current TmdbId.
+            ShowDetails? details = await Api.GetDetailsAsync(TmdbId, MediaType, ct);
             if (ct.IsCancellationRequested) return;
+            _details = details;
             _loading = false;
 
             // check if this item is already in the queue

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -370,7 +370,11 @@ else
     private ShowMatchResult? _showMatch;
     private bool _matchLoading;
     private bool _disposed;
-    private CancellationTokenSource? _matchCts;
+    // single page-scoped CTS — covers the awaited Details/Queue fetches AND the
+    // fire-and-forget match load. Rapid navigation cancels in-flight calls so a
+    // late response for show A can't overwrite _details / _queueItem while the
+    // user is on show B (especially visible with the trailer iframe). pins #112.
+    private CancellationTokenSource? _loadCts;
     private int _activeTrailerIndex;
     private bool _trailerPlaying;
 
@@ -385,8 +389,8 @@ else
     public void Dispose()
     {
         _disposed = true;
-        _matchCts?.Cancel();
-        _matchCts?.Dispose();
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
     }
 
     protected override async Task OnParametersSetAsync()
@@ -402,18 +406,31 @@ else
         _loading = true;
         StateHasChanged();
 
-        _details = await Api.GetDetailsAsync(TmdbId, MediaType);
-        _loading = false;
+        // cancel any prior in-flight loads (details/queue/match) so a late response
+        // from the previous TmdbId can't clobber state for the current one.
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        _loadCts = new CancellationTokenSource();
+        CancellationToken ct = _loadCts.Token;
 
-        // check if this item is already in the queue
-        List<QueueItem> queue = await Api.GetQueueAsync();
-        _queueItem = queue.FirstOrDefault(i => i.TmdbId == TmdbId && i.MediaType == MediaType);
+        try
+        {
+            _details = await Api.GetDetailsAsync(TmdbId, MediaType, ct);
+            if (ct.IsCancellationRequested) return;
+            _loading = false;
 
-        // cancel any previous match load and start new one
-        _matchCts?.Cancel();
-        _matchCts?.Dispose();
-        _matchCts = new CancellationTokenSource();
-        _ = LoadShowMatch(_matchCts.Token);
+            // check if this item is already in the queue
+            List<QueueItem> queue = await Api.GetQueueAsync(ct);
+            if (ct.IsCancellationRequested) return;
+            _queueItem = queue.FirstOrDefault(i => i.TmdbId == TmdbId && i.MediaType == MediaType);
+        }
+        catch (OperationCanceledException)
+        {
+            // a newer OnParametersSetAsync took over — abandon silently.
+            return;
+        }
+
+        _ = LoadShowMatch(ct);
     }
 
     private async Task LoadShowMatch(CancellationToken ct)

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -45,24 +45,24 @@ public class ApiClient(HttpClient http)
         await _http.GetFromJsonAsync<List<SearchResult>>($"api/search/recommendations/{mediaType}/{tmdbId}") ?? [];
 
     // details
-    public async Task<ShowDetails?> GetDetailsAsync(int tmdbId, string mediaType) =>
-        await _http.GetFromJsonAsync<ShowDetails>($"api/details/{mediaType}/{tmdbId}");
+    public async Task<ShowDetails?> GetDetailsAsync(int tmdbId, string mediaType, CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<ShowDetails>($"api/details/{mediaType}/{tmdbId}", cancellationToken);
 
     // season episodes
     public async Task<SeasonDetail?> GetSeasonAsync(int tmdbId, int seasonNumber) =>
         await _http.GetFromJsonAsync<SeasonDetail>($"api/details/tv/{tmdbId}/season/{seasonNumber}");
 
     // queue
-    public async Task<QueueResponse> GetQueueResponseAsync()
+    public async Task<QueueResponse> GetQueueResponseAsync(CancellationToken cancellationToken = default)
     {
-        QueueResponse? response = await _http.GetFromJsonAsync<QueueResponse>("api/queue");
+        QueueResponse? response = await _http.GetFromJsonAsync<QueueResponse>("api/queue", cancellationToken);
         return response ?? new QueueResponse([], []);
     }
 
     // convenience for callers that only need items (Details page, Queue page)
-    public async Task<List<QueueItem>> GetQueueAsync()
+    public async Task<List<QueueItem>> GetQueueAsync(CancellationToken cancellationToken = default)
     {
-        QueueResponse response = await GetQueueResponseAsync();
+        QueueResponse response = await GetQueueResponseAsync(cancellationToken);
         return response.Items;
     }
 

--- a/HurrahTv.Shared/Models/ShowDetails.cs
+++ b/HurrahTv.Shared/Models/ShowDetails.cs
@@ -20,6 +20,43 @@ public class ShowDetails : SearchResult
     public string? NextEpisodeName { get; set; }
     public int? NextEpisodeSeason { get; set; }
     public int? NextEpisodeNumber { get; set; }
+
+    // shallow copy with fresh list instances. TmdbService caches the canonical instance
+    // and hands callers a clone so per-request mutation (e.g. user-filtered AvailableOn
+    // in DetailsEndpoints) can't bleed back into the cache. pins #109.
+    public ShowDetails Clone() => new()
+    {
+        TmdbId = TmdbId,
+        Title = Title,
+        Overview = Overview,
+        PosterPath = PosterPath,
+        BackdropPath = BackdropPath,
+        MediaType = MediaType,
+        FirstAirDate = FirstAirDate,
+        ReleaseDate = ReleaseDate,
+        VoteAverage = VoteAverage,
+        GenreIds = [.. GenreIds],
+        OriginalLanguage = OriginalLanguage,
+        AvailableOn = [.. AvailableOn],
+        NotOnYourServices = NotOnYourServices,
+        NoStreamingInfo = NoStreamingInfo,
+        Tagline = Tagline,
+        NumberOfSeasons = NumberOfSeasons,
+        NumberOfEpisodes = NumberOfEpisodes,
+        Runtime = Runtime,
+        Genres = [.. Genres],
+        Seasons = [.. Seasons],
+        Trailers = [.. Trailers],
+        Status = Status,
+        LastEpisodeAirDate = LastEpisodeAirDate,
+        LastEpisodeName = LastEpisodeName,
+        LastEpisodeSeason = LastEpisodeSeason,
+        LastEpisodeNumber = LastEpisodeNumber,
+        NextEpisodeAirDate = NextEpisodeAirDate,
+        NextEpisodeName = NextEpisodeName,
+        NextEpisodeSeason = NextEpisodeSeason,
+        NextEpisodeNumber = NextEpisodeNumber,
+    };
 }
 
 public class TrailerDto

--- a/HurrahTv.Shared/Models/ShowDetails.cs
+++ b/HurrahTv.Shared/Models/ShowDetails.cs
@@ -28,6 +28,10 @@ public class ShowDetails : SearchResult
     // MemberwiseClone covers all scalar fields automatically — only mutable collections
     // need explicit re-allocation. New non-list properties added to ShowDetails or its
     // SearchResult base get cloned for free; new list properties must extend this list.
+    //
+    // The list elements (AvailableService, SeasonInfo, TrailerDto) are shared by
+    // reference — mutating an element on the clone still bleeds into the cache. No
+    // current caller does this; if one is added, it needs a deeper copy than Clone.
     public ShowDetails Clone()
     {
         ShowDetails copy = (ShowDetails)MemberwiseClone();
@@ -74,4 +78,13 @@ public class SeasonDetail
     public int SeasonNumber { get; set; }
     public string Name { get; set; } = "";
     public List<EpisodeInfo> Episodes { get; set; } = [];
+
+    // see ShowDetails.Clone for rationale (#109). callers that need to mutate
+    // an EpisodeInfo inside the returned list need a deeper copy than this.
+    public SeasonDetail Clone()
+    {
+        SeasonDetail copy = (SeasonDetail)MemberwiseClone();
+        copy.Episodes = [.. Episodes];
+        return copy;
+    }
 }

--- a/HurrahTv.Shared/Models/ShowDetails.cs
+++ b/HurrahTv.Shared/Models/ShowDetails.cs
@@ -24,39 +24,20 @@ public class ShowDetails : SearchResult
     // shallow copy with fresh list instances. TmdbService caches the canonical instance
     // and hands callers a clone so per-request mutation (e.g. user-filtered AvailableOn
     // in DetailsEndpoints) can't bleed back into the cache. pins #109.
-    public ShowDetails Clone() => new()
+    //
+    // MemberwiseClone covers all scalar fields automatically — only mutable collections
+    // need explicit re-allocation. New non-list properties added to ShowDetails or its
+    // SearchResult base get cloned for free; new list properties must extend this list.
+    public ShowDetails Clone()
     {
-        TmdbId = TmdbId,
-        Title = Title,
-        Overview = Overview,
-        PosterPath = PosterPath,
-        BackdropPath = BackdropPath,
-        MediaType = MediaType,
-        FirstAirDate = FirstAirDate,
-        ReleaseDate = ReleaseDate,
-        VoteAverage = VoteAverage,
-        GenreIds = [.. GenreIds],
-        OriginalLanguage = OriginalLanguage,
-        AvailableOn = [.. AvailableOn],
-        NotOnYourServices = NotOnYourServices,
-        NoStreamingInfo = NoStreamingInfo,
-        Tagline = Tagline,
-        NumberOfSeasons = NumberOfSeasons,
-        NumberOfEpisodes = NumberOfEpisodes,
-        Runtime = Runtime,
-        Genres = [.. Genres],
-        Seasons = [.. Seasons],
-        Trailers = [.. Trailers],
-        Status = Status,
-        LastEpisodeAirDate = LastEpisodeAirDate,
-        LastEpisodeName = LastEpisodeName,
-        LastEpisodeSeason = LastEpisodeSeason,
-        LastEpisodeNumber = LastEpisodeNumber,
-        NextEpisodeAirDate = NextEpisodeAirDate,
-        NextEpisodeName = NextEpisodeName,
-        NextEpisodeSeason = NextEpisodeSeason,
-        NextEpisodeNumber = NextEpisodeNumber,
-    };
+        ShowDetails copy = (ShowDetails)MemberwiseClone();
+        copy.GenreIds = [.. GenreIds];
+        copy.AvailableOn = [.. AvailableOn];
+        copy.Genres = [.. Genres];
+        copy.Seasons = [.. Seasons];
+        copy.Trailers = [.. Trailers];
+        return copy;
+    }
 }
 
 public class TrailerDto


### PR DESCRIPTION
## Summary

Bundle of three trailer-PR follow-ups surfaced by `/xsimplify` on #113. All touch the Details fetch path, so they bundle cleanly while the code is fresh.

- **#109 (bug, cache mutation)** — `TmdbService.GetDetailsAsync` returns a defensive `Clone()` so `DetailsEndpoints` can keep doing per-request `AvailableOn` filtering without leaking the previous user's filtered list into the cache. The trailer PR added `Trailers` as a second mutable-shared surface, which this fix covers too.
- **#110 (enhancement, perf)** — Trailers move to a new `GetTrailersAsync` with its own 6h cache. `DetailsEndpoints` parallel-fetches via `Task.WhenAll`, so the user-perceived round-trip stays single, but curation fan-out (~20 TMDb IDs per AI-row hydration) no longer pays for the videos block it never reads.
- **#112 (bug, stale response overwrite)** — `Details.razor` consolidates to a single page-scoped `_loadCts` covering details + queue + match. Threads the token through `ApiClient.GetDetailsAsync` / `GetQueueAsync` and drops late responses, so rapid show-to-show navigation can no longer mount show A's trailer iframe under show B's URL.

## What changed

| File | Why |
|---|---|
| `HurrahTv.Shared/Models/ShowDetails.cs` | `Clone()` — shallow copy with fresh list instances |
| `HurrahTv.Api/Services/TmdbService.cs` | Return clone from `GetDetailsAsync`; split out `GetTrailersAsync`; drop `videos` from `append_to_response` |
| `HurrahTv.Api/Endpoints/DetailsEndpoints.cs` | `Task.WhenAll` details + trailers; mutate the clone (safe) |
| `HurrahTv.Client/Services/ApiClient.cs` | Thread `CancellationToken` through `GetDetailsAsync` / `GetQueueAsync` |
| `HurrahTv.Client/Pages/Details.razor` | `_loadCts` replaces `_matchCts`; catch `OperationCanceledException` to abandon stale runs silently |
| `HurrahTv.Api.Tests/DetailsCacheIsolationTests.cs` | New regression — two users with different services hit the same `tmdbId`; each sees their own provider; the cache stays the full set |

## Test plan

- [x] `dotnet test HurrahTv.slnx` — 110 passing (was 109, +1 for new regression)
- [x] `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` — clean
- [ ] Manual: rapid-click between two shows in the queue, confirm the rendered show is always the last-clicked one (#112 acceptance)
- [ ] Manual (after deploy): cold-cache curation request — confirm Details page still gets trailers in a single user-perceived round-trip

Closes #109
Closes #110
Closes #112