### PR TITLE
Don't hide queued shows with unknown provider data from Home

### DIFF
--- a/.claude/skills/compound/skill.md
+++ b/.claude/skills/compound/skill.md
@@ -69,6 +69,6 @@ Present a table of what was captured:
 
 ## Rules
 - One learning per file, named descriptively
-- Learnings/ is gitignored — local knowledge base
+- Learnings/ is tracked in git (per CLAUDE.md) — commit new learning files; prefer a standalone branch/PR (e.g. `learnings/<topic>`, matching #137) but committing alongside the work that surfaced them is fine
 - Don't duplicate what's derivable from reading current code
 - Focus on the *why*, not the *what*

--- a/HurrahTv.Api/Endpoints/QueueEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/QueueEndpoints.cs
@@ -200,6 +200,9 @@ public static class QueueEndpoints
         }
     }
 
+    // canonical pair: HurrahTv.Shared QueueItemExtensions.IsStreamableOn mirrors this for the
+    // client Home filter. keep the two in lockstep — empty/unknown providers must "don't hide",
+    // and a match is plain service-id membership (no StreamingService.ById registry gate).
     private static bool IsWatchableOn(string availableOnJson, HashSet<int> activeServiceIds)
     {
         if (string.IsNullOrWhiteSpace(availableOnJson) || availableOnJson == "[]")

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -511,6 +511,9 @@ else
     {
         IEnumerable<QueueItem> scoped = _items
             .Where(i => MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType)
+            // deliberate asymmetry vs QueueItemExtensions.IsStreamableOn / IsWatchableOn: an
+            // explicit service chip HIDES empty-provider items (it asks "is this on THIS
+            // service"), unlike the Home filter which keeps unknown-provider items visible.
             .Where(i => _selectedServiceId is not int svcId || _itemProviderIds.GetValueOrDefault(i.Id)?.Contains(svcId) == true);
         List<QueueItem> scopedList = [.. scoped];
         _totalCount = scopedList.Count;

--- a/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
@@ -123,6 +123,17 @@ public class QueueItemExtensionsTests
         Assert.True(item.IsStreamableOn([8]));
     }
 
+    // a provider id the StreamingService registry doesn't know (999) is still streamable if
+    // the user subscribes to it — IsStreamableOn matches on plain membership, exactly like the
+    // API's IsWatchableOn (no ById gate). Contrast VisibleServicesFor below, which DOES skip
+    // unknown ids because it renders logos. pins the client/API alignment for #141.
+    [Fact]
+    public void IsStreamableOn_ProviderInUserServices_NotInRegistry_ReturnsTrue()
+    {
+        QueueItem item = new() { AvailableOnJson = "[999]" };
+        Assert.True(item.IsStreamableOn([999]));
+    }
+
     // a title with KNOWN providers that don't intersect the user's services is still
     // hidden — that's the filter's purpose; only the empty/unknown case changed for #141.
     [Fact]
@@ -132,6 +143,9 @@ public class QueueItemExtensionsTests
         Assert.False(item.IsStreamableOn([8]));
     }
 
+    // pins guard ordering: empty AvailableOnJson would hit the "unknown — don't hide" path,
+    // but the empty-userServices guard runs FIRST and returns false. if the two guards were
+    // swapped, a user with no services would see unknown-provider items leak through.
     [Fact]
     public void IsStreamableOn_NoUserServices_ReturnsFalse()
     {

--- a/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
@@ -99,6 +99,46 @@ public class QueueItemExtensionsTests
         Assert.Empty(item.ParseAvailableOnProviderIds());
     }
 
