### PR TITLE
Capture PWA service-worker + beforeinstallprompt learnings (#15)

### DIFF
--- a/Learnings/beforeinstallprompt-fires-before-wasm-boot.md
+++ b/Learnings/beforeinstallprompt-fires-before-wasm-boot.md
@@ -1,0 +1,78 @@
+# beforeinstallprompt Fires Before WASM Boots — Capture Early, Bridge to Blazor
+
+> **Area:** WASM | UI
+> **Date:** 2026-05-26
+> **Resolves:** mkerchenski/hurrah-tv#15
+
+## Context
+Adding the Android/desktop-Chrome install prompt to the Blazor WASM client. Chrome
+fires a one-shot `beforeinstallprompt` event when it deems the app installable; you
+must `preventDefault()` and stash it to trigger the install later. The `InstallBanner`
+component decides whether to show an Install button.
+
+## Learning
+
+**The event fires too early for any Blazor-side listener to catch it.** Chrome fires
+`beforeinstallprompt` during/shortly after page load — well before the WASM runtime
+downloads and boots, and before a lazily-imported ES module (`js/install.js`) loads.
+A listener registered inside the module, or inside a component's `OnAfterRenderAsync`,
+will miss the event entirely.
+
+**Capture it in an inline `<script>` in `index.html` `<head>`** — the earliest
+execution point — and stash the deferred event on `window`. The lazy module reads it
+later:
+
+```js
+// index.html, inline, before everything
+window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    window.__hurrahInstallPrompt = e;
+    if (window.__hurrahNotifyInstall) window.__hurrahNotifyInstall(); // late-event bridge
+});
+```
+
+**Two timing cases, both must be handled:**
+
+1. **Event already fired before the component mounts** (the common case — WASM boot is
+   slow, so by the time `InstallBanner` reaches `OnAfterRenderAsync(firstRender)` the
+   event is usually already stashed). A simple `canPromptInstall()` check on first
+   render works here.
+2. **Event fires *after* the component mounts** (Chrome's installability heuristics can
+   delay it). A first-render-only check misses this until a full reload. Fix: the
+   component subscribes a `DotNetObjectReference` callback; the module wires
+   `window.__hurrahNotifyInstall` to invoke it (and fires it immediately if the event
+   was already stashed). The same bridge handles Chrome *re-offering* after a declined
+   prompt. Remember `@implements IDisposable` to dispose the `DotNetObjectReference`.
+
+This is the same `DotNetObjectReference` + `[JSInvokable]` pattern the codebase already
+uses for long-press (`LongPressService.AttachAsync`).
+
+**`prompt()` is single-use** — calling it consumes the event, so null the stash after.
+Chrome may emit a fresh `beforeinstallprompt` later if the user didn't install, which
+re-triggers the bridge.
+
+**Testing caveat:** Chrome won't fire a real `beforeinstallprompt` in an automated
+DevTools session (engagement heuristics). Verify the wiring by checking the component
+subscribed (`typeof window.__hurrahNotifyInstall === 'function'`), then *simulate* the
+late event — set `window.__hurrahInstallPrompt` to a fake `{prompt(){}, userChoice}` and
+call `window.__hurrahNotifyInstall()` — and assert the Install banner appears with no
+reload.
+
+## Example
+```csharp
+// InstallBanner.razor — subscribe once, react to late events
+protected override async Task OnAfterRenderAsync(bool firstRender)
+{
+    if (!firstRender) return;
+    if (await InstallSvc.ShouldShowAsync()) { _variant = Variant.Ios; StateHasChanged(); return; } // iOS: no event
+    _selfRef = DotNetObjectReference.Create(this);
+    await InstallSvc.OnInstallAvailableAsync(_selfRef); // fires now if stashed, and on future events
+}
+
+[JSInvokable]
+public async Task OnInstallAvailable()
+{
+    if (_variant != Variant.None) return;
+    if (await InstallSvc.CanPromptInstallAsync()) { _variant = Variant.Install; await InvokeAsync(StateHasChanged); }
+}
+```

--- a/Learnings/service-worker-coexists-with-version-update-flow.md
+++ b/Learnings/service-worker-coexists-with-version-update-flow.md
@@ -1,0 +1,78 @@
+# Service Worker Must Not Fight the Existing Version/Update Flow
+
+> **Area:** WASM | Deployment
+> **Date:** 2026-05-26
+> **Resolves:** mkerchenski/hurrah-tv#15
+
+## Context
+Adding a PWA service worker to a Blazor WASM app that *already* had a working
+update mechanism: `UpdateBanner.razor` polls `/api/version` (via `js/version.js`)
+and hard-reloads with `Nav.NavigateTo(uri, forceLoad: true)` when the deployed
+version changes. CI also stamps a short SHA as `BuildVersion` and cache-busts CSS
+with `?v=SHA`. A naive cache-first SW would have silently broken all of this.
+
+## Learning
+
+A service worker layered onto an app with an existing update flow is a
+*coexistence* problem, not a greenfield one. The rules that kept our update flow
+working:
+
+1. **Navigations + `appsettings.json` are network-first, not cache-first.**
+   `forceLoad: true` issues a real navigation that the SW's `fetch` handler
+   *does* intercept (forceLoad bypasses Blazor's router, not the SW). Network-first
+   means the reload lands on fresh `index.html` → fresh fingerprinted `_framework/*`
+   (cache-miss → refetch). `appsettings.json` must also be network-first because it
+   carries `BuildVersion`, which drives the `?v=` cache-bust for lazy JS module
+   imports — a stale copy pins old modules.
+
+2. **Hand-roll the SW; do NOT use Blazor's `service-worker.published.js` +
+   `service-worker-assets.js` integrity manifest.** That approach gatekeeps app
+   *boot* on every asset hash matching the manifest. A partial deploy, or the CI
+   `sed` that rewrites `index.html` after the manifest is generated, produces an
+   integrity mismatch → app won't boot. We already had content-fingerprinting and
+   `?v=` busting, so a minimal network-first SW is strictly safer.
+
+3. **Key the cache name to `BuildVersion`** (`hurrah-cache-<sha>`, stamped in CI
+   like the CSS bust). `activate` deletes old caches → automatic per-deploy
+   cleanup, no manifest. Scope the cleanup to your own prefix
+   (`k.startsWith('hurrah-cache-')`) so you don't wipe CacheStorage owned by other
+   features.
+
+4. **SW activates silently** (`skipWaiting()` + `clients.claim()`) and does NOT
+   post an "update available" message. `version.js`/`UpdateBanner` stays the sole
+   update prompt — otherwise you double-prompt.
+
+5. **Serve `service-worker.js` with `no-cache`, and check that branch BEFORE the
+   `?v=` immutable branch** in the Api's `OnPrepareResponse`. Otherwise a future
+   fingerprinted SW URL would be pinned `immutable` for a year, defeating updates.
+
+6. **Tie cache writes to `event.waitUntil(...)`.** A fire-and-forget
+   `caches.open().then(put)` can be dropped if the SW is terminated between
+   microtasks. Pass the `FetchEvent` into the helper and `waitUntil` the put.
+
+7. **`/api/*` is network-only** (return without `respondWith`) — never cache
+   per-user mutable data.
+
+## Verifying locally
+SW registration is deliberately skipped on `localhost` (so `dotnet watch`
+hot-reload isn't intercepted), which also blocks local PWA testing. To verify:
+publish Release, assemble the client wwwroot into the Api output (as CI does),
+relax the localhost guard *in the throwaway artifact only*, serve over
+`http://localhost` (a secure context, so the SW registers), then drive Chrome
+DevTools — `emulate` network=Offline + reload proves the shell boots from cache.
+`navigator.onLine` stays `true` under CDP offline emulation (known quirk) — judge
+offline success by the app rendering, not that flag.
+
+## Example
+```js
+// fetch routing that preserves the update flow
+if (url.pathname.startsWith('/api/')) return;            // network-only
+if (req.mode === 'navigate') { respondWith(networkFirst(event, req, OFFLINE_SHELL)); return; }
+if (url.pathname === '/appsettings.json') { respondWith(networkFirst(event, req, req)); return; }
+respondWith(cacheFirst(event, req));                     // fingerprinted/static
+```
+```csharp
+// Program.cs — SW no-cache MUST precede the ?v= immutable branch
+if (path.EndsWith("service-worker.js")) CacheControl = "no-cache";
+else if (Query.ContainsKey("v"))        CacheControl = "public, max-age=31536000, immutable";
+```


### PR DESCRIPTION
## Summary

Two engineering learnings captured from the PWA work in #136 (`/compound`):

- `Learnings/service-worker-coexists-with-version-update-flow.md` — why the SW is hand-rolled network-first, how it avoids fighting the existing `UpdateBanner`/`/api/version` flow, BuildVersion-keyed cache naming, the `no-cache` vs `?v=` header ordering, `event.waitUntil` for cache writes, and the local-verification technique.
- `Learnings/beforeinstallprompt-fires-before-wasm-boot.md` — the event fires before the WASM runtime boots, so it must be captured in an inline `index.html` script and bridged to Blazor via a JS→.NET callback for late events.

Both cross-reference `Resolves: #15` and avoid overlap with the existing `ios-home-screen-pwa.md`.

Docs-only; no code changes.