### PR TITLE
ApiClient + show-match: thread CancellationToken through every call

### DIFF
--- a/HurrahTv.Api/Endpoints/CurationEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/CurationEndpoints.cs
@@ -111,7 +111,7 @@ public static class CurationEndpoints
         // personalized match for a specific show
         group.MapGet("/match/{mediaType}/{tmdbId:int}", async (string mediaType, int tmdbId,
             ClaimsPrincipal user, DbService db, CurationService curation, TmdbService tmdb,
-            IMemoryCache cache, ILogger<CurationService> logger) =>
+            IMemoryCache cache, ILogger<CurationService> logger, CancellationToken ct) =>
         {
             try
             {
@@ -136,12 +136,18 @@ public static class CurationEndpoints
                     ? await db.GetShowSentimentsAsync(tmdbId, userId)
                     : null;
 
-                ShowMatchResult? result = await curation.GetShowMatchAsync(userId, show, watchlist, showSentiments, queueItem);
+                ShowMatchResult? result = await curation.GetShowMatchAsync(userId, show, watchlist, showSentiments, queueItem, ct);
 
                 if (result is not null)
                     cache.Set(cacheKey, result, TimeSpan.FromHours(12));
 
                 return Results.Ok(result);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // client navigated away mid-flight — abort the paid AI inference and stay quiet.
+                // pins #117.
+                return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
             }
             catch (Exception ex)
             {

--- a/HurrahTv.Api/Services/CurationService.cs
+++ b/HurrahTv.Api/Services/CurationService.cs
@@ -277,7 +277,7 @@ public partial class CurationService
     }
 
     // personalized match blurb for a specific show
-    public async Task<ShowMatchResult?> GetShowMatchAsync(string userId, ShowDetails show, List<QueueItem> watchlist, ShowSentiments? showSentiments = null, QueueItem? queueItem = null)
+    public async Task<ShowMatchResult?> GetShowMatchAsync(string userId, ShowDetails show, List<QueueItem> watchlist, ShowSentiments? showSentiments = null, QueueItem? queueItem = null, CancellationToken cancellationToken = default)
     {
         if (!IsEnabled) return null;
 
@@ -338,12 +338,14 @@ public partial class CurationService
 
         try
         {
+            // forward CT so rapid Details-page navigation aborts the paid AI inference,
+            // not just the response on the client side. pins #117.
             Message response = await _client!.Messages.Create(new MessageCreateParams
             {
                 Model = _model,
                 MaxTokens = 150,
                 Messages = [new MessageParam { Role = Role.User, Content = prompt }]
-            });
+            }, cancellationToken: cancellationToken);
 
             string text = "";
             if (response.Content.Count > 0 && response.Content[0].TryPickText(out TextBlock? textBlock))
@@ -353,6 +355,9 @@ public partial class CurationService
             int outputTokens = (int)response.Usage.OutputTokens;
             decimal cost = (inputTokens * InputCostPerToken) + (outputTokens * OutputCostPerToken);
 
+            // intentionally not forwarding ct — if the inference completed and we're
+            // about to dispose, we still want the usage row written so cost tracking
+            // stays accurate.
             await _db.TrackAIUsageAsync(userId, inputTokens, outputTokens, cost, "show-match");
 
             // parse
@@ -363,6 +368,12 @@ public partial class CurationService
                 text = text[jsonStart..(jsonEnd + 1)];
 
             return JsonSerializer.Deserialize<ShowMatchResult>(text, CaseInsensitive);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // client navigated away — propagate so endpoint can return 499 instead of
+            // pretending success with null.
+            throw;
         }
         catch (Exception ex)
         {

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -441,7 +441,17 @@ else
     {
         _matchLoading = true;
         if (!_disposed) StateHasChanged();
-        _showMatch = await Api.GetShowMatchAsync(TmdbId, MediaType);
+        try
+        {
+            // pass ct so the AI inference itself aborts on rapid navigation, not just
+            // the response on this side. pins #117.
+            _showMatch = await Api.GetShowMatchAsync(TmdbId, MediaType, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // newer load took over — abandon silently.
+            return;
+        }
         if (ct.IsCancellationRequested) return;
         _matchLoading = false;
         if (!_disposed) StateHasChanged();

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -447,9 +447,12 @@ else
             // the response on this side. pins #117.
             _showMatch = await Api.GetShowMatchAsync(TmdbId, MediaType, ct);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            // newer load took over — abandon silently.
+            // newer load took over — abandon silently. unfiltered catch would also
+            // swallow HttpClient.Timeout TaskCanceledExceptions and leave _matchLoading
+            // stuck true. when our ct isn't the cancel source, fall through so the
+            // late-check below clears state normally.
             return;
         }
         if (ct.IsCancellationRequested) return;

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -8,49 +8,49 @@ public class ApiClient(HttpClient http)
     private readonly HttpClient _http = http;
 
     // auth
-    public async Task<bool> SendCodeAsync(string phoneNumber)
+    public async Task<bool> SendCodeAsync(string phoneNumber, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage response = await _http.PostAsJsonAsync("api/auth/send-code", new SendCodeRequest(phoneNumber));
+        HttpResponseMessage response = await _http.PostAsJsonAsync("api/auth/send-code", new SendCodeRequest(phoneNumber), cancellationToken);
         return response.IsSuccessStatusCode;
     }
 
-    public async Task<AuthResponse?> VerifyCodeAsync(string phoneNumber, string code)
+    public async Task<AuthResponse?> VerifyCodeAsync(string phoneNumber, string code, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage response = await _http.PostAsJsonAsync("api/auth/verify", new VerifyCodeRequest(phoneNumber, code));
+        HttpResponseMessage response = await _http.PostAsJsonAsync("api/auth/verify", new VerifyCodeRequest(phoneNumber, code), cancellationToken);
         if (response.IsSuccessStatusCode)
-            return await response.Content.ReadFromJsonAsync<AuthResponse>();
+            return await response.Content.ReadFromJsonAsync<AuthResponse>(cancellationToken);
         return null;
     }
 
     // search
-    public async Task<SearchResponse> SearchAsync(string query) =>
-        await _http.GetFromJsonAsync<SearchResponse>($"api/search?q={Uri.EscapeDataString(query)}")
+    public async Task<SearchResponse> SearchAsync(string query, CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<SearchResponse>($"api/search?q={Uri.EscapeDataString(query)}", cancellationToken)
         ?? new SearchResponse();
 
-    public async Task<List<SearchResult>> ForYouAsync(string mediaType = "all", int[]? excludeIds = null)
+    public async Task<List<SearchResult>> ForYouAsync(string mediaType = "all", int[]? excludeIds = null, CancellationToken cancellationToken = default)
     {
         string url = $"api/search/for-you?mediaType={mediaType}";
         if (excludeIds?.Length > 0) url += "&exclude=" + string.Join(",", excludeIds);
-        return await _http.GetFromJsonAsync<List<SearchResult>>(url) ?? [];
+        return await _http.GetFromJsonAsync<List<SearchResult>>(url, cancellationToken) ?? [];
     }
 
-    public async Task<List<SearchResult>> NewOnServicesAsync(string mediaType = "tv", int[]? excludeIds = null)
+    public async Task<List<SearchResult>> NewOnServicesAsync(string mediaType = "tv", int[]? excludeIds = null, CancellationToken cancellationToken = default)
     {
         string url = $"api/search/new?mediaType={mediaType}";
         if (excludeIds?.Length > 0) url += "&exclude=" + string.Join(",", excludeIds);
-        return await _http.GetFromJsonAsync<List<SearchResult>>(url) ?? [];
+        return await _http.GetFromJsonAsync<List<SearchResult>>(url, cancellationToken) ?? [];
     }
 
-    public async Task<List<SearchResult>> GetRecommendationsAsync(int tmdbId, string mediaType) =>
-        await _http.GetFromJsonAsync<List<SearchResult>>($"api/search/recommendations/{mediaType}/{tmdbId}") ?? [];
+    public async Task<List<SearchResult>> GetRecommendationsAsync(int tmdbId, string mediaType, CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<List<SearchResult>>($"api/search/recommendations/{mediaType}/{tmdbId}", cancellationToken) ?? [];
 
     // details
     public async Task<ShowDetails?> GetDetailsAsync(int tmdbId, string mediaType, CancellationToken cancellationToken = default) =>
         await _http.GetFromJsonAsync<ShowDetails>($"api/details/{mediaType}/{tmdbId}", cancellationToken);
 
     // season episodes
-    public async Task<SeasonDetail?> GetSeasonAsync(int tmdbId, int seasonNumber) =>
-        await _http.GetFromJsonAsync<SeasonDetail>($"api/details/tv/{tmdbId}/season/{seasonNumber}");
+    public async Task<SeasonDetail?> GetSeasonAsync(int tmdbId, int seasonNumber, CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<SeasonDetail>($"api/details/tv/{tmdbId}/season/{seasonNumber}", cancellationToken);
 
     // queue
     public async Task<QueueResponse> GetQueueResponseAsync(CancellationToken cancellationToken = default)
@@ -67,160 +67,165 @@ public class ApiClient(HttpClient http)
     }
 
     // watched episodes
-    public async Task MarkEpisodeWatchedAsync(int tmdbId, int season, int episode) =>
-        await _http.PostAsJsonAsync("api/episodes/watched", new WatchedEpisodeRequest(tmdbId, season, episode));
+    public async Task MarkEpisodeWatchedAsync(int tmdbId, int season, int episode, CancellationToken cancellationToken = default) =>
+        await _http.PostAsJsonAsync("api/episodes/watched", new WatchedEpisodeRequest(tmdbId, season, episode), cancellationToken);
 
-    public async Task UnmarkEpisodeWatchedAsync(int tmdbId, int season, int episode) =>
-        await _http.DeleteAsync($"api/episodes/watched/{tmdbId}/{season}/{episode}");
+    public async Task UnmarkEpisodeWatchedAsync(int tmdbId, int season, int episode, CancellationToken cancellationToken = default) =>
+        await _http.DeleteAsync($"api/episodes/watched/{tmdbId}/{season}/{episode}", cancellationToken);
 
-    public async Task<List<WatchedEpisode>> GetWatchedEpisodesAsync(int tmdbId) =>
-        await _http.GetFromJsonAsync<List<WatchedEpisode>>($"api/episodes/watched/{tmdbId}") ?? [];
+    public async Task<List<WatchedEpisode>> GetWatchedEpisodesAsync(int tmdbId, CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<List<WatchedEpisode>>($"api/episodes/watched/{tmdbId}", cancellationToken) ?? [];
 
-    public async Task<QueueItem?> AddToQueueAsync(QueueItem item)
+    public async Task<QueueItem?> AddToQueueAsync(QueueItem item, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage response = await _http.PostAsJsonAsync("api/queue", item);
+        HttpResponseMessage response = await _http.PostAsJsonAsync("api/queue", item, cancellationToken);
         if (response.IsSuccessStatusCode)
-            return await response.Content.ReadFromJsonAsync<QueueItem>();
+            return await response.Content.ReadFromJsonAsync<QueueItem>(cancellationToken);
         return null;
     }
 
-    public async Task RemoveFromQueueAsync(int id) =>
-        await _http.DeleteAsync($"api/queue/{id}");
+    public async Task RemoveFromQueueAsync(int id, CancellationToken cancellationToken = default) =>
+        await _http.DeleteAsync($"api/queue/{id}", cancellationToken);
 
-    public async Task<QueueItem?> UpdateStatusAsync(int id, QueueStatus status)
+    public async Task<QueueItem?> UpdateStatusAsync(int id, QueueStatus status, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/status", new QueueStatusUpdate(status));
-        return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>() : null;
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/status", new QueueStatusUpdate(status), cancellationToken);
+        return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>(cancellationToken) : null;
     }
 
-    public async Task<QueueItem?> UpdateSentimentAsync(int id, int? sentiment)
+    public async Task<QueueItem?> UpdateSentimentAsync(int id, int? sentiment, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/sentiment", new SentimentUpdate(sentiment));
-        return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>() : null;
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/sentiment", new SentimentUpdate(sentiment), cancellationToken);
+        return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>(cancellationToken) : null;
     }
 
-    public async Task<bool> UpdateQueuePositionAsync(int id, int position)
+    public async Task<bool> UpdateQueuePositionAsync(int id, int position, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/position", new PositionUpdate(position));
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/position", new PositionUpdate(position), cancellationToken);
         return res.IsSuccessStatusCode;
     }
 
-    public async Task<QueueItem?> UpdateProgressAsync(int id, int? season, int? episode)
+    public async Task<QueueItem?> UpdateProgressAsync(int id, int? season, int? episode, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/progress", new ProgressUpdate(season, episode));
-        return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>() : null;
+        HttpResponseMessage res = await _http.PutAsJsonAsync($"api/queue/{id}/progress", new ProgressUpdate(season, episode), cancellationToken);
+        return res.IsSuccessStatusCode ? await res.Content.ReadFromJsonAsync<QueueItem>(cancellationToken) : null;
     }
 
-    public Task<QueueItem?> MarkAsSeenAsync(SearchResult result) => PostStatusAsync("api/queue/seen", result);
+    public Task<QueueItem?> MarkAsSeenAsync(SearchResult result, CancellationToken cancellationToken = default) =>
+        PostStatusAsync("api/queue/seen", result, cancellationToken);
 
     // returns the queue item for this content, creating as WantToWatch if absent.
     // never mutates existing — used by QuickActions when the dialog opens from a browse surface
     // that can't know whether the item is already queued. Caller follows up with UpdateStatus /
     // UpdateSentiment using the returned Id.
-    public Task<QueueItem?> EnsureQueueItemAsync(SearchResult result) => PostStatusAsync("api/queue/ensure", result);
+    public Task<QueueItem?> EnsureQueueItemAsync(SearchResult result, CancellationToken cancellationToken = default) =>
+        PostStatusAsync("api/queue/ensure", result, cancellationToken);
 
     // season & episode sentiments
-    public async Task<ShowSentiments> GetShowSentimentsAsync(int tmdbId) =>
-        await _http.GetFromJsonAsync<ShowSentiments>($"api/shows/{tmdbId}/sentiments") ?? new();
+    public async Task<ShowSentiments> GetShowSentimentsAsync(int tmdbId, CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<ShowSentiments>($"api/shows/{tmdbId}/sentiments", cancellationToken) ?? new();
 
-    public async Task SetSeasonSentimentAsync(int tmdbId, int seasonNumber, int? sentiment) =>
-        await _http.PutAsJsonAsync($"api/shows/{tmdbId}/seasons/{seasonNumber}/sentiment", new { Sentiment = sentiment });
+    public async Task SetSeasonSentimentAsync(int tmdbId, int seasonNumber, int? sentiment, CancellationToken cancellationToken = default) =>
+        await _http.PutAsJsonAsync($"api/shows/{tmdbId}/seasons/{seasonNumber}/sentiment", new { Sentiment = sentiment }, cancellationToken);
 
-    public async Task SetEpisodeSentimentAsync(int tmdbId, int seasonNumber, int episodeNumber, int? sentiment) =>
-        await _http.PutAsJsonAsync($"api/shows/{tmdbId}/seasons/{seasonNumber}/episodes/{episodeNumber}/sentiment", new { Sentiment = sentiment });
+    public async Task SetEpisodeSentimentAsync(int tmdbId, int seasonNumber, int episodeNumber, int? sentiment, CancellationToken cancellationToken = default) =>
+        await _http.PutAsJsonAsync($"api/shows/{tmdbId}/seasons/{seasonNumber}/episodes/{episodeNumber}/sentiment", new { Sentiment = sentiment }, cancellationToken);
 
-    private async Task<QueueItem?> PostStatusAsync(string endpoint, SearchResult result)
+    private async Task<QueueItem?> PostStatusAsync(string endpoint, SearchResult result, CancellationToken cancellationToken = default)
     {
         QueueItem qi = result.ToQueueItem();
         SeenRequest request = new(result.TmdbId, result.MediaType, result.Title, result.PosterPath, qi.AvailableOnJson, result.BackdropPath);
-        HttpResponseMessage response = await _http.PostAsJsonAsync(endpoint, request);
+        HttpResponseMessage response = await _http.PostAsJsonAsync(endpoint, request, cancellationToken);
         if (response.IsSuccessStatusCode)
-            return await response.Content.ReadFromJsonAsync<QueueItem>();
+            return await response.Content.ReadFromJsonAsync<QueueItem>(cancellationToken);
         return null;
     }
 
     // curation
-    public async Task<CurationResponse?> GetCuratedRowsAsync()
+    public async Task<CurationResponse?> GetCuratedRowsAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            return await _http.GetFromJsonAsync<CurationResponse>("api/curation/rows");
+            return await _http.GetFromJsonAsync<CurationResponse>("api/curation/rows", cancellationToken);
         }
+        catch (OperationCanceledException) { throw; }
         catch { return null; }
     }
 
-    public async Task<CurationResponse?> RefreshCurationAsync()
+    public async Task<CurationResponse?> RefreshCurationAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            HttpResponseMessage response = await _http.PostAsync("api/curation/refresh", null);
+            HttpResponseMessage response = await _http.PostAsync("api/curation/refresh", null, cancellationToken);
             if (response.IsSuccessStatusCode)
-                return await response.Content.ReadFromJsonAsync<CurationResponse>();
+                return await response.Content.ReadFromJsonAsync<CurationResponse>(cancellationToken);
             return null;
         }
+        catch (OperationCanceledException) { throw; }
         catch { return null; }
     }
 
-    public async Task<ShowMatchResult?> GetShowMatchAsync(int tmdbId, string mediaType)
+    public async Task<ShowMatchResult?> GetShowMatchAsync(int tmdbId, string mediaType, CancellationToken cancellationToken = default)
     {
         try
         {
-            return await _http.GetFromJsonAsync<ShowMatchResult?>($"api/curation/match/{mediaType}/{tmdbId}");
+            return await _http.GetFromJsonAsync<ShowMatchResult?>($"api/curation/match/{mediaType}/{tmdbId}", cancellationToken);
         }
+        catch (OperationCanceledException) { throw; }
         catch { return null; }
     }
 
     // user settings
-    public async Task<UserSettings> GetUserSettingsAsync() =>
-        await _http.GetFromJsonAsync<UserSettings>("api/settings") ?? new UserSettings();
+    public async Task<UserSettings> GetUserSettingsAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<UserSettings>("api/settings", cancellationToken) ?? new UserSettings();
 
-    public async Task SetUserSettingsAsync(UserSettings settings) =>
-        await _http.PutAsJsonAsync("api/settings", settings);
+    public async Task SetUserSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default) =>
+        await _http.PutAsJsonAsync("api/settings", settings, cancellationToken);
 
     // user services
-    public async Task<List<int>> GetUserServicesAsync() =>
-        await _http.GetFromJsonAsync<List<int>>("api/services") ?? [];
+    public async Task<List<int>> GetUserServicesAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<List<int>>("api/services", cancellationToken) ?? [];
 
-    public async Task SetUserServicesAsync(List<int> providerIds) =>
-        await _http.PutAsJsonAsync("api/services", providerIds);
+    public async Task SetUserServicesAsync(List<int> providerIds, CancellationToken cancellationToken = default) =>
+        await _http.PutAsJsonAsync("api/services", providerIds, cancellationToken);
 
     // user genres
-    public async Task<List<int>> GetUserGenresAsync() =>
-        await _http.GetFromJsonAsync<List<int>>("api/genres") ?? [];
+    public async Task<List<int>> GetUserGenresAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<List<int>>("api/genres", cancellationToken) ?? [];
 
-    public async Task SetUserGenresAsync(List<int> genreIds) =>
-        await _http.PutAsJsonAsync("api/genres", genreIds);
+    public async Task SetUserGenresAsync(List<int> genreIds, CancellationToken cancellationToken = default) =>
+        await _http.PutAsJsonAsync("api/genres", genreIds, cancellationToken);
 
     // profile
-    public async Task<UserProfile?> GetProfileAsync() =>
-        await _http.GetFromJsonAsync<UserProfile>("api/profile");
+    public async Task<UserProfile?> GetProfileAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<UserProfile>("api/profile", cancellationToken);
 
-    public async Task<AuthResponse?> UpdateProfileAsync(string? firstName)
+    public async Task<AuthResponse?> UpdateProfileAsync(string? firstName, CancellationToken cancellationToken = default)
     {
-        HttpResponseMessage response = await _http.PutAsJsonAsync("api/profile", new UpdateProfileRequest(firstName));
+        HttpResponseMessage response = await _http.PutAsJsonAsync("api/profile", new UpdateProfileRequest(firstName), cancellationToken);
         if (!response.IsSuccessStatusCode) return null;
-        return await response.Content.ReadFromJsonAsync<AuthResponse>();
+        return await response.Content.ReadFromJsonAsync<AuthResponse>(cancellationToken);
     }
 
     // admin
-    public async Task<AdminUsersResponse?> GetAdminUsersAsync() =>
-        await _http.GetFromJsonAsync<AdminUsersResponse>("api/admin/users");
+    public async Task<AdminUsersResponse?> GetAdminUsersAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<AdminUsersResponse>("api/admin/users", cancellationToken);
 
-    public async Task<AdminUserDetail?> GetAdminUserDetailAsync(string userId) =>
-        await _http.GetFromJsonAsync<AdminUserDetail>($"api/admin/users/{userId}");
+    public async Task<AdminUserDetail?> GetAdminUserDetailAsync(string userId, CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<AdminUserDetail>($"api/admin/users/{userId}", cancellationToken);
 
-    public async Task<HttpResponseMessage> SetUserAdminAsync(string userId, bool isAdmin) =>
-        await _http.PostAsJsonAsync($"api/admin/users/{userId}/admin", new AdminSetAdminRequest(isAdmin));
+    public async Task<HttpResponseMessage> SetUserAdminAsync(string userId, bool isAdmin, CancellationToken cancellationToken = default) =>
+        await _http.PostAsJsonAsync($"api/admin/users/{userId}/admin", new AdminSetAdminRequest(isAdmin), cancellationToken);
 
-    public async Task<HttpResponseMessage> SetUserFirstNameAsync(string userId, string? firstName) =>
-        await _http.PutAsJsonAsync($"api/admin/users/{userId}/firstname", new AdminSetFirstNameRequest(firstName));
+    public async Task<HttpResponseMessage> SetUserFirstNameAsync(string userId, string? firstName, CancellationToken cancellationToken = default) =>
+        await _http.PutAsJsonAsync($"api/admin/users/{userId}/firstname", new AdminSetFirstNameRequest(firstName), cancellationToken);
 
-    public async Task<HttpResponseMessage> DeleteUserAsync(string userId) =>
-        await _http.DeleteAsync($"api/admin/users/{userId}");
+    public async Task<HttpResponseMessage> DeleteUserAsync(string userId, CancellationToken cancellationToken = default) =>
+        await _http.DeleteAsync($"api/admin/users/{userId}", cancellationToken);
 
-    public async Task<AdminAiUsageResponse?> GetAdminAiUsageAsync() =>
-        await _http.GetFromJsonAsync<AdminAiUsageResponse>("api/admin/ai-usage");
+    public async Task<AdminAiUsageResponse?> GetAdminAiUsageAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<AdminAiUsageResponse>("api/admin/ai-usage", cancellationToken);
 
-    public async Task<AdminOnboardingFunnel?> GetAdminOnboardingAsync() =>
-        await _http.GetFromJsonAsync<AdminOnboardingFunnel>("api/admin/onboarding");
+    public async Task<AdminOnboardingFunnel?> GetAdminOnboardingAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<AdminOnboardingFunnel>("api/admin/onboarding", cancellationToken);
 }

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -148,7 +148,11 @@ public class ApiClient(HttpClient http)
         {
             return await _http.GetFromJsonAsync<CurationResponse>("api/curation/rows", cancellationToken);
         }
-        catch (OperationCanceledException) { throw; }
+        // only rethrow caller-driven cancellation. HttpClient.Timeout surfaces as
+        // TaskCanceledException with our token NOT cancelled — that should keep the
+        // legacy "all-errors-return-null" contract so existing callers (no CT) don't
+        // suddenly see exceptions.
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch { return null; }
     }
 