+    // #141: a title with no stored provider data is "unknown — don't hide", mirroring the
+    // API's IsWatchableOn — otherwise a queued show whose providers TMDb hasn't surfaced
+    // yet vanishes from the Home watchlist rows.
+    [Fact]
+    public void IsStreamableOn_EmptyProviderData_ReturnsTrue()
+    {
+        QueueItem item = new() { AvailableOnJson = "[]" };
+        Assert.True(item.IsStreamableOn([8]));
+    }
+
+    [Fact]
+    public void IsStreamableOn_MalformedProviderData_ReturnsTrue()
+    {
+        QueueItem item = new() { AvailableOnJson = "not json" };
+        Assert.True(item.IsStreamableOn([8]));
+    }
+
+    [Fact]
+    public void IsStreamableOn_ProviderInUserServices_ReturnsTrue()
+    {
+        QueueItem item = new() { AvailableOnJson = "[8,15]" };
+        Assert.True(item.IsStreamableOn([8]));
+    }
+
+    // a title with KNOWN providers that don't intersect the user's services is still
+    // hidden — that's the filter's purpose; only the empty/unknown case changed for #141.
+    [Fact]
+    public void IsStreamableOn_KnownProvider_NotInUserServices_ReturnsFalse()
+    {
+        QueueItem item = new() { AvailableOnJson = "[15]" };
+        Assert.False(item.IsStreamableOn([8]));
+    }
+
+    [Fact]
+    public void IsStreamableOn_NoUserServices_ReturnsFalse()
+    {
+        QueueItem item = new() { AvailableOnJson = "[]" };
+        Assert.False(item.IsStreamableOn([]));
+    }
+
     [Fact]
     public void VisibleServicesFor_EmptyUserServices_ReturnsEmpty()
     {

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -57,6 +57,20 @@ public class WatchlistFiltersTests
     }
 
     [Fact]
