### PR TITLE
AI shutdown + cancellation hardening (#123-128)

### DIFF
--- a/HurrahTv.Api.Tests/AIUsageDetachedWriteTests.cs
+++ b/HurrahTv.Api.Tests/AIUsageDetachedWriteTests.cs
@@ -38,6 +38,32 @@ public class AIUsageDetachedWriteTests(PostgresFixture fx) : IAsyncLifetime
         Assert.Equal("show-match", requestType);
     }
 
+    // pins #123 — fire-and-forget writes registered via the drain hosted service
+    // must complete during StopAsync. Mimics SIGTERM / Azure deploy slot swap where
+    // the request pipeline returns before the Task.Run continuation runs.
+    [Fact]
+    public async Task TrackUsageDetached_RowLands_WhenStopAsyncDrainsInFlightWrites()
+    {
+        await SeedUserAsync("drain-user");
+
+        using IServiceScope scope = fx.Factory.Services.CreateScope();
+        CurationService curation = scope.ServiceProvider.GetRequiredService<CurationService>();
+        AIUsageDrainHostedService drain = fx.Factory.Services.GetRequiredService<AIUsageDrainHostedService>();
+
+        // production usage pattern — discard return value (no await).
+        _ = curation.TrackUsageDetachedAsync("drain-user", inputTokens: 42, outputTokens: 7, cost: 0.0001m, requestType: "show-match");
+
+        // StopAsync awaits the in-flight write (or times out at 10s). With no
+        // contention this finishes in tens of ms.
+        await drain.StopAsync(CancellationToken.None);
+
+        (int inputTokens, int outputTokens, decimal cost, string requestType) = await QueryUsageRowAsync("drain-user");
+        Assert.Equal(42, inputTokens);
+        Assert.Equal(7, outputTokens);
+        Assert.Equal(0.0001m, cost);
+        Assert.Equal("show-match", requestType);
+    }
+
     private async Task SeedUserAsync(string userId)
     {
         using NpgsqlConnection db = new(fx.ConnectionString);

--- a/HurrahTv.Api/Endpoints/CurationEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/CurationEndpoints.cs
@@ -14,19 +14,20 @@ public static class CurationEndpoints
         RouteGroupBuilder group = app.MapGroup("/api/curation").RequireAuthorization();
 
         // get AI-curated rows for the home page
-        group.MapGet("/rows", async (ClaimsPrincipal user, DbService db, CurationService curation, TmdbService tmdb, ILogger<CurationService> logger) =>
+        group.MapGet("/rows", async (ClaimsPrincipal user, DbService db, CurationService curation,
+            TmdbService tmdb, ILogger<CurationService> logger, CancellationToken ct) =>
         {
             try
             {
                 string userId = user.GetUserId();
-                Task<List<QueueItem>> watchlistTask = db.GetQueueAsync(userId);
-                Task<List<int>> providerTask = db.GetUserServicesAsync(userId);
-                Task<UserSettings> settingsTask = db.GetUserSettingsAsync(userId);
+                Task<List<QueueItem>> watchlistTask = db.GetQueueAsync(userId, ct);
+                Task<List<int>> providerTask = db.GetUserServicesAsync(userId, ct);
+                Task<UserSettings> settingsTask = db.GetUserSettingsAsync(userId, ct);
                 await Task.WhenAll(watchlistTask, providerTask, settingsTask);
 
                 List<QueueItem> watchlist = watchlistTask.Result;
                 List<int> providerIds = providerTask.Result;
-                CurationResult result = await curation.GetCuratedRowsAsync(userId, watchlist, providerIds, settingsTask.Result.EnglishOnly);
+                CurationResult result = await curation.GetCuratedRowsAsync(userId, watchlist, providerIds, settingsTask.Result.EnglishOnly, cancellationToken: ct);
 
                 if (result.Rows.Count > 0)
                 {
@@ -34,7 +35,7 @@ public static class CurationEndpoints
                     ExcludeShows(result, excludeIds);
                 }
 
-                List<CuratedRowResponse> rows = await ResolveRowsAsync(result.Rows, providerIds, tmdb);
+                List<CuratedRowResponse> rows = await ResolveRowsAsync(result.Rows, providerIds, tmdb, ct);
 
                 return Results.Ok(new CurationResponse
                 {
@@ -45,6 +46,12 @@ public static class CurationEndpoints
                     Error = result.Error,
                     CandidateCount = result.CandidateCount
                 });
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // client navigated away — log signal only; mirror /match (see #117, #120,
+                // and Learnings/status-499-server-log-only.md). pins #126.
+                return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
             }
             catch (Exception ex)
             {
@@ -59,7 +66,7 @@ public static class CurationEndpoints
 
         // force refresh AI curation (rate-limited per user)
         group.MapPost("/refresh", async (ClaimsPrincipal user, DbService db, CurationService curation,
-            TmdbService tmdb, IMemoryCache cache, ILogger<CurationService> logger) =>
+            TmdbService tmdb, IMemoryCache cache, ILogger<CurationService> logger, CancellationToken ct) =>
         {
             try
             {
@@ -69,17 +76,22 @@ public static class CurationEndpoints
                 if (cache.TryGetValue(rateLimitKey, out _))
                     return Results.Ok(new CurationResponse { AiEnabled = curation.IsEnabled, Error = "Please wait before refreshing again" });
 
+                // anti-abuse rate-limit lands BEFORE the cancellable chain so a
+                // rapid retry can't bypass it. We deliberately do NOT pre-blank the
+                // curation cache row here — GetCuratedRowsAsync(forceRefresh: true)
+                // skips the cache check, and a successful AI pass overwrites the row
+                // at the end of the call. Pre-blanking lost the user's row on a
+                // mid-flight client cancel (#xsimplify).
                 cache.Set(rateLimitKey, true, RefreshCooldown);
-                await db.SetCurationCacheAsync(userId, "[]", "force-refresh");
 
-                Task<List<QueueItem>> watchlistTask = db.GetQueueAsync(userId);
-                Task<List<int>> providerTask = db.GetUserServicesAsync(userId);
-                Task<UserSettings> settingsTask = db.GetUserSettingsAsync(userId);
+                Task<List<QueueItem>> watchlistTask = db.GetQueueAsync(userId, ct);
+                Task<List<int>> providerTask = db.GetUserServicesAsync(userId, ct);
+                Task<UserSettings> settingsTask = db.GetUserSettingsAsync(userId, ct);
                 await Task.WhenAll(watchlistTask, providerTask, settingsTask);
 
                 List<QueueItem> watchlist = watchlistTask.Result;
                 List<int> providerIds = providerTask.Result;
-                CurationResult result = await curation.GetCuratedRowsAsync(userId, watchlist, providerIds, settingsTask.Result.EnglishOnly);
+                CurationResult result = await curation.GetCuratedRowsAsync(userId, watchlist, providerIds, settingsTask.Result.EnglishOnly, forceRefresh: true, cancellationToken: ct);
 
                 if (result.Rows.Count > 0)
                 {
@@ -87,7 +99,7 @@ public static class CurationEndpoints
                     ExcludeShows(result, excludeIds);
                 }
 
-                List<CuratedRowResponse> rows = await ResolveRowsAsync(result.Rows, providerIds, tmdb);
+                List<CuratedRowResponse> rows = await ResolveRowsAsync(result.Rows, providerIds, tmdb, ct);
 
                 return Results.Ok(new CurationResponse
                 {
@@ -96,6 +108,10 @@ public static class CurationEndpoints
                     WatchlistChanged = true,
                     AiEnabled = curation.IsEnabled
                 });
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
             }
             catch (Exception ex)
             {
@@ -177,7 +193,7 @@ public static class CurationEndpoints
     }
 
     private static async Task<List<CuratedRowResponse>> ResolveRowsAsync(
-        List<AICuratedRow> aiRows, List<int> providerIds, TmdbService tmdb)
+        List<AICuratedRow> aiRows, List<int> providerIds, TmdbService tmdb, CancellationToken cancellationToken = default)
     {
         List<CuratedRowResponse> rows = [];
         HashSet<int> providerSet = [.. providerIds];
@@ -189,18 +205,18 @@ public static class CurationEndpoints
                 ShowDetails? details;
                 if (aiRow.ItemMediaTypes.TryGetValue(tmdbId, out string? knownType) && MediaTypes.IsValid(knownType))
                 {
-                    details = await tmdb.GetDetailsAsync(tmdbId, knownType);
+                    details = await tmdb.GetDetailsAsync(tmdbId, knownType, cancellationToken);
                 }
                 else
                 {
                     // fallback for rows cached before ItemMediaTypes existed
-                    details = await tmdb.GetDetailsAsync(tmdbId, MediaTypes.Tv);
-                    details ??= await tmdb.GetDetailsAsync(tmdbId, MediaTypes.Movie);
+                    details = await tmdb.GetDetailsAsync(tmdbId, MediaTypes.Tv, cancellationToken);
+                    details ??= await tmdb.GetDetailsAsync(tmdbId, MediaTypes.Movie, cancellationToken);
                 }
 
                 if (details != null)
                 {
-                    List<AvailableService> providers = await tmdb.GetWatchProvidersAsync(tmdbId, details.MediaType);
+                    List<AvailableService> providers = await tmdb.GetWatchProvidersAsync(tmdbId, details.MediaType, cancellationToken);
                     details.AvailableOn = [.. providers.Where(p => (p.Type is ProviderType.Flatrate or ProviderType.Ads) && providerSet.Contains(p.ProviderId))];
                 }
                 return details;

--- a/HurrahTv.Api/Endpoints/QueueEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/QueueEndpoints.cs
@@ -14,15 +14,20 @@ public static class QueueEndpoints
     {
         RouteGroupBuilder group = app.MapGroup("/api/queue").RequireAuthorization();
 
-        group.MapGet("", async (ClaimsPrincipal user, DbService db, IServiceScopeFactory scopeFactory) =>
+        group.MapGet("", async (ClaimsPrincipal user, DbService db, IServiceScopeFactory scopeFactory, CancellationToken ct) =>
         {
             string userId = user.GetUserId();
 
-            // run watched + services in parallel with the queue read so we don't pay them sequentially
-            Task<List<WatchedEpisode>> watchedTask = db.GetWatchedEpisodesAsync(userId);
-            Task<List<int>> activeServicesTask = db.GetUserServicesAsync(userId);
+            // run watched + services in parallel with the queue read so we don't pay
+            // them sequentially. Task.WhenAll observes all three so a caller-driven
+            // OCE on any one of them doesn't strand the others as unobserved Task
+            // exceptions (which would surface in TaskScheduler.UnobservedTaskException).
+            Task<List<WatchedEpisode>> watchedTask = db.GetWatchedEpisodesAsync(userId, ct);
+            Task<List<int>> activeServicesTask = db.GetUserServicesAsync(userId, ct);
+            Task<List<QueueItem>> itemsTask = db.GetQueueAsync(userId, ct);
+            await Task.WhenAll(watchedTask, activeServicesTask, itemsTask);
 
-            List<QueueItem> items = await db.GetQueueAsync(userId);
+            List<QueueItem> items = itemsTask.Result;
 
             List<QueueItem> staleEpisodes = [.. items
                 .Where(i => i.MediaType == MediaTypes.Tv
@@ -42,11 +47,11 @@ public static class QueueEndpoints
             if (staleEpisodes.Count > 0 || staleProviders.Count > 0)
                 _ = RefreshStaleItemsInBackground(scopeFactory, staleEpisodes, staleProviders);
 
-            HashSet<int> activeServiceIds = [.. await activeServicesTask];
+            HashSet<int> activeServiceIds = [.. activeServicesTask.Result];
             if (activeServiceIds.Count > 0)
                 items = [.. items.Where(i => IsWatchableOn(i.AvailableOnJson, activeServiceIds))];
 
-            return Results.Ok(new QueueResponse(items, await watchedTask));
+            return Results.Ok(new QueueResponse(items, watchedTask.Result));
         });
 
         group.MapPost("", async (QueueItem item, ClaimsPrincipal user, DbService db) =>

--- a/HurrahTv.Api/Endpoints/QueueEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/QueueEndpoints.cs
@@ -16,42 +16,51 @@ public static class QueueEndpoints
 
         group.MapGet("", async (ClaimsPrincipal user, DbService db, IServiceScopeFactory scopeFactory, CancellationToken ct) =>
         {
-            string userId = user.GetUserId();
+            try
+            {
+                string userId = user.GetUserId();
 
-            // run watched + services in parallel with the queue read so we don't pay
-            // them sequentially. Task.WhenAll observes all three so a caller-driven
-            // OCE on any one of them doesn't strand the others as unobserved Task
-            // exceptions (which would surface in TaskScheduler.UnobservedTaskException).
-            Task<List<WatchedEpisode>> watchedTask = db.GetWatchedEpisodesAsync(userId, ct);
-            Task<List<int>> activeServicesTask = db.GetUserServicesAsync(userId, ct);
-            Task<List<QueueItem>> itemsTask = db.GetQueueAsync(userId, ct);
-            await Task.WhenAll(watchedTask, activeServicesTask, itemsTask);
+                // run watched + services in parallel with the queue read so we don't pay
+                // them sequentially. Task.WhenAll observes all three so a caller-driven
+                // OCE on any one of them doesn't strand the others as unobserved Task
+                // exceptions (which would surface in TaskScheduler.UnobservedTaskException).
+                Task<List<WatchedEpisode>> watchedTask = db.GetWatchedEpisodesAsync(userId, ct);
+                Task<List<int>> activeServicesTask = db.GetUserServicesAsync(userId, ct);
+                Task<List<QueueItem>> itemsTask = db.GetQueueAsync(userId, ct);
+                await Task.WhenAll(watchedTask, activeServicesTask, itemsTask);
 
-            List<QueueItem> items = itemsTask.Result;
+                List<QueueItem> items = itemsTask.Result;
 
-            List<QueueItem> staleEpisodes = [.. items
-                .Where(i => i.MediaType == MediaTypes.Tv
-                    && i.Status is QueueStatus.Watching or QueueStatus.WantToWatch
-                    && (i.LastEpisodeCheckAt == null
-                        || DateTime.UtcNow - i.LastEpisodeCheckAt > EpisodeCheckStaleAfter
-                        || i.LatestEpisodeSeason == null))];
+                List<QueueItem> staleEpisodes = [.. items
+                    .Where(i => i.MediaType == MediaTypes.Tv
+                        && i.Status is QueueStatus.Watching or QueueStatus.WantToWatch
+                        && (i.LastEpisodeCheckAt == null
+                            || DateTime.UtcNow - i.LastEpisodeCheckAt > EpisodeCheckStaleAfter
+                            || i.LatestEpisodeSeason == null))];
 
-            List<QueueItem> staleProviders = [.. items
-                .Where(i => i.AvailableOnCheckedAt == null
-                    || DateTime.UtcNow - i.AvailableOnCheckedAt > ProviderCheckStaleAfter)];
+                List<QueueItem> staleProviders = [.. items
+                    .Where(i => i.AvailableOnCheckedAt == null
+                        || DateTime.UtcNow - i.AvailableOnCheckedAt > ProviderCheckStaleAfter)];
 
-            // fire-and-forget the TMDb refresh — fresh episode/provider data shows up on the
-            // next /api/queue call, but the current request returns immediately. IsWatchableOn
-            // returns true for items with empty AvailableOnJson, so newly-added items are NOT
-            // hidden during the pre-refresh window.
-            if (staleEpisodes.Count > 0 || staleProviders.Count > 0)
-                _ = RefreshStaleItemsInBackground(scopeFactory, staleEpisodes, staleProviders);
+                // fire-and-forget the TMDb refresh — fresh episode/provider data shows up on the
+                // next /api/queue call, but the current request returns immediately. IsWatchableOn
+                // returns true for items with empty AvailableOnJson, so newly-added items are NOT
+                // hidden during the pre-refresh window.
+                if (staleEpisodes.Count > 0 || staleProviders.Count > 0)
+                    _ = RefreshStaleItemsInBackground(scopeFactory, staleEpisodes, staleProviders);
 
-            HashSet<int> activeServiceIds = [.. activeServicesTask.Result];
-            if (activeServiceIds.Count > 0)
-                items = [.. items.Where(i => IsWatchableOn(i.AvailableOnJson, activeServiceIds))];
+                HashSet<int> activeServiceIds = [.. activeServicesTask.Result];
+                if (activeServiceIds.Count > 0)
+                    items = [.. items.Where(i => IsWatchableOn(i.AvailableOnJson, activeServiceIds))];
 
-            return Results.Ok(new QueueResponse(items, watchedTask.Result));
+                return Results.Ok(new QueueResponse(items, watchedTask.Result));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // client navigated away — mirror /api/curation/rows + /match.
+                // See Learnings/status-499-server-log-only.md for the rationale.
+                return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
+            }
         });
 
         group.MapPost("", async (QueueItem item, ClaimsPrincipal user, DbService db) =>

--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -14,6 +14,13 @@ builder.Services.AddSingleton<DbService>();
 builder.Services.AddSingleton<SmsService>();
 builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<CurationService>();
+// drain in-flight detached AIUsage writes on host shutdown (#123). Registered as
+// both a hosted service (StopAsync drain) and a singleton so CurationService can
+// resolve it for Register(Task). Same instance for both — hosted services are
+// singletons by default; the explicit AddSingleton(sp => GetRequiredService) keeps
+// the lookup path unified.
+builder.Services.AddSingleton<AIUsageDrainHostedService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<AIUsageDrainHostedService>());
 
 // jwt auth
 string jwtKey = builder.Configuration["Jwt:Key"] ?? throw new InvalidOperationException("Jwt:Key is required");

--- a/HurrahTv.Api/Services/AIUsageDrainHostedService.cs
+++ b/HurrahTv.Api/Services/AIUsageDrainHostedService.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+
+namespace HurrahTv.Api.Services;
+
+// tracks in-flight detached AIUsage writes (CurationService.TrackUsageDetachedAsync)
+// and drains them on host shutdown with a bounded timeout. Anthropic was already paid
+// for the inference, so the cost row landing is non-negotiable — without this the
+// Task.Run continuation either runs against a partially-disposed root provider (logged
+// inner-catch) or never runs (process exits before the thread-pool picks it up).
+// SIGTERM / app-pool recycle / Azure deploy slot swap are exactly when in-flight
+// writes are most common — every running request flushes through the same window.
+// pins #123.
+//
+// shape: singleton-scoped, exposes Run(Func<CT, Task>) so registration is ATOMIC with
+// task creation — the in-flight TaskCompletionSource is added to the dict BEFORE the
+// thread-pool dispatch happens, so a concurrent StopAsync snapshot can't miss it.
+// ConcurrentDictionary entries are removed on completion via ContinueWith. StopAsync
+// snapshots and uses Task.WaitAsync(linked CT) so the WhenAll fault propagates and
+// the timeout timer is disposed when drain wins (no orphan Task.Delay leak).
+public sealed partial class AIUsageDrainHostedService(ILogger<AIUsageDrainHostedService> logger) : IHostedService
+{
+    // host drain budget. Azure's deploy graceful-stop budget is ~10s before SIGKILL.
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(10);
+
+    // each inner write gets a slightly tighter timeout so it terminates before the
+    // outer drain budget, leaving room for the drain to log completion rather than
+    // racing the host's hard kill.
+    private static readonly TimeSpan InnerWriteTimeout = TimeSpan.FromSeconds(8);
+
+    private readonly ConcurrentDictionary<Task, byte> _inFlight = new();
+    private readonly ILogger<AIUsageDrainHostedService> _logger = logger;
+
+    // Run owns the dispatch so the in-flight task is registered BEFORE thread-pool
+    // scheduling — closes the Register-after-Task.Run race window where a concurrent
+    // StopAsync could snapshot empty between Task.Run returning and the caller's
+    // separate Register call.
+    public Task Run(Func<CancellationToken, Task> work)
+    {
+        TaskCompletionSource tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // add BEFORE Task.Run schedules — once Run returns the tcs.Task is observable
+        // to any concurrent StopAsync. Remove via ContinueWith so the dict doesn't
+        // accumulate completed tasks across the lifetime of the process.
+        _inFlight.TryAdd(tcs.Task, 0);
+        _ = tcs.Task.ContinueWith(static (t, state) =>
+            ((ConcurrentDictionary<Task, byte>)state!).TryRemove(t, out _),
+            _inFlight, TaskScheduler.Default);
+
+        _ = Task.Run(async () =>
+        {
+            using CancellationTokenSource cts = new(InnerWriteTimeout);
+            try
+            {
+                await work(cts.Token);
+            }
+            catch
+            {
+                // work() is expected to handle/log its own exceptions; this catch is
+                // defense-in-depth so a logger throw during host shutdown doesn't escape
+                // as an unobserved task fault (which the drain's Task.WhenAll would then
+                // surface as an AggregateException at the wrong layer).
+            }
+            finally
+            {
+                tcs.TrySetResult();
+            }
+        });
+
+        return tcs.Task;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        Task[] snapshot = [.. _inFlight.Keys];
+        if (snapshot.Length == 0) return;
+
+        // host-driven shutdown CT is already signalled — drain budget is zero. Log
+        // honestly rather than misreporting as a 10s timeout (which is what would
+        // happen if we entered the Task.Delay race with a pre-cancelled CT).
+        if (cancellationToken.IsCancellationRequested)
+        {
+            LogDrainAborted(snapshot.Length);
+            return;
+        }
+
+        LogDraining(snapshot.Length);
+
+        using CancellationTokenSource timeoutCts = new(DrainTimeout);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            // WaitAsync(linkedCts.Token) awaits the WhenAll task with cancellation —
+            // disposing the linked CTS cancels the timeout timer when drain wins, so
+            // no orphan Task.Delay is left running. Faults in the inner snapshot tasks
+            // surface as exceptions here (rather than being silently held in the drain
+            // Task and observed only by reference comparison).
+            await Task.WhenAll(snapshot).WaitAsync(linkedCts.Token);
+            LogDrainComplete();
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            // count snapshot tasks that haven't completed yet — concurrent Register
+            // additions are excluded since they aren't in the snapshot.
+            int remaining = snapshot.Count(t => !t.IsCompleted);
+            LogDrainTimeout(DrainTimeout.TotalSeconds, remaining);
+        }
+        catch (OperationCanceledException)
+        {
+            int remaining = snapshot.Count(t => !t.IsCompleted);
+            LogDrainAborted(remaining);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Draining {Count} in-flight AIUsage writes on shutdown")]
+    private partial void LogDraining(int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "AIUsage drain complete")]
+    private partial void LogDrainComplete();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AIUsage drain timed out after {Timeout}s — {Remaining} writes may be lost")]
+    private partial void LogDrainTimeout(double timeout, int remaining);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AIUsage drain aborted by host shutdown — {Remaining} writes may be lost")]
+    private partial void LogDrainAborted(int remaining);
+}

--- a/HurrahTv.Api/Services/AIUsageDrainHostedService.cs
+++ b/HurrahTv.Api/Services/AIUsageDrainHostedService.cs
@@ -15,8 +15,14 @@ namespace HurrahTv.Api.Services;
 // task creation — the in-flight TaskCompletionSource is added to the dict BEFORE the
 // thread-pool dispatch happens, so a concurrent StopAsync snapshot can't miss it.
 // ConcurrentDictionary entries are removed on completion via ContinueWith. StopAsync
-// snapshots and uses Task.WaitAsync(linked CT) so the WhenAll fault propagates and
-// the timeout timer is disposed when drain wins (no orphan Task.Delay leak).
+// snapshots and uses Task.WaitAsync(linked CT) so the timeout timer is disposed when
+// drain wins (no orphan Task.Delay leak).
+//
+// fault contract: the tracked TCS always TrySetResult, even if the inner work threw —
+// snapshot tasks are log-only by design (callers handle their own exceptions before
+// they leave the Run delegate). StopAsync awaits Task.WhenAll(snapshot).WaitAsync(ct)
+// for cancellation, not fault observation; the WhenAll itself can't fault under this
+// contract.
 public sealed partial class AIUsageDrainHostedService(ILogger<AIUsageDrainHostedService> logger) : IHostedService
 {
     // host drain budget. Azure's deploy graceful-stop budget is ~10s before SIGKILL.
@@ -78,10 +84,12 @@ public sealed partial class AIUsageDrainHostedService(ILogger<AIUsageDrainHosted
 
         // host-driven shutdown CT is already signalled — drain budget is zero. Log
         // honestly rather than misreporting as a 10s timeout (which is what would
-        // happen if we entered the Task.Delay race with a pre-cancelled CT).
+        // happen if we entered the Task.Delay race with a pre-cancelled CT). Count
+        // not-yet-completed snapshot tasks so the report is accurate even if some
+        // finished between the snapshot and this check.
         if (cancellationToken.IsCancellationRequested)
         {
-            LogDrainAborted(snapshot.Length);
+            LogDrainAborted(snapshot.Count(t => !t.IsCompleted));
             return;
         }
 

--- a/HurrahTv.Api/Services/CurationService.cs
+++ b/HurrahTv.Api/Services/CurationService.cs
@@ -19,7 +19,7 @@ public partial class CurationService
     // worst case at a known constant. Process-wide (static) because CurationService
     // is scoped (per-request) and a per-instance semaphore would do nothing.
     //
-    // Two separate gates so a burst of /rows (slow, large token budget) doesn't
+    // two separate gates so a burst of /rows (slow, large token budget) doesn't
     // starve Details-page /match calls (fast, small token budget) behind the same
     // queue. Sized for Haiku throughput at a $50/mo cap: at ~$0.06/curation * 2 +
     // ~$0.005/match * 2 ≈ $0.13 worst-case overshoot, which is the bounded-
@@ -64,7 +64,7 @@ public partial class CurationService
     // ObjectDisposed during host shutdown surfaces in the log rather than as an
     // unobserved Task fault. pins #121.
     //
-    // Dispatched through AIUsageDrainHostedService.Run so the in-flight task is
+    // dispatched through AIUsageDrainHostedService.Run so the in-flight task is
     // registered with the drain BEFORE thread-pool scheduling — closes the SIGTERM
     // race window where a Register-after-Task.Run ordering could let StopAsync
     // snapshot empty between the two calls. Run also bounds the inner write with
@@ -78,6 +78,13 @@ public partial class CurationService
                 using IServiceScope scope = _scopeFactory.CreateScope();
                 DbService scopedDb = scope.ServiceProvider.GetRequiredService<DbService>();
                 await scopedDb.TrackAIUsageAsync(userId, inputTokens, outputTokens, cost, requestType, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // inner-write CT hit the 8s budget — expected during shutdown drain
+                // or under DB contention, not a write failure. Log at Warning so it
+                // doesn't trip error-level alerts on deploy-slot swaps.
+                _logger.LogWarning("Detached AIUsage write cancelled for {UserId} ({RequestType}) — drain budget exceeded", userId, requestType);
             }
             catch (Exception ex)
             {

--- a/HurrahTv.Api/Services/CurationService.cs
+++ b/HurrahTv.Api/Services/CurationService.cs
@@ -12,24 +12,43 @@ public partial class CurationService
     private const decimal InputCostPerToken = 0.0000008m;  // haiku: $0.80/MTok in
     private const decimal OutputCostPerToken = 0.000004m;  // haiku: $4.00/MTok out
 
+    // bound concurrent paid AI inferences so a burst can't overshoot the monthly
+    // budget by more than `(MatchSlots + CurationSlots) * per-call-cost`. The pre-AI
+    // budget check (_db.GetMonthlyAICostAsync) races with detached AIUsage writes
+    // under load, so the gates' purpose isn't perfect accounting — they cap the
+    // worst case at a known constant. Process-wide (static) because CurationService
+    // is scoped (per-request) and a per-instance semaphore would do nothing.
+    //
+    // Two separate gates so a burst of /rows (slow, large token budget) doesn't
+    // starve Details-page /match calls (fast, small token budget) behind the same
+    // queue. Sized for Haiku throughput at a $50/mo cap: at ~$0.06/curation * 2 +
+    // ~$0.005/match * 2 ≈ $0.13 worst-case overshoot, which is the bounded-
+    // eventual-consistency option from #124.
+    private const int MaxConcurrentMatchInferences = 2;
+    private const int MaxConcurrentCurationInferences = 2;
+    private static readonly SemaphoreSlim AiMatchGate = new(MaxConcurrentMatchInferences, MaxConcurrentMatchInferences);
+    private static readonly SemaphoreSlim AiCurationGate = new(MaxConcurrentCurationInferences, MaxConcurrentCurationInferences);
+
     private static readonly JsonSerializerOptions CaseInsensitive = new() { PropertyNameCaseInsensitive = true };
 
     private readonly DbService _db;
     private readonly TmdbService _tmdb;
     private readonly ILogger<CurationService> _logger;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly AIUsageDrainHostedService _drain;
     private readonly string _model;
     private readonly decimal _monthlyBudget;
     private readonly AnthropicClient? _client;
 
     public bool IsEnabled => _client != null;
 
-    public CurationService(IConfiguration config, DbService db, TmdbService tmdb, ILogger<CurationService> logger, IServiceScopeFactory scopeFactory)
+    public CurationService(IConfiguration config, DbService db, TmdbService tmdb, ILogger<CurationService> logger, IServiceScopeFactory scopeFactory, AIUsageDrainHostedService drain)
     {
         _db = db;
         _tmdb = tmdb;
         _logger = logger;
         _scopeFactory = scopeFactory;
+        _drain = drain;
         _model = config["AI:CurationModel"] ?? "claude-haiku-4-5-20251001";
         _monthlyBudget = config.GetValue<decimal>("AI:MonthlyBudgetUsd", 50m);
 
@@ -44,15 +63,21 @@ public partial class CurationService
     // becomes scoped. The try covers _scopeFactory.CreateScope() too so an
     // ObjectDisposed during host shutdown surfaces in the log rather than as an
     // unobserved Task fault. pins #121.
-    public async Task TrackUsageDetachedAsync(string userId, int inputTokens, int outputTokens, decimal cost, string requestType)
+    //
+    // Dispatched through AIUsageDrainHostedService.Run so the in-flight task is
+    // registered with the drain BEFORE thread-pool scheduling — closes the SIGTERM
+    // race window where a Register-after-Task.Run ordering could let StopAsync
+    // snapshot empty between the two calls. Run also bounds the inner write with
+    // an 8s timeout so it can't outlive the drain's 10s deadline. pins #123.
+    public Task TrackUsageDetachedAsync(string userId, int inputTokens, int outputTokens, decimal cost, string requestType)
     {
-        await Task.Run(async () =>
+        return _drain.Run(async ct =>
         {
             try
             {
                 using IServiceScope scope = _scopeFactory.CreateScope();
                 DbService scopedDb = scope.ServiceProvider.GetRequiredService<DbService>();
-                await scopedDb.TrackAIUsageAsync(userId, inputTokens, outputTokens, cost, requestType);
+                await scopedDb.TrackAIUsageAsync(userId, inputTokens, outputTokens, cost, requestType, ct);
             }
             catch (Exception ex)
             {
@@ -61,15 +86,19 @@ public partial class CurationService
         });
     }
 
-    public async Task<CurationResult> GetCuratedRowsAsync(string userId, List<QueueItem> watchlist, List<int> providerIds, bool englishOnly = false)
+    public async Task<CurationResult> GetCuratedRowsAsync(string userId, List<QueueItem> watchlist, List<int> providerIds, bool englishOnly = false, bool forceRefresh = false, CancellationToken cancellationToken = default)
     {
         if (!IsEnabled)
             return new CurationResult { Error = "AI not enabled" };
 
         string currentHash = ComputeWatchlistHash(watchlist);
 
-        // check cache
-        (string? rowsJson, string? watchlistHash)? cached = await _db.GetCurationCacheAsync(userId);
+        // check cache (unless caller forced a refresh — /refresh endpoint passes
+        // forceRefresh=true so the cache check is skipped without first blanking the
+        // cache row. Pre-blanking lost the user's row on mid-flight client cancel.)
+        (string? rowsJson, string? watchlistHash)? cached = forceRefresh
+            ? null
+            : await _db.GetCurationCacheAsync(userId, cancellationToken);
         if (cached != null && cached.Value.watchlistHash == currentHash && cached.Value.rowsJson != null
             && cached.Value.rowsJson != "[]")
         {
@@ -81,7 +110,7 @@ public partial class CurationService
         bool watchlistChanged = cached != null && cached.Value.watchlistHash != currentHash;
 
         // budget check
-        decimal monthlyCost = await _db.GetMonthlyAICostAsync();
+        decimal monthlyCost = await _db.GetMonthlyAICostAsync(cancellationToken);
         if (monthlyCost >= _monthlyBudget)
         {
             _logger.LogWarning("AI monthly budget exceeded: ${Cost:F2} / ${Budget:F2}", monthlyCost, _monthlyBudget);
@@ -96,32 +125,32 @@ public partial class CurationService
             return new CurationResult { Error = "Add a few more shows to your list to unlock AI recommendations" };
 
         // phase 1: gather candidate pool from TMDb (excluding watchlist)
-        List<SearchResult> candidatePool = await GatherCandidatePoolAsync(providerIds, watchlist, englishOnly);
+        List<SearchResult> candidatePool = await GatherCandidatePoolAsync(providerIds, watchlist, englishOnly, cancellationToken);
 
         if (candidatePool.Count < 10)
             return new CurationResult { Error = "Not enough content available right now — try adding more streaming services", CandidateCount = candidatePool.Count };
 
         // phase 2: send candidates + taste profile to AI for curation
-        List<AICuratedRow> rows = await CurateWithAIAsync(userId, signalItems, watchlist, candidatePool);
+        List<AICuratedRow> rows = await CurateWithAIAsync(userId, signalItems, watchlist, candidatePool, cancellationToken);
 
         if (rows.Count == 0)
             return new CurationResult { Error = "Couldn't generate recommendations right now — try again later", CandidateCount = candidatePool.Count };
 
         string rowsJsonStr = JsonSerializer.Serialize(rows);
-        await _db.SetCurationCacheAsync(userId, rowsJsonStr, currentHash);
+        await _db.SetCurationCacheAsync(userId, rowsJsonStr, currentHash, cancellationToken);
 
         return new CurationResult { Rows = rows, FromCache = false, WatchlistChanged = watchlistChanged, CandidateCount = candidatePool.Count };
     }
 
-    private async Task<List<SearchResult>> GatherCandidatePoolAsync(List<int> providerIds, List<QueueItem> watchlist, bool englishOnly)
+    private async Task<List<SearchResult>> GatherCandidatePoolAsync(List<int> providerIds, List<QueueItem> watchlist, bool englishOnly, CancellationToken cancellationToken)
     {
         HashSet<int> watchlistIds = [.. watchlist.Select(i => i.TmdbId)];
 
         // fetch recent TV and movies in parallel across user's services
-        Task<List<SearchResult>> newTv = _tmdb.NewOnServicesAsync(providerIds, "tv", deep: true, englishOnly: englishOnly);
-        Task<List<SearchResult>> newMovies = _tmdb.NewOnServicesAsync(providerIds, "movie", deep: true, englishOnly: englishOnly);
-        Task<List<SearchResult>> popularTv = _tmdb.PopularOnServicesAsync(providerIds, "tv", deep: true, englishOnly: englishOnly);
-        Task<List<SearchResult>> popularMovies = _tmdb.PopularOnServicesAsync(providerIds, "movie", deep: true, englishOnly: englishOnly);
+        Task<List<SearchResult>> newTv = _tmdb.NewOnServicesAsync(providerIds, "tv", deep: true, englishOnly: englishOnly, cancellationToken: cancellationToken);
+        Task<List<SearchResult>> newMovies = _tmdb.NewOnServicesAsync(providerIds, "movie", deep: true, englishOnly: englishOnly, cancellationToken: cancellationToken);
+        Task<List<SearchResult>> popularTv = _tmdb.PopularOnServicesAsync(providerIds, "tv", deep: true, englishOnly: englishOnly, cancellationToken: cancellationToken);
+        Task<List<SearchResult>> popularMovies = _tmdb.PopularOnServicesAsync(providerIds, "movie", deep: true, englishOnly: englishOnly, cancellationToken: cancellationToken);
         await Task.WhenAll(newTv, newMovies, popularTv, popularMovies);
 
         // combine and deduplicate, excluding watchlist items
@@ -137,17 +166,17 @@ public partial class CurationService
         }
 
         // enrich with provider info for shows that don't have it
-        pool = await _tmdb.FilterToUserServicesAsync(pool, providerIds);
+        pool = await _tmdb.FilterToUserServicesAsync(pool, providerIds, cancellationToken);
 
         return pool;
     }
 
     private async Task<List<AICuratedRow>> CurateWithAIAsync(string userId, List<QueueItem> signalItems,
-        List<QueueItem> allItems, List<SearchResult> candidates)
+        List<QueueItem> allItems, List<SearchResult> candidates, CancellationToken cancellationToken)
     {
         string tasteProfile = BuildTasteProfile(signalItems, allItems);
         string candidateList = BuildCandidateList(candidates);
-        string? firstName = await _db.GetUserFirstNameAsync(userId);
+        string? firstName = await _db.GetUserFirstNameAsync(userId, cancellationToken);
         string namedAddress = string.IsNullOrWhiteSpace(firstName) ? "" : $"\nThe user's name is {firstName}. Address them by name in 1-2 of the reasons where it lands naturally — don't force it into every line.\n";
 
         string prompt = $$"""
@@ -179,14 +208,18 @@ public partial class CurationService
             The "id" is the candidate number (# before each show). Order by recommendation strength (best first).
             """;
 
+        await AiCurationGate.WaitAsync(cancellationToken);
         try
         {
+            // forward CT so Home-page navigation aborts the paid AI inference. Same
+            // pattern as GetShowMatchAsync (#117/#122) — /rows is the most expensive
+            // AI path (12-15 picks, larger token budget than /match). pins #126.
             Message response = await _client!.Messages.Create(new MessageCreateParams
             {
                 Model = _model,
                 MaxTokens = 1024,
                 Messages = [new MessageParam { Role = Role.User, Content = prompt }]
-            });
+            }, cancellationToken: cancellationToken);
 
             string text = "";
             if (response.Content.Count > 0 && response.Content[0].TryPickText(out TextBlock? textBlock))
@@ -240,10 +273,20 @@ public partial class CurationService
                 ItemMediaTypes = itemMediaTypes
             }];
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // client navigated away — propagate so endpoint can return 499 instead of
+            // burying as a generic "AI curation failed" log. Mirrors GetShowMatchAsync.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "AI curation failed for {UserId}", userId);
             return [];
+        }
+        finally
+        {
+            AiCurationGate.Release();
         }
     }
 
@@ -311,7 +354,7 @@ public partial class CurationService
         if (signalItems.Count < 2) return null;
 
         // budget check
-        decimal monthlyCost = await _db.GetMonthlyAICostAsync();
+        decimal monthlyCost = await _db.GetMonthlyAICostAsync(cancellationToken);
         if (monthlyCost >= _monthlyBudget) return null;
 
         string tasteProfile = BuildTasteProfile(signalItems, watchlist);
@@ -361,6 +404,7 @@ public partial class CurationService
             {"match":"strong" or "good" or "stretch" or "miss","reason":"Your 1-2 sentence take"}
             """;
 
+        await AiMatchGate.WaitAsync(cancellationToken);
         try
         {
             // forward CT so rapid Details-page navigation aborts the paid AI inference,
@@ -404,6 +448,10 @@ public partial class CurationService
         {
             _logger.LogError(ex, "Show match failed for {UserId}/{TmdbId}", userId, show.TmdbId);
             return null;
+        }
+        finally
+        {
+            AiMatchGate.Release();
         }
     }
 

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -176,7 +176,7 @@ public class DbService(IConfiguration config)
     // queue operations
     public async Task<List<QueueItem>> GetQueueAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
         // canonical status ordering: see HurrahTv.Shared.Models.QueueStatusOrdering.DisplayOrder
         // — Client UI sorts share the same rule via QueueStatusOrdering.SortPriority.
         // ELSE 4 matches DisplayOrder.Count so unknown enum values sort after every known one.
@@ -403,7 +403,7 @@ public class DbService(IConfiguration config)
 
     public async Task UpdateProvidersAsync(int id, string availableOnJson, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
         CommandDefinition cmd = new("""
             UPDATE QueueItems SET
                 AvailableOnJson      = @AvailableOnJson,
@@ -423,7 +423,7 @@ public class DbService(IConfiguration config)
         DateTime? nextEpisodeDate, int? nextEpisodeSeason, int? nextEpisodeNumber,
         CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
         CommandDefinition cmd = new("""
             UPDATE QueueItems SET
                 LatestEpisodeDate   = @Latest,
@@ -451,22 +451,23 @@ public class DbService(IConfiguration config)
     // user preferences (loads services, genres, and settings in parallel)
     public record UserPreferences(List<int> ProviderIds, List<int> GenreIds, bool EnglishOnly);
 
-    public async Task<UserPreferences> GetUserPreferencesAsync(string userId)
+    public async Task<UserPreferences> GetUserPreferencesAsync(string userId, CancellationToken cancellationToken = default)
     {
-        Task<List<int>> providers = GetUserServicesAsync(userId);
-        Task<List<int>> genres = GetUserGenresAsync(userId);
-        Task<UserSettings> settings = GetUserSettingsAsync(userId);
+        Task<List<int>> providers = GetUserServicesAsync(userId, cancellationToken);
+        Task<List<int>> genres = GetUserGenresAsync(userId, cancellationToken);
+        Task<UserSettings> settings = GetUserSettingsAsync(userId, cancellationToken);
         await Task.WhenAll(providers, genres, settings);
         return new UserPreferences(providers.Result, genres.Result, settings.Result.EnglishOnly);
     }
 
     // user services
-    public async Task<List<int>> GetUserServicesAsync(string userId)
+    public async Task<List<int>> GetUserServicesAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        IEnumerable<int> ids = await db.QueryAsync<int>(
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
             "SELECT ProviderId FROM UserServices WHERE UserId = @UserId AND IsActive = TRUE",
-            new { UserId = userId });
+            new { UserId = userId }, cancellationToken: cancellationToken);
+        IEnumerable<int> ids = await db.QueryAsync<int>(cmd);
         return [.. ids];
     }
 
@@ -493,12 +494,13 @@ public class DbService(IConfiguration config)
     }
 
     // user genres
-    public async Task<List<int>> GetUserGenresAsync(string userId)
+    public async Task<List<int>> GetUserGenresAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        IEnumerable<int> ids = await db.QueryAsync<int>(
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
             "SELECT GenreId FROM UserGenres WHERE UserId = @UserId",
-            new { UserId = userId });
+            new { UserId = userId }, cancellationToken: cancellationToken);
+        IEnumerable<int> ids = await db.QueryAsync<int>(cmd);
         return [.. ids];
     }
 
@@ -519,7 +521,7 @@ public class DbService(IConfiguration config)
     // season & episode sentiments
     public async Task<ShowSentiments> GetShowSentimentsAsync(int tmdbId, string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
         CommandDefinition seasonsCmd = new(
             "SELECT TmdbId, SeasonNumber, Sentiment FROM SeasonSentiments WHERE UserId = @UserId AND TmdbId = @TmdbId",
             new { UserId = userId, TmdbId = tmdbId }, cancellationToken: cancellationToken);
@@ -616,22 +618,26 @@ public class DbService(IConfiguration config)
         return userId;
     }
 
-    // ai usage tracking
-    public async Task TrackAIUsageAsync(string userId, int inputTokens, int outputTokens, decimal costUsd, string requestType)
+    // ai usage tracking — CT bounds the write so it can't outlive the drain budget
+    // when invoked through AIUsageDrainHostedService.Run (which passes an 8s
+    // timeout-bounded token). pins follow-up to #123.
+    public async Task TrackAIUsageAsync(string userId, int inputTokens, int outputTokens, decimal costUsd, string requestType, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        await db.ExecuteAsync("""
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new("""
             INSERT INTO AIUsage (UserId, InputTokens, OutputTokens, EstimatedCostUsd, RequestType, CreatedAt)
             VALUES (@UserId, @InputTokens, @OutputTokens, @CostUsd, @RequestType, @CreatedAt)
-            """, new { UserId = userId, InputTokens = inputTokens, OutputTokens = outputTokens, CostUsd = costUsd, RequestType = requestType, CreatedAt = DateTime.UtcNow });
+            """, new { UserId = userId, InputTokens = inputTokens, OutputTokens = outputTokens, CostUsd = costUsd, RequestType = requestType, CreatedAt = DateTime.UtcNow }, cancellationToken: cancellationToken);
+        await db.ExecuteAsync(cmd);
     }
 
-    public async Task<decimal> GetMonthlyAICostAsync()
+    public async Task<decimal> GetMonthlyAICostAsync(CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        return await db.QuerySingleOrDefaultAsync<decimal>(
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
             "SELECT COALESCE(SUM(EstimatedCostUsd), 0) FROM AIUsage WHERE EXTRACT(YEAR FROM CreatedAt) = @Year AND EXTRACT(MONTH FROM CreatedAt) = @Month",
-            new { DateTime.UtcNow.Year, DateTime.UtcNow.Month });
+            new { DateTime.UtcNow.Year, DateTime.UtcNow.Month }, cancellationToken: cancellationToken);
+        return await db.QuerySingleOrDefaultAsync<decimal>(cmd);
     }
 
     public async Task<decimal> GetUserAICostAsync(string userId)
@@ -643,32 +649,35 @@ public class DbService(IConfiguration config)
     }
 
     // curation cache
-    public async Task<(string? rowsJson, string? watchlistHash)?> GetCurationCacheAsync(string userId)
+    public async Task<(string? rowsJson, string? watchlistHash)?> GetCurationCacheAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        (string RowsJson, string WatchlistHash)? row = await db.QuerySingleOrDefaultAsync<(string RowsJson, string WatchlistHash)?>(
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
             "SELECT RowsJson, WatchlistHash FROM CurationCache WHERE UserId = @UserId",
-            new { UserId = userId });
+            new { UserId = userId }, cancellationToken: cancellationToken);
+        (string RowsJson, string WatchlistHash)? row = await db.QuerySingleOrDefaultAsync<(string RowsJson, string WatchlistHash)?>(cmd);
         return row;
     }
 
-    public async Task SetCurationCacheAsync(string userId, string rowsJson, string watchlistHash)
+    public async Task SetCurationCacheAsync(string userId, string rowsJson, string watchlistHash, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        await db.ExecuteAsync("""
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new("""
             INSERT INTO CurationCache (UserId, RowsJson, WatchlistHash, GeneratedAt)
             VALUES (@UserId, @RowsJson, @Hash, NOW())
             ON CONFLICT (UserId) DO UPDATE SET RowsJson = @RowsJson, WatchlistHash = @Hash, GeneratedAt = NOW()
-            """, new { UserId = userId, RowsJson = rowsJson, Hash = watchlistHash });
+            """, new { UserId = userId, RowsJson = rowsJson, Hash = watchlistHash }, cancellationToken: cancellationToken);
+        await db.ExecuteAsync(cmd);
     }
 
     // user settings
-    public async Task<UserSettings> GetUserSettingsAsync(string userId)
+    public async Task<UserSettings> GetUserSettingsAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        UserSettings? settings = await db.QuerySingleOrDefaultAsync<UserSettings>(
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
             "SELECT EnglishOnly, ShowWatching, ShowWantToWatch, ShowFinished, WatchlistSort, MediaType FROM UserSettings WHERE UserId = @UserId",
-            new { UserId = userId });
+            new { UserId = userId }, cancellationToken: cancellationToken);
+        UserSettings? settings = await db.QuerySingleOrDefaultAsync<UserSettings>(cmd);
         return settings ?? new UserSettings();
     }
 
@@ -716,12 +725,13 @@ public class DbService(IConfiguration config)
             new { UserId = userId, TmdbId = tmdbId, Season = season, Episode = episode });
     }
 
-    public async Task<List<WatchedEpisode>> GetWatchedEpisodesAsync(string userId)
+    public async Task<List<WatchedEpisode>> GetWatchedEpisodesAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        IEnumerable<(int TmdbId, int Season, int Episode)> rows = await db.QueryAsync<(int, int, int)>(
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
             "SELECT TmdbId, Season, Episode FROM WatchedEpisodes WHERE UserId = @UserId",
-            new { UserId = userId });
+            new { UserId = userId }, cancellationToken: cancellationToken);
+        IEnumerable<(int TmdbId, int Season, int Episode)> rows = await db.QueryAsync<(int, int, int)>(cmd);
         return [.. rows.Select(r => new WatchedEpisode(r.TmdbId, r.Season, r.Episode))];
     }
 
@@ -772,12 +782,13 @@ public class DbService(IConfiguration config)
     }
 
     // user profile
-    public async Task<string?> GetUserFirstNameAsync(string userId)
+    public async Task<string?> GetUserFirstNameAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using NpgsqlConnection db = await OpenAsync();
-        return await db.QuerySingleOrDefaultAsync<string?>(
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
             "SELECT FirstName FROM Users WHERE Id = @UserId",
-            new { UserId = userId });
+            new { UserId = userId }, cancellationToken: cancellationToken);
+        return await db.QuerySingleOrDefaultAsync<string?>(cmd);
     }
 
     public async Task SetUserFirstNameAsync(string userId, string? firstName)
@@ -972,10 +983,14 @@ public class DbService(IConfiguration config)
         return new AdminOnboardingFunnel(total, withServices, withGenres, withQueue, [.. buckets]);
     }
 
-    private async Task<NpgsqlConnection> OpenAsync()
+    // accepts ct so cancellation aborts connection acquisition (TCP handshake + auth
+    // round-trip) for callers that already abandoned their request. Without this,
+    // OpenAsync runs to completion before the subsequent Dapper command throws OCE,
+    // wasting a pooled connection on a request the caller has given up on. pins #127.
+    private async Task<NpgsqlConnection> OpenAsync(CancellationToken cancellationToken = default)
     {
         NpgsqlConnection conn = new(_connectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(cancellationToken);
         return conn;
     }
 }

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -88,21 +88,21 @@ public class TmdbService
 
     // popular content on user's services (no date filter — best for "trending")
     public async Task<List<SearchResult>> PopularOnServicesAsync(List<int> providerIds, string mediaType = "tv",
-        List<int>? genreIds = null, bool deep = false, bool englishOnly = false) =>
-        await InterleaveByProviderAsync(providerIds, mediaType, genreIds, recentOnly: false, deep: deep, englishOnly: englishOnly);
+        List<int>? genreIds = null, bool deep = false, bool englishOnly = false, CancellationToken cancellationToken = default) =>
+        await InterleaveByProviderAsync(providerIds, mediaType, genreIds, recentOnly: false, deep: deep, englishOnly: englishOnly, cancellationToken: cancellationToken);
 
     // recently released content on user's services (date-filtered — "new this season")
     public async Task<List<SearchResult>> NewOnServicesAsync(List<int> providerIds, string mediaType = "tv",
-        List<int>? genreIds = null, bool deep = false, bool englishOnly = false) =>
-        await InterleaveByProviderAsync(providerIds, mediaType, genreIds, recentOnly: true, deep: deep, englishOnly: englishOnly);
+        List<int>? genreIds = null, bool deep = false, bool englishOnly = false, CancellationToken cancellationToken = default) =>
+        await InterleaveByProviderAsync(providerIds, mediaType, genreIds, recentOnly: true, deep: deep, englishOnly: englishOnly, cancellationToken: cancellationToken);
 
     private async Task<List<SearchResult>> InterleaveByProviderAsync(List<int> providerIds, string mediaType,
-        List<int>? genreIds, bool recentOnly, bool deep = false, bool englishOnly = false)
+        List<int>? genreIds, bool recentOnly, bool deep = false, bool englishOnly = false, CancellationToken cancellationToken = default)
     {
         if (providerIds.Count == 0) return [];
 
         int perProvider = deep ? DeepResultsPerProvider : ResultsPerProvider;
-        Task<List<SearchResult>>[] tasks = [.. providerIds.Select(pid => DiscoverForProviderAsync(pid, mediaType, genreIds, recentOnly, englishOnly))];
+        Task<List<SearchResult>>[] tasks = [.. providerIds.Select(pid => DiscoverForProviderAsync(pid, mediaType, genreIds, recentOnly, englishOnly, cancellationToken))];
         await Task.WhenAll(tasks);
 
         List<SearchResult> interleaved = [];
@@ -120,7 +120,7 @@ public class TmdbService
     }
 
     private async Task<List<SearchResult>> DiscoverForProviderAsync(int providerId, string mediaType,
-        List<int>? genreIds, bool recentOnly, bool englishOnly = false)
+        List<int>? genreIds, bool recentOnly, bool englishOnly = false, CancellationToken cancellationToken = default)
     {
         string genres = genreIds?.Count > 0 ? string.Join("|", genreIds) : "";
         string dateSuffix = recentOnly ? $":{DateTime.UtcNow.AddDays(-NewContentDaysBack):yyyy-MM-dd}" : ":all";
@@ -150,7 +150,7 @@ public class TmdbService
         if (englishOnly)
             url += "&with_original_language=en";
 
-        TmdbPagedResponse<TmdbMultiResult>? response = await GetAsync<TmdbPagedResponse<TmdbMultiResult>>(url);
+        TmdbPagedResponse<TmdbMultiResult>? response = await GetAsync<TmdbPagedResponse<TmdbMultiResult>>(url, cancellationToken);
         if (response == null) return [];
 
         List<SearchResult> results = [.. response.Results.Select(r => { r.MediaType = mediaType; return MapToSearchResult(r); })];
@@ -190,7 +190,7 @@ public class TmdbService
         return [.. enriched.Select(e => e.result)];
     }
 
-    public async Task<List<SearchResult>> FilterToUserServicesAsync(List<SearchResult> results, List<int> providerIds)
+    public async Task<List<SearchResult>> FilterToUserServicesAsync(List<SearchResult> results, List<int> providerIds, CancellationToken cancellationToken = default)
     {
         if (providerIds.Count == 0) return [];
 
@@ -199,7 +199,7 @@ public class TmdbService
         Task<(SearchResult result, List<AvailableService> providers)>[] tasks = [.. results
             .Select(async r =>
             {
-                List<AvailableService> providers = await GetWatchProvidersAsync(r.TmdbId, r.MediaType);
+                List<AvailableService> providers = await GetWatchProvidersAsync(r.TmdbId, r.MediaType, cancellationToken);
                 return (r, providers);
             })];
 
@@ -539,7 +539,17 @@ public class TmdbService
             string json = await response.Content.ReadAsStringAsync(cancellationToken);
             return JsonSerializer.Deserialize<T>(json, JsonOpts);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        // narrow the filter to caller-driven cancellation only: HttpClient.Timeout raises
+        // TaskCanceledException (a subclass of OCE) when its internal CTS fires, which
+        // would otherwise escape `ex is not OperationCanceledException` and propagate
+        // as 500. Same trap as Learnings/oce-rethrow-needs-token-filter.md, one layer
+        // deeper. Caller cancellation rethrows; everything else (timeouts, network,
+        // parse) falls into the null-return path. pins #125.
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             Console.Error.WriteLine($"TMDb API error: {ex.Message}");
             return default;


### PR DESCRIPTION
## Summary
Closes the shutdown / cancellation gaps left after #122, plus the xsimplify follow-ups that surfaced while wiring it up.

- **#127**: `DbService.OpenAsync` accepts `CancellationToken`; threaded through every CT-aware method + the curation-path helpers (`GetUserServices`, `GetUserSettings`, `GetMonthlyAICost`, `GetCurationCache`, etc.) so cancellation aborts connection acquisition, not just the Dapper command.
- **#126**: CT threaded through `GetCuratedRowsAsync` → `GatherCandidatePoolAsync` → `CurateWithAIAsync` and the TMDb discover/filter helpers (mirrors #122 for `/match`). `/api/curation/rows` and `/refresh` forward `HttpContext.RequestAborted` and translate caller-driven OCE to 499.
- **#125**: Tightened `TmdbService.GetAsync` OCE filter to caller-token-only so `HttpClient.Timeout`'s `TaskCanceledException` no longer escapes as 500. Documented against `Learnings/oce-rethrow-needs-token-filter.md`.
- **#124**: Bounded concurrent paid AI inferences via two static `SemaphoreSlim` gates — `AiMatchGate(2)` and `AiCurationGate(2)`. Worst-case overshoot ~$0.13/burst. Two gates (not one shared 3) so `/rows` bursts can't starve `/match` on Details pages.
- **#123**: New `AIUsageDrainHostedService` tracks fire-and-forget AIUsage writes and drains on shutdown. `Run(Func<CT, Task>)` owns the dispatch so the in-flight `TaskCompletionSource` is registered BEFORE thread-pool scheduling — closes the SIGTERM race where `Register`-after-`Task.Run` could let `StopAsync` snapshot empty. Linked CTS + `WaitAsync` so WhenAll fault propagates, the timeout timer is disposed when drain wins, and a pre-cancelled host CT is logged as `LogDrainAborted` (not misreported as a 10s timeout). Inner writes get an 8s timeout so they can't outlive the drain budget.
- **#128**: `/api/queue` accepts CT and threads it to `GetQueueAsync` / `GetWatchedEpisodesAsync` / `GetUserServicesAsync`. `Task.WhenAll` on the three parallel reads so an OCE doesn't strand unobserved Tasks.

### xsimplify fixes (folded in)
- `/api/curation/refresh` no longer pre-blanks the curation cache row — a new `forceRefresh` flag on `GetCuratedRowsAsync` skips the cache check instead. Prevents mid-flight client cancel from locking the user out with an empty cache.
- `DbService.TrackAIUsageAsync` gained a CT param so drain-bounded writes honor the 8s internal timeout.

### Tests
New: `TrackUsageDetached_RowLands_WhenStopAsyncDrainsInFlightWrites` — fires `_ = TrackUsageDetachedAsync(...)` then calls `StopAsync(None)` and asserts the row landed (pins #123's contract).

## Test plan
- [x] `dotnet build HurrahTv.slnx` clean
- [x] `dotnet test HurrahTv.slnx` — 112/112 pass
- [x] `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` clean (the exact command CI runs)
- [ ] Smoke /api/curation/rows + /refresh in dev; navigate away mid-call and confirm 499 with no cache loss
- [ ] Smoke /api/queue cancel mid-request; no `UnobservedTaskException` in logs

Closes #123
Closes #124
Closes #125
Closes #126
Closes #127
Closes #128

Follow-up filed: #129 (move candidate-pool gather inside the curation gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)