@@ -161,7 +165,7 @@ public class ApiClient(HttpClient http)
                 return await response.Content.ReadFromJsonAsync<CurationResponse>(cancellationToken);
             return null;
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch { return null; }
     }
 
@@ -171,7 +175,7 @@ public class ApiClient(HttpClient http)
         {
             return await _http.GetFromJsonAsync<ShowMatchResult?>($"api/curation/match/{mediaType}/{tmdbId}", cancellationToken);
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch { return null; }
     }
 


### PR DESCRIPTION
## Summary

- Every `ApiClient` HTTP method now accepts `CancellationToken cancellationToken = default` and forwards it to `GetFromJsonAsync` / `PostAsJsonAsync` / `PutAsJsonAsync` / `DeleteAsync` / `PostAsync` and the follow-up `ReadFromJsonAsync`. Default token preserves all existing call sites — pages with a page-scoped CTS (Details) can now cancel every in-flight call, not just the two that PR #114 happened to wire up. Closes #115.
- `CurationService.GetShowMatchAsync` accepts the token and forwards it into `_client.Messages.Create`, so the paid Anthropic inference itself aborts on rapid Details navigation. Closes #117.
- `CurationEndpoints /match` handler accepts `CancellationToken` (Minimal API auto-binds from `HttpContext.RequestAborted`), threads it to `GetShowMatchAsync`, and returns `499 Client Closed Request` if the client navigated away.
- `Details.razor.LoadShowMatch` passes `ct` through and catches `OperationCanceledException` so a superseded call abandons silently.