+    public void AvailableNow_Includes_Watching_Item_With_No_ProviderData()
+    {
+        // pins #141 — a Watching show whose providers TMDb hasn't surfaced (empty
+        // AvailableOnJson) used to be dropped from both Home rows by the streamability
+        // gate. "Unknown providers" must be treated as "don't hide", matching the API.
+        QueueItem item = TvItem(status: QueueStatus.Watching, latestEpisode: Today.AddDays(-1));
+        item.AvailableOnJson = "[]";
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableNow);
+    }
+
+    [Fact]
     public void AvailableNow_Excludes_TvItem_With_LatestEpisodeDate_In_Future()
     {
         // regression: the old predicate `DaysSinceLatestEpisode is <= 7` would silently

--- a/HurrahTv.Shared/Models/QueueItemExtensions.cs
+++ b/HurrahTv.Shared/Models/QueueItemExtensions.cs
@@ -26,12 +26,17 @@ public static class QueueItemExtensions
     public static int? DaysSinceLatestEpisode(this QueueItem item, DateTime todayUtc) =>
         item.LatestEpisodeDate is { } d ? (int)(todayUtc.Date - d.Date).TotalDays : null;
 
-    // boolean form of VisibleServicesFor — short-circuits on first match without allocating
-    // a result list. Use in filter predicates where only "streamable y/n" matters.
+    // streamable y/n for the Home watchlist filter. Mirrors the API's IsWatchableOn
+    // (QueueEndpoints): a title with no stored provider data is "unknown — don't hide",
+    // not "not streamable". Otherwise a queued show whose providers TMDb/JustWatch hasn't
+    // surfaced (common for daily network shows) silently vanishes from the Home rows even
+    // though it shows on the Queue page (#141).
     public static bool IsStreamableOn(this QueueItem item, IReadOnlyList<int> userServices)
     {
         if (userServices.Count == 0) return false;
-        foreach (int id in item.ParseAvailableOnProviderIds())
+        List<int> providerIds = item.ParseAvailableOnProviderIds();
+        if (providerIds.Count == 0) return true; // unknown providers — don't hide
+        foreach (int id in providerIds)
         {
             if (userServices.Contains(id) && StreamingService.ById.ContainsKey(id))
                 return true;

--- a/HurrahTv.Shared/Models/QueueItemExtensions.cs
+++ b/HurrahTv.Shared/Models/QueueItemExtensions.cs
@@ -26,19 +26,21 @@ public static class QueueItemExtensions
     public static int? DaysSinceLatestEpisode(this QueueItem item, DateTime todayUtc) =>
         item.LatestEpisodeDate is { } d ? (int)(todayUtc.Date - d.Date).TotalDays : null;
 
-    // streamable y/n for the Home watchlist filter. Mirrors the API's IsWatchableOn
-    // (QueueEndpoints): a title with no stored provider data is "unknown — don't hide",
-    // not "not streamable". Otherwise a queued show whose providers TMDb/JustWatch hasn't
-    // surfaced (common for daily network shows) silently vanishes from the Home rows even
-    // though it shows on the Queue page (#141).
+    // streamable y/n for the Home watchlist filter — mirrors the API's IsWatchableOn
+    // (QueueEndpoints) exactly: empty/unknown provider data is "don't hide" (#141), and a
+    // match is plain service-id membership. NOT the same rule as the Queue page's
+    // per-service chip filter, which hides empty-provider items because it answers a
+    // narrower question ("is this demonstrably on THIS service" — see Queue.razor).
     public static bool IsStreamableOn(this QueueItem item, IReadOnlyList<int> userServices)
     {
-        if (userServices.Count == 0) return false;
+        if (userServices.Count == 0) return false; // guard order matters: must precede the empty-providers check below
         List<int> providerIds = item.ParseAvailableOnProviderIds();
         if (providerIds.Count == 0) return true; // unknown providers — don't hide
         foreach (int id in providerIds)
         {
-            if (userServices.Contains(id) && StreamingService.ById.ContainsKey(id))
+            // membership only — no StreamingService.ById gate, matching IsWatchableOn. a
+            // provider the registry doesn't know is still streamable if the user has it.
+            if (userServices.Contains(id))
                 return true;
         }
         return false;

--- a/Learnings/dotnet-watch-locks-shared-dll.md
+++ b/Learnings/dotnet-watch-locks-shared-dll.md
@@ -1,0 +1,41 @@
+# A Running `dotnet watch` Locks Shared.dll — Stop Dev Servers Before `dotnet test`
+
+> **Area:** Deployment
+> **Date:** 2026-05-27
+
+## Context
+
+While iterating on PR #142 on Windows, both dev servers were running via
+`dotnet watch` (the CLAUDE.md "Running Locally" flow). A `dotnet test HurrahTv.slnx`
+issued in parallel failed the rebuild with:
+
+```
+error MSB3027: Could not copy "...\HurrahTv.Shared\bin\Debug\net10.0\HurrahTv.Shared.dll"
+to "bin\Debug\net10.0\HurrahTv.Shared.dll". Exceeded retry count of 10. Failed.
+The file is locked by: "HurrahTv.Api (31600)"
+```
+
+The test projects that had already built passed; only the projects whose output
+the running app holds open failed to copy.
+
+## Learning
+
+On Windows, the live `HurrahTv.Api` (and `HurrahTv.Client`) host process started by
+`dotnet watch` keeps `HurrahTv.Shared.dll` open. A concurrent full-solution build or
+`dotnet test` can't overwrite that DLL, so MSBuild retries and then fails with
+MSB3027/MSB3021 — a **file lock, not a compile error**. `dotnet watch` will have
+already hot-reloaded the source change into the running process, which is why the
+app behaves correctly even though the out-of-band build fails.
+
+Before running `dotnet test` / `dotnet build` against the whole solution on Windows,
+stop the dev servers. One-liner to kill just this repo's watch + host processes:
+
+```powershell
+Get-CimInstance Win32_Process -Filter "Name='dotnet.exe' OR Name='HurrahTv.Api.exe' OR Name='HurrahTv.Client.exe'" |
+  Where-Object { $_.CommandLine -match 'HurrahTv|dotnet-watch' } |
+  ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+```
+
+This is platform-specific: on macOS/Linux the loader doesn't hold an exclusive
+write lock, so the same parallel `dotnet test` generally succeeds. The symptom is
+Windows-only, which is why it isn't in the (cross-platform) CLAUDE.md test notes.

--- a/Learnings/predicate-alignment-truth-table.md
+++ b/Learnings/predicate-alignment-truth-table.md
@@ -1,0 +1,74 @@
+# Aligning Predicates: Use a Truth Table, and Don't Trust Copied Guards
+
+> **Area:** Data
+> **Date:** 2026-05-27
+> **Resolves:** mkerchenski/hurrah-tv#141
+
+## Context
+
+#141 was a client/API divergence: the Home watchlist filter (`IsStreamableOn`,
+`HurrahTv.Shared/Models/QueueItemExtensions.cs`) hid queued shows whose
+`AvailableOnJson` was empty, while the API queue read (`IsWatchableOn`,
+`HurrahTv.Api/Endpoints/QueueEndpoints.cs`) kept them ("unknown providers — don't
+hide"). The fix made the empty case match and shipped with tests.
+
+A follow-up `/xreview` then ran a full truth table comparing the two predicates
+across *every* input category, not just the reported one. It found a **second,
+independent divergence** that the empty-case fix left untouched: the client gated
+each provider match on `&& StreamingService.ById.ContainsKey(id)`, which the API
+never did. A provider id present in both the user's services and an item's
+`AvailableOnJson` but absent from the hardcoded `ById` registry (e.g. a TMDb
+provider outside our eight) would be kept by the API and hidden by the client —
+the *same class of bug* #141 was filed to fix, hiding in the same method.
+
+## Learning
+
+Two things that aren't obvious until a divergence bites twice:
+
+1. **"Align predicate X to predicate Y" is only finished when a truth table over
+   every input category agrees.** The reported symptom (empty providers) is one
+   row of that table. Enumerate the rest — null, malformed, known-match,
+   known-no-match, empty-collection, and *out-of-registry* — and check each pair.
+   The cheap audit for an intra-language alignment is the truth table; for the
+   cross-*language* case (a SQL `CASE` or Razor condition re-implementing the same
+   rule) see `Learnings/shared-promotion-semantic-audit.md`.
+
+2. **A guard that is correct in one predicate is often wrong when copy-pasted into
+   another that asks a different question of the same data.** The
+   `ById.ContainsKey` guard is *correct* in `VisibleServicesFor` — that method
+   renders service logos, and you can't render a logo for a provider the registry
+   doesn't know. It is *wrong* in `IsStreamableOn` — a visibility predicate, where
+   a show is still streamable on a service the user has even if our registry
+   doesn't list that provider. Same field (`AvailableOnJson`), different question
+   ("which logos?" vs "hide y/n?"), so the guard doesn't transfer. When you see a
+   guard repeated across sibling helpers, ask what question each one answers before
+   assuming it belongs in both.
+
+## Example
+
+The residual divergence and its fix (the empty-case fix from #141 was already in
+place; this is the second alignment):
+
+```csharp
+// before — borrowed from VisibleServicesFor, wrong here:
+if (userServices.Contains(id) && StreamingService.ById.ContainsKey(id))
+    return true;
+
+// after — plain membership, matching the API's IsWatchableOn:
+if (userServices.Contains(id))
+    return true;
+```
+
+Truth table that proved the alignment complete (non-empty userServices unless noted):
+
+| AvailableOnJson | userServices | API IsWatchableOn | Client IsStreamableOn (after) |
+|---|---|---|---|
+| `null` / `""` / `"[]"` / malformed | any | true | true |
+| `[8]` (known) | `[8]` | true | true |
+| `[8]` (known) | `[9]` | false | false |
+| `[999]` (out-of-registry) | `[999]` | true | **true** (was false) |
+| any | `[]` | n/a (API skips filter) | false (by-design guard, kept) |
+
+The empty-`userServices` row is a deliberate, documented asymmetry, not a bug — the
+API skips filtering entirely when no services are selected, the client returns
+false, and the only client call site can't reach that state with a non-empty queue.


### PR DESCRIPTION
## Summary
- The Home watchlist filter dropped any TV item with empty `AvailableOnJson` from **both** rows, because `IsStreamableOn` (`HurrahTv.Shared/Models/QueueItemExtensions.cs`) treated "no provider data" as "not streamable" — the opposite of the API's `IsWatchableOn` (`HurrahTv.Api/Endpoints/QueueEndpoints.cs`), which treats unknown providers as "don't hide."
- Result: a daily network show (e.g. Jimmy Kimmel Live!) whose Hulu provider TMDb/JustWatch hadn't surfaced yet would appear on the Queue page but vanish from Home, even when the user subscribes to the service it actually streams on.
- Aligns `IsStreamableOn` with the API: an empty/unknown provider record no longer hides the show. Titles with **known** providers the user doesn't subscribe to stay filtered (unchanged), and the empty-`userServices` edge is preserved.
- Adds a filter-level regression test plus direct `IsStreamableOn` unit coverage (the helper previously had none).

## Note on verification
The change was authored in a remote environment without a .NET SDK (SDK install blocked by network policy), so `dotnet test` and the `dotnet format` gate could not be run locally. CI on this PR is the first full build + test + format run.

## Test plan
- [ ] CI build passes
- [ ] CI test suite passes (`HurrahTv.Shared.Tests` + `HurrahTv.Api.Tests`)
- [ ] CI `Verify formatting` step passes
- [ ] Manual: a Watching show with no provider data (e.g. Jimmy Kimmel Live!) now appears in a Home watchlist row
- [ ] Manual: a show whose only known provider is one you don't subscribe to is still filtered out of Home

Closes #141

https://claude.ai/code/session_01M8YxWuJnqx7BoX2q1DNYRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8YxWuJnqx7BoX2q1DNYRT)_