## What changed

| File | Why |
|---|---|
| `HurrahTv.Client/Services/ApiClient.cs` | Add `CancellationToken cancellationToken = default` to every public method; forward to all HTTP and `ReadFromJsonAsync` calls. Wrapped catch blocks in curation methods (`GetCuratedRowsAsync`, `RefreshCurationAsync`, `GetShowMatchAsync`) now rethrow `OperationCanceledException` so cancellation surfaces as cancellation, not a silent `null`. |
| `HurrahTv.Api/Endpoints/CurationEndpoints.cs` | `/match` handler accepts `CancellationToken ct`, threads it to `GetShowMatchAsync`, and returns 499 on client abort instead of pretending success with null. |
| `HurrahTv.Api/Services/CurationService.cs` | `GetShowMatchAsync` accepts `CancellationToken`; forwards to `_client.Messages.Create`. `TrackAIUsageAsync` intentionally does NOT receive the token — if the inference completed, the usage row must be written. Cancellation rethrows for the endpoint to handle. |
| `HurrahTv.Client/Pages/Details.razor` | `LoadShowMatch` passes `ct` and catches `OperationCanceledException`. |

## Why bundled

#117 is a subset of #115 (the match call is one of many `ApiClient` callers that needs the token), but #117 also requires server-side plumbing for the AI inference itself. They share a single test/manual-verification surface — Details rapid-nav — and #117's issue body notes "could be folded into that issue if both are done at once." Single PR keeps the cancellation story coherent.

## Test plan

- [x] `dotnet build HurrahTv.slnx` — clean (0 warnings, 0 errors)
- [x] `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` — clean
- [x] `dotnet test HurrahTv.slnx` — 110/110 passing (no new tests; all existing call sites use the default token so behavior is unchanged where unaltered)
- [ ] Manual: rapid-click between two shows on the Details page; confirm AI usage row count reflects one inference for the final navigation, not N (server-side token counter via `/api/admin/ai-usage` or `AIUsage` table)
- [ ] Manual: confirm Details / Queue / Home pages still render correctly with the cancellation paths wired

Closes #115
Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)