### PR TITLE
Settings: per-control auto-save, drop the Save button

### DIFF
--- a/HurrahTv.Client.Tests/FieldSaverTests.cs
+++ b/HurrahTv.Client.Tests/FieldSaverTests.cs
@@ -1,0 +1,57 @@
+using HurrahTv.Client.Services;
+
+namespace HurrahTv.Client.Tests;
+
+// FieldSaver runs in single-threaded Blazor WASM. These tests emulate that by driving it inline:
+// debounceMs:0 makes the debounce delay complete synchronously, and gating each save on a
+// TaskCompletionSource (whose continuations run inline on the thread that completes it) keeps every
+// step on the test thread — no real waiting, fully deterministic. Pins the last-write-wins
+// serialization that closes the overlapping-PUT race in #102 / PR #143: saves never overlap, so the
+// server commits them in order even though it doesn't observe request aborts.
+public class FieldSaverTests
+{
+    private static FieldSaver NewSaver() => new(() => Task.CompletedTask, debounceMs: 0);
+
+    [Fact]
+    public void Saves_DoNotOverlap_SecondWaitsForFirstToComplete()
+    {
+        List<int> started = [];
+        TaskCompletionSource gate1 = new();
+        TaskCompletionSource gate2 = new();
+        FieldSaver saver = NewSaver();
+
+        saver.Schedule(async () => { started.Add(1); await gate1.Task; });
+        Assert.Equal(new[] { 1 }, started); // first save starts immediately
+
+        saver.Schedule(async () => { started.Add(2); await gate2.Task; });
+        Assert.Equal(new[] { 1 }, started); // second is queued, not started — one request in flight at a time
+
+        gate1.SetResult();                  // first completes -> the drain runs the queued second
+        Assert.Equal(new[] { 1, 2 }, started);
+
+        saver.Dispose();                    // second left parked on gate2 — abandoned, no background work
+    }
+
+    [Fact]
+    public void RapidChanges_WhileSaving_OnlyTheLatestQueuedRuns()
+    {
+        List<int> started = [];
+        TaskCompletionSource gate1 = new();
+        TaskCompletionSource gate4 = new();
+        FieldSaver saver = NewSaver();
+
+        saver.Schedule(async () => { started.Add(1); await gate1.Task; });
+        Assert.Equal(new[] { 1 }, started);
+
+        // three more changes arrive while #1 is in flight; only the last (#4) should run next
+        saver.Schedule(() => { started.Add(2); return Task.CompletedTask; });
+        saver.Schedule(() => { started.Add(3); return Task.CompletedTask; });
+        saver.Schedule(async () => { started.Add(4); await gate4.Task; });
+        Assert.Equal(new[] { 1 }, started); // still only #1 has started
+
+        gate1.SetResult();
+        Assert.Equal(new[] { 1, 4 }, started); // #2 and #3 were superseded in the queue; last write wins
+
+        saver.Dispose();
+    }
+}

--- a/HurrahTv.Client.Tests/FieldSaverTests.cs
+++ b/HurrahTv.Client.Tests/FieldSaverTests.cs
@@ -54,4 +54,17 @@ public class FieldSaverTests
 
         saver.Dispose();
     }
+
+    [Fact]
+    public void FailedSave_SurfacesFailedState()
+    {
+        FieldSaver saver = NewSaver();
+
+        // a non-success PUT surfaces as a thrown save (see Settings.razor); FieldSaver must show Failed
+        // so the inline "Couldn't save" + Retry affordance appears
+        saver.Schedule(() => Task.FromException(new InvalidOperationException("save failed")));
+        Assert.Equal(FieldSaver.Status.Failed, saver.State);
+
+        saver.Dispose();
+    }
 }

--- a/HurrahTv.Client/Components/SaveIndicator.razor
+++ b/HurrahTv.Client/Components/SaveIndicator.razor
@@ -1,29 +1,26 @@
 @* inline per-control save status for Settings auto-save. Shows nothing while idle,
    a spinner while saving, a brief "Saved", or an inline retry affordance on failure. #102 *@
 
-@if (Saver is not null)
-{
-    <span class="inline-flex items-center gap-1.5 text-sm min-h-[1.25rem]">
-        @if (Saver.State == FieldSaver.Status.Saving)
-        {
-            <span class="w-3.5 h-3.5 border-2 border-gray-500 border-t-transparent rounded-full animate-spin"></span>
-            <span class="text-gray-500">Saving…</span>
-        }
-        else if (Saver.State == FieldSaver.Status.Saved)
-        {
-            <span class="icon-[heroicons--check-circle-solid] w-4 h-4 text-green-400 fade-in"></span>
-            <span class="text-green-400 fade-in">Saved</span>
-        }
-        else if (Saver.State == FieldSaver.Status.Failed)
-        {
-            <span class="icon-[heroicons--exclamation-circle-solid] w-4 h-4 text-red-400"></span>
-            <span class="text-red-400">Couldn't save</span>
-            <button class="text-accent hover:text-accent-light font-medium underline underline-offset-2"
-                    @onclick="() => Saver.Retry()">Retry</button>
-        }
-    </span>
-}
+<span class="inline-flex items-center gap-1.5 text-sm min-h-[1.25rem]" role="status" aria-live="polite">
+    @if (Saver.State == FieldSaver.Status.Saving)
+    {
+        <span class="w-3.5 h-3.5 border-2 border-gray-500 border-t-transparent rounded-full animate-spin" aria-hidden="true"></span>
+        <span class="text-gray-500">Saving…</span>
+    }
+    else if (Saver.State == FieldSaver.Status.Saved)
+    {
+        <span class="icon-[heroicons--check-circle-solid] w-4 h-4 text-green-400 fade-in" aria-hidden="true"></span>
+        <span class="text-green-400 fade-in">Saved</span>
+    }
+    else if (Saver.State == FieldSaver.Status.Failed)
+    {
+        <span class="icon-[heroicons--exclamation-circle-solid] w-4 h-4 text-red-400" aria-hidden="true"></span>
+        <span class="text-red-400">Couldn't save</span>
+        <button class="text-accent hover:text-accent-light font-medium underline underline-offset-2"
+                @onclick="() => Saver.Retry()">Retry</button>
+    }
+</span>
 
 @code {
-    [Parameter, EditorRequired] public FieldSaver? Saver { get; set; }
+    [Parameter, EditorRequired] public FieldSaver Saver { get; set; } = default!;
 }

--- a/HurrahTv.Client/Components/SaveIndicator.razor
+++ b/HurrahTv.Client/Components/SaveIndicator.razor
@@ -1,0 +1,29 @@
+@* inline per-control save status for Settings auto-save. Shows nothing while idle,
+   a spinner while saving, a brief "Saved", or an inline retry affordance on failure. #102 *@
+
+@if (Saver is not null)
+{
+    <span class="inline-flex items-center gap-1.5 text-sm min-h-[1.25rem]">
+        @if (Saver.State == FieldSaver.Status.Saving)
+        {
+            <span class="w-3.5 h-3.5 border-2 border-gray-500 border-t-transparent rounded-full animate-spin"></span>
+            <span class="text-gray-500">Saving…</span>
+        }
+        else if (Saver.State == FieldSaver.Status.Saved)
+        {
+            <span class="icon-[heroicons--check-circle-solid] w-4 h-4 text-green-400 fade-in"></span>
+            <span class="text-green-400 fade-in">Saved</span>
+        }
+        else if (Saver.State == FieldSaver.Status.Failed)
+        {
+            <span class="icon-[heroicons--exclamation-circle-solid] w-4 h-4 text-red-400"></span>
+            <span class="text-red-400">Couldn't save</span>
+            <button class="text-accent hover:text-accent-light font-medium underline underline-offset-2"
+                    @onclick="() => Saver.Retry()">Retry</button>
+        }
+    </span>
+}
+
+@code {
+    [Parameter, EditorRequired] public FieldSaver? Saver { get; set; }
+}

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -148,7 +148,7 @@
         List<int> snapshot = [.. _selectedServices];
         _servicesSaver.Schedule(async () =>
         {
-            await Api.SetUserServicesAsync(snapshot);
+            if (!await Api.SetUserServicesAsync(snapshot)) throw new InvalidOperationException("save failed");
             UserServicesCache.Set(snapshot);
         });
     }
@@ -156,7 +156,10 @@
     private void OnGenresChanged()
     {
         List<int> snapshot = [.. _selectedGenres];
-        _genresSaver.Schedule(() => Api.SetUserGenresAsync(snapshot));
+        _genresSaver.Schedule(async () =>
+        {
+            if (!await Api.SetUserGenresAsync(snapshot)) throw new InvalidOperationException("save failed");
+        });
     }
 
     private void OnEnglishOnlyChanged()
@@ -174,7 +177,10 @@
             WatchlistSort = _settings.WatchlistSort,
             MediaType = _settings.MediaType,
         };
-        _settingsSaver.Schedule(() => Api.SetUserSettingsAsync(snapshot));
+        _settingsSaver.Schedule(async () =>
+        {
+            if (!await Api.SetUserSettingsAsync(snapshot)) throw new InvalidOperationException("save failed");
+        });
     }
 
     private void OnNameChanged()

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -146,9 +146,9 @@
     private void OnServicesChanged()
     {
         List<int> snapshot = [.. _selectedServices];
-        _servicesSaver.Schedule(async ct =>
+        _servicesSaver.Schedule(async () =>
         {
-            await Api.SetUserServicesAsync(snapshot, ct);
+            await Api.SetUserServicesAsync(snapshot);
             UserServicesCache.Set(snapshot);
         });
     }
@@ -156,7 +156,7 @@
     private void OnGenresChanged()
     {
         List<int> snapshot = [.. _selectedGenres];
-        _genresSaver.Schedule(ct => Api.SetUserGenresAsync(snapshot, ct));
+        _genresSaver.Schedule(() => Api.SetUserGenresAsync(snapshot));
     }
 
     private void OnEnglishOnlyChanged()
@@ -174,17 +174,17 @@
             WatchlistSort = _settings.WatchlistSort,
             MediaType = _settings.MediaType,
         };
-        _settingsSaver.Schedule(ct => Api.SetUserSettingsAsync(snapshot, ct));
+        _settingsSaver.Schedule(() => Api.SetUserSettingsAsync(snapshot));
     }
 
     private void OnNameChanged()
     {
         // not snapshotted like the other handlers: each keystroke reschedules the 1.5s debounce,
         // so when this fires _firstName is already the final typed value — reading it live is correct.
-        _nameSaver.Schedule(async ct =>
+        _nameSaver.Schedule(async () =>
         {
             string? trimmed = string.IsNullOrWhiteSpace(_firstName) ? null : _firstName.Trim();
-            AuthResponse? auth = await Api.UpdateProfileAsync(trimmed, ct);
+            AuthResponse? auth = await Api.UpdateProfileAsync(trimmed);
             if (auth is null) throw new InvalidOperationException("profile update failed");
             await TokenService.SetTokenAsync(auth.Token);
             AuthState.NotifyAuthChanged();

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -1,5 +1,6 @@
 @page "/settings"
 @attribute [Authorize]
+@implements IDisposable
 @inject ApiClient Api
 @inject UserServicesCache UserServicesCache
 @inject TokenService TokenService
@@ -13,35 +14,31 @@
     <h1 class="text-xl md:text-2xl font-bold mb-4 md:mb-6">Settings</h1>
 
     <div class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4 md:mb-6">
-        <h2 class="text-lg font-semibold mb-2">Your Name</h2>
+        <div class="flex items-center gap-3 mb-2">
+            <h2 class="text-lg font-semibold">Your Name</h2>
+            <SaveIndicator Saver="_nameSaver" />
+        </div>
         <p class="text-gray-400 text-sm mb-4">Used to personalize your home page and AI recommendations. Optional.</p>
 
         @if (_loaded)
         {
-            <div class="flex items-center gap-3 max-w-md">
-                <input type="text" @bind="_firstName" @bind:event="oninput"
-                       placeholder="First name"
-                       maxlength="50"
-                       class="flex-1 bg-surface-100 border border-surface-200 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent" />
-                <button class="bg-accent hover:bg-accent-light text-white font-semibold px-4 py-2 rounded-lg transition-colors disabled:opacity-40"
-                        @onclick="SaveName" disabled="@_savingName">
-                    @(_savingName ? "..." : "Save")
-                </button>
-                @if (_savedName)
-                {
-                    <span class="text-green-400 text-sm fade-in">Saved!</span>
-                }
-            </div>
+            <input type="text" @bind="_firstName" @bind:event="oninput" @bind:after="OnNameChanged"
+                   placeholder="First name"
+                   maxlength="50"
+                   class="w-full max-w-md bg-surface-100 border border-surface-200 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent" />
         }
     </div>
 
     <div class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4 md:mb-6">
-        <h2 class="text-lg font-semibold mb-2">My Streaming Services</h2>
+        <div class="flex items-center gap-3 mb-2">
+            <h2 class="text-lg font-semibold">My Streaming Services</h2>
+            <SaveIndicator Saver="_servicesSaver" />
+        </div>
         <p class="text-gray-400 text-sm mb-4">Select the services you subscribe to.</p>
 
         @if (_loaded)
         {
-            <ServicePicker @bind-SelectedIds="_selectedServices" />
+            <ServicePicker @bind-SelectedIds="_selectedServices" @bind-SelectedIds:after="OnServicesChanged" />
         }
         else
         {
@@ -50,43 +47,38 @@
     </div>
 
     <div class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4 md:mb-6">
-        <h2 class="text-lg font-semibold mb-2">My Genres</h2>
+        <div class="flex items-center gap-3 mb-2">
+            <h2 class="text-lg font-semibold">My Genres</h2>
+            <SaveIndicator Saver="_genresSaver" />
+        </div>
         <p class="text-gray-400 text-sm mb-4">Pick genres you're interested in. Leave empty to see everything.</p>
 
         @if (_loaded)
         {
-            <GenrePicker @bind-SelectedIds="_selectedGenres" />
+            <GenrePicker @bind-SelectedIds="_selectedGenres" @bind-SelectedIds:after="OnGenresChanged" />
         }
     </div>
 
     <div class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4 md:mb-6">
-        <h2 class="text-lg font-semibold mb-2">Content Filters</h2>
-        <label class="flex items-center gap-3 cursor-pointer">
-            <div class="relative">
-                <input type="checkbox" class="sr-only peer" @bind="_englishOnly" />
-                <div class="w-10 h-6 bg-surface-200 rounded-full peer-checked:bg-accent transition-colors"></div>
-                <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-4"></div>
-            </div>
-            <div>
-                <span class="text-sm text-white">English originals only</span>
-                <p class="text-xs text-gray-500">Hide dubbed and subtitled shows from your feed</p>
-            </div>
-        </label>
-    </div>
-
-    @if (_loaded)
-    {
-        <div class="flex items-center gap-3 mb-4 md:mb-6">
-            <button class="bg-accent hover:bg-accent-light text-white font-semibold px-6 py-2 rounded-lg transition-colors disabled:opacity-40"
-                    @onclick="Save" disabled="@_saving">
-                Save
-            </button>
-            @if (_saved)
-            {
-                <span class="text-green-400 text-sm fade-in">Saved!</span>
-            }
+        <div class="flex items-center gap-3 mb-2">
+            <h2 class="text-lg font-semibold">Content Filters</h2>
+            <SaveIndicator Saver="_settingsSaver" />
         </div>
-    }
+        @if (_loaded)
+        {
+            <label class="flex items-center gap-3 cursor-pointer">
+                <div class="relative">
+                    <input type="checkbox" class="sr-only peer" @bind="_englishOnly" @bind:after="OnEnglishOnlyChanged" />
+                    <div class="w-10 h-6 bg-surface-200 rounded-full peer-checked:bg-accent transition-colors"></div>
+                    <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-4"></div>
+                </div>
+                <div>
+                    <span class="text-sm text-white">English originals only</span>
+                    <p class="text-xs text-gray-500">Hide dubbed and subtitled shows from your feed</p>
+                </div>
+            </label>
+        }
+    </div>
 
     <div class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4 md:mb-6">
         <h2 class="text-lg font-semibold mb-2">Tell a friend</h2>
@@ -108,15 +100,31 @@
 </div>
 
 @code {
+    // debounce windows: pickers/toggles coalesce rapid taps tightly; the name field
+    // waits for a typing pause before persisting.
+    private const int ToggleDebounceMs = 250;
+    private const int NameDebounceMs = 1500;
+
     private List<int> _selectedServices = [];
     private List<int> _selectedGenres = [];
     private bool _englishOnly;
     private string _firstName = "";
     private bool _loaded;
-    private bool _saving;
-    private bool _saved;
-    private bool _savingName;
-    private bool _savedName;
+
+    // one saver per control — each owns its own debounce + inline status. See #102.
+    private FieldSaver _servicesSaver = default!;
+    private FieldSaver _genresSaver = default!;
+    private FieldSaver _settingsSaver = default!;
+    private FieldSaver _nameSaver = default!;
+
+    protected override void OnInitialized()
+    {
+        Func<Task> rerender = () => InvokeAsync(StateHasChanged);
+        _servicesSaver = new FieldSaver(rerender, ToggleDebounceMs);
+        _genresSaver = new FieldSaver(rerender, ToggleDebounceMs);
+        _settingsSaver = new FieldSaver(rerender, ToggleDebounceMs);
+        _nameSaver = new FieldSaver(rerender, NameDebounceMs);
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -133,25 +141,38 @@
         _loaded = true;
     }
 
-    private async Task SaveName()
+    private void OnServicesChanged()
     {
-        if (_savingName) return;
-        _savingName = true;
-        try
+        List<int> snapshot = [.. _selectedServices];
+        _servicesSaver.Schedule(async ct =>
+        {
+            await Api.SetUserServicesAsync(snapshot, ct);
+            UserServicesCache.Set(snapshot);
+        });
+    }
+
+    private void OnGenresChanged()
+    {
+        List<int> snapshot = [.. _selectedGenres];
+        _genresSaver.Schedule(ct => Api.SetUserGenresAsync(snapshot, ct));
+    }
+
+    private void OnEnglishOnlyChanged()
+    {
+        bool value = _englishOnly;
+        _settingsSaver.Schedule(ct => Api.SetUserSettingsAsync(new UserSettings { EnglishOnly = value }, ct));
+    }
+
+    private void OnNameChanged()
+    {
+        _nameSaver.Schedule(async ct =>
         {
             string? trimmed = string.IsNullOrWhiteSpace(_firstName) ? null : _firstName.Trim();
-            AuthResponse? auth = await Api.UpdateProfileAsync(trimmed);
-            if (auth is not null)
-            {
-                await TokenService.SetTokenAsync(auth.Token);
-                AuthState.NotifyAuthChanged();
-            }
-            _savedName = true;
-            StateHasChanged();
-            await Task.Delay(2000);
-            _savedName = false;
-        }
-        finally { _savingName = false; }
+            AuthResponse? auth = await Api.UpdateProfileAsync(trimmed, ct);
+            if (auth is null) throw new InvalidOperationException("profile update failed");
+            await TokenService.SetTokenAsync(auth.Token);
+            AuthState.NotifyAuthChanged();
+        });
     }
 
     private async Task ShareApp()
@@ -170,22 +191,11 @@
         if (notice is not null) _ = Toast.ShowAsync(notice);
     }
 
-    private async Task Save()
+    public void Dispose()
     {
-        if (_saving) return;
-        _saving = true;
-        try
-        {
-            await Task.WhenAll(
-                Api.SetUserServicesAsync(_selectedServices),
-                Api.SetUserGenresAsync(_selectedGenres),
-                Api.SetUserSettingsAsync(new UserSettings { EnglishOnly = _englishOnly }));
-            UserServicesCache.Set(_selectedServices);
-            _saved = true;
-            StateHasChanged();
-            await Task.Delay(2000);
-            _saved = false;
-        }
-        finally { _saving = false; }
+        _servicesSaver?.Dispose();
+        _genresSaver?.Dispose();
+        _settingsSaver?.Dispose();
+        _nameSaver?.Dispose();
     }
 }

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -108,6 +108,7 @@
     private List<int> _selectedServices = [];
     private List<int> _selectedGenres = [];
     private bool _englishOnly;
+    private UserSettings _settings = new();
     private string _firstName = "";
     private bool _loaded;
 
@@ -136,7 +137,8 @@
 
         _selectedServices = servicesTask.Result;
         _selectedGenres = genresTask.Result;
-        _englishOnly = settingsTask.Result.EnglishOnly;
+        _settings = settingsTask.Result;
+        _englishOnly = _settings.EnglishOnly;
         _firstName = profileTask.Result?.FirstName ?? "";
         _loaded = true;
     }
@@ -159,12 +161,26 @@
 
     private void OnEnglishOnlyChanged()
     {
-        bool value = _englishOnly;
-        _settingsSaver.Schedule(ct => Api.SetUserSettingsAsync(new UserSettings { EnglishOnly = value }, ct));
+        // only EnglishOnly is editable here, but the settings PUT upserts the whole row —
+        // carry the other fields (home filters, sort, media type) from the loaded settings so
+        // toggling this doesn't reset them to defaults server-side.
+        _settings.EnglishOnly = _englishOnly;
+        UserSettings snapshot = new()
+        {
+            EnglishOnly = _settings.EnglishOnly,
+            ShowWatching = _settings.ShowWatching,
+            ShowWantToWatch = _settings.ShowWantToWatch,
+            ShowFinished = _settings.ShowFinished,
+            WatchlistSort = _settings.WatchlistSort,
+            MediaType = _settings.MediaType,
+        };
+        _settingsSaver.Schedule(ct => Api.SetUserSettingsAsync(snapshot, ct));
     }
 
     private void OnNameChanged()
     {
+        // not snapshotted like the other handlers: each keystroke reschedules the 1.5s debounce,
+        // so when this fires _firstName is already the final typed value — reading it live is correct.
         _nameSaver.Schedule(async ct =>
         {
             string? trimmed = string.IsNullOrWhiteSpace(_firstName) ? null : _firstName.Trim();

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -183,22 +183,31 @@ public class ApiClient(HttpClient http)
     public async Task<UserSettings> GetUserSettingsAsync(CancellationToken cancellationToken = default) =>
         await _http.GetFromJsonAsync<UserSettings>("api/settings", cancellationToken) ?? new UserSettings();
 
-    public async Task SetUserSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default) =>
-        await _http.PutAsJsonAsync("api/settings", settings, cancellationToken);
+    public async Task<bool> SetUserSettingsAsync(UserSettings settings, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.PutAsJsonAsync("api/settings", settings, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
 
     // user services
     public async Task<List<int>> GetUserServicesAsync(CancellationToken cancellationToken = default) =>
         await _http.GetFromJsonAsync<List<int>>("api/services", cancellationToken) ?? [];
 
-    public async Task SetUserServicesAsync(List<int> providerIds, CancellationToken cancellationToken = default) =>
-        await _http.PutAsJsonAsync("api/services", providerIds, cancellationToken);
+    public async Task<bool> SetUserServicesAsync(List<int> providerIds, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.PutAsJsonAsync("api/services", providerIds, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
 
     // user genres
     public async Task<List<int>> GetUserGenresAsync(CancellationToken cancellationToken = default) =>
         await _http.GetFromJsonAsync<List<int>>("api/genres", cancellationToken) ?? [];
 
-    public async Task SetUserGenresAsync(List<int> genreIds, CancellationToken cancellationToken = default) =>
-        await _http.PutAsJsonAsync("api/genres", genreIds, cancellationToken);
+    public async Task<bool> SetUserGenresAsync(List<int> genreIds, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.PutAsJsonAsync("api/genres", genreIds, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
 
     // profile
     public async Task<UserProfile?> GetProfileAsync(CancellationToken cancellationToken = default) =>

--- a/HurrahTv.Client/Services/FieldSaver.cs
+++ b/HurrahTv.Client/Services/FieldSaver.cs
@@ -12,7 +12,8 @@ public sealed class FieldSaver(Func<Task> stateChanged, int debounceMs = 250) : 
 {
     public enum Status { Idle, Saving, Saved, Failed }
 
-    private static readonly TimeSpan SavedDisplay = TimeSpan.FromMilliseconds(1500);
+    private const int SavedDisplayMs = 1500; // how long "Saved" lingers before fading to Idle
+    private const int SavedPollMs = 100;     // granularity for cutting that linger short when a new change queues
 
     private CancellationTokenSource? _debounceCts;
     private Func<Task>? _pending; // newest debounced save waiting to run; a not-yet-started one is replaced
@@ -82,7 +83,14 @@ public sealed class FieldSaver(Func<Task> stateChanged, int debounceMs = 250) : 
 
                 State = Status.Saved;
                 await Notify();
-                await Task.Delay(SavedDisplay);
+
+                // hold "Saved" briefly, but bail the moment a new change queues so the next save
+                // isn't stuck waiting behind this cosmetic delay
+                for (int elapsed = 0; elapsed < SavedDisplayMs && _pending is null; elapsed += SavedPollMs)
+                {
+                    await Task.Delay(SavedPollMs);
+                }
+
                 if (_pending is null && State == Status.Saved)
                 {
                     State = Status.Idle;
@@ -96,7 +104,10 @@ public sealed class FieldSaver(Func<Task> stateChanged, int debounceMs = 250) : 
     private async Task Notify()
     {
         if (_disposed) return;
-        await stateChanged();
+        // best-effort UI refresh — a renderer disposed mid-flight is the only realistic throw, and
+        // faulting this fire-and-forget task would just be console noise (see PR #143 review)
+        try { await stateChanged(); }
+        catch { }
     }
 
     public void Dispose()

--- a/HurrahTv.Client/Services/FieldSaver.cs
+++ b/HurrahTv.Client/Services/FieldSaver.cs
@@ -1,0 +1,94 @@
+namespace HurrahTv.Client.Services;
+
+// per-control debounced auto-save for Settings. Each control owns one FieldSaver: a
+// change schedules a save after a debounce window (coalescing rapid toggles into one
+// PUT), and a version counter ensures a stale in-flight save can't stamp its result
+// over a newer change — the off→on→off race ends at off. Replaces the page-wide Save
+// button. See #102.
+public sealed class FieldSaver(Func<Task> stateChanged, int debounceMs = 250) : IDisposable
+{
+    public enum Status { Idle, Saving, Saved, Failed }
+
+    private static readonly TimeSpan SavedDisplay = TimeSpan.FromMilliseconds(1500);
+
+    private CancellationTokenSource? _debounceCts;
+    private Func<CancellationToken, Task>? _lastSave;
+    private int _version;
+    private bool _disposed;
+
+    public Status State { get; private set; }
+
+    // schedule (or reschedule) a save. Cancels any pending debounce so only the latest
+    // value within the window fires; a save already past the debounce is cancelled too,
+    // abandoning its now-stale request.
+    public void Schedule(Func<CancellationToken, Task> save) => _ = RunAsync(save, immediate: false);
+
+    // retry re-runs the last save immediately, skipping the debounce.
+    public void Retry()
+    {
+        if (_lastSave is { } save) _ = RunAsync(save, immediate: true);
+    }
+
+    private async Task RunAsync(Func<CancellationToken, Task> save, bool immediate)
+    {
+        _lastSave = save;
+
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        CancellationTokenSource cts = new();
+        _debounceCts = cts;
+        CancellationToken token = cts.Token; // capture before any later Dispose invalidates cts.Token
+
+        if (!immediate)
+        {
+            try { await Task.Delay(debounceMs, token); }
+            catch (OperationCanceledException) { return; }
+        }
+
+        int version = ++_version;
+        State = Status.Saving;
+        await Notify();
+
+        try
+        {
+            await save(token);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            return; // our own cancellation — a newer save superseded this one and owns the state
+        }
+        catch
+        {
+            if (version == _version)
+            {
+                State = Status.Failed;
+                await Notify();
+            }
+            return;
+        }
+
+        if (version != _version) return;
+        State = Status.Saved;
+        await Notify();
+
+        await Task.Delay(SavedDisplay);
+        if (version == _version && State == Status.Saved)
+        {
+            State = Status.Idle;
+            await Notify();
+        }
+    }
+
+    private async Task Notify()
+    {
+        if (_disposed) return;
+        await stateChanged();
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        try { _debounceCts?.Cancel(); } catch (ObjectDisposedException) { }
+        _debounceCts?.Dispose();
+    }
+}

--- a/HurrahTv.Client/Services/FieldSaver.cs
+++ b/HurrahTv.Client/Services/FieldSaver.cs
@@ -71,7 +71,9 @@ public sealed class FieldSaver(Func<Task> stateChanged, int debounceMs = 250) : 
         State = Status.Saved;
         await Notify();
 
-        await Task.Delay(SavedDisplay);
+        try { await Task.Delay(SavedDisplay, token); }
+        catch (OperationCanceledException) { return; } // disposed or superseded during the Saved display
+
         if (version == _version && State == Status.Saved)
         {
             State = Status.Idle;

--- a/HurrahTv.Client/Services/FieldSaver.cs
+++ b/HurrahTv.Client/Services/FieldSaver.cs
@@ -1,10 +1,13 @@
 namespace HurrahTv.Client.Services;
 
-// per-control debounced auto-save for Settings. Each control owns one FieldSaver: a
-// change schedules a save after a debounce window (coalescing rapid toggles into one
-// PUT), and a version counter ensures a stale in-flight save can't stamp its result
-// over a newer change — the off→on→off race ends at off. Replaces the page-wide Save
-// button. See #102.
+// per-control debounced auto-save for Settings. A change debounces (coalescing rapid toggles
+// into one request), then enters a single-slot queue drained by one worker: at most one save is
+// in flight at a time, and a newer change runs only after the current one completes. Because
+// requests never overlap, they reach the server in order — so the off->on->off race ends at off
+// on the server, not just in the UI. This matters because the settings PUTs don't observe request
+// aborts, so cancelling an in-flight request wouldn't stop a slower earlier write from committing
+// after a newer one. Saves therefore run to completion (no per-save cancellation) and the latest
+// queued change always wins. Replaces the page-wide Save button. See #102.
 public sealed class FieldSaver(Func<Task> stateChanged, int debounceMs = 250) : IDisposable
 {
     public enum Status { Idle, Saving, Saved, Failed }
@@ -12,73 +15,82 @@ public sealed class FieldSaver(Func<Task> stateChanged, int debounceMs = 250) : 
     private static readonly TimeSpan SavedDisplay = TimeSpan.FromMilliseconds(1500);
 
     private CancellationTokenSource? _debounceCts;
-    private Func<CancellationToken, Task>? _lastSave;
-    private int _version;
+    private Func<Task>? _pending; // newest debounced save waiting to run; a not-yet-started one is replaced
+    private Func<Task>? _lastSave; // for Retry
+    private bool _draining;
     private bool _disposed;
 
     public Status State { get; private set; }
 
-    // schedule (or reschedule) a save. Cancels any pending debounce so only the latest
-    // value within the window fires; a save already past the debounce is cancelled too,
-    // abandoning its now-stale request.
-    public void Schedule(Func<CancellationToken, Task> save) => _ = RunAsync(save, immediate: false);
+    // schedule a save after the debounce window. rapid calls within the window coalesce — only the
+    // last one runs.
+    public void Schedule(Func<Task> save)
+    {
+        _lastSave = save;
+        _ = DebounceThenQueue(save);
+    }
 
     // retry re-runs the last save immediately, skipping the debounce.
     public void Retry()
     {
-        if (_lastSave is { } save) _ = RunAsync(save, immediate: true);
+        if (_lastSave is { } save) QueueAndDrain(save);
     }
 
-    private async Task RunAsync(Func<CancellationToken, Task> save, bool immediate)
+    private async Task DebounceThenQueue(Func<Task> save)
     {
-        _lastSave = save;
-
         _debounceCts?.Cancel();
         _debounceCts?.Dispose();
         CancellationTokenSource cts = new();
         _debounceCts = cts;
-        CancellationToken token = cts.Token; // capture before any later Dispose invalidates cts.Token
+        try { await Task.Delay(debounceMs, cts.Token); }
+        catch (OperationCanceledException) { return; } // a newer change superseded this one within the window
 
-        if (!immediate)
-        {
-            try { await Task.Delay(debounceMs, token); }
-            catch (OperationCanceledException) { return; }
-        }
+        QueueAndDrain(save);
+    }
 
-        int version = ++_version;
-        State = Status.Saving;
-        await Notify();
+    private void QueueAndDrain(Func<Task> save)
+    {
+        _pending = save; // newest wins; a not-yet-started pending save is dropped
+        _ = Drain();
+    }
 
+    private async Task Drain()
+    {
+        if (_draining) return; // a worker is already running; it will pick up _pending
+        _draining = true;
         try
         {
-            await save(token);
-        }
-        catch (OperationCanceledException) when (token.IsCancellationRequested)
-        {
-            return; // our own cancellation — a newer save superseded this one and owns the state
-        }
-        catch
-        {
-            if (version == _version)
+            while (_pending is { } save)
             {
-                State = Status.Failed;
+                _pending = null;
+                State = Status.Saving;
                 await Notify();
+
+                bool ok;
+                try { await save(); ok = true; }
+                catch { ok = false; }
+
+                if (_pending is not null) continue; // a newer change arrived during the save — run it next
+
+                if (!ok)
+                {
+                    State = Status.Failed;
+                    await Notify();
+                    if (_pending is not null) continue; // newer change arrived during the failed-state notify
+                    return; // surfaced Failed; Retry (or a later change) re-enters the drain
+                }
+
+                State = Status.Saved;
+                await Notify();
+                await Task.Delay(SavedDisplay);
+                if (_pending is null && State == Status.Saved)
+                {
+                    State = Status.Idle;
+                    await Notify();
+                }
             }
-            return;
         }
-
-        if (version != _version) return;
-        State = Status.Saved;
-        await Notify();
-
-        try { await Task.Delay(SavedDisplay, token); }
-        catch (OperationCanceledException) { return; } // disposed or superseded during the Saved display
-
-        if (version == _version && State == Status.Saved)
-        {
-            State = Status.Idle;
-            await Notify();
-        }
+        finally { _draining = false; }
     }
 
     private async Task Notify()

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -498,6 +498,9 @@
   .inline-block {
     display: inline-block;
   }
+  .inline-flex {
+    display: inline-flex;
+  }
   .aspect-\[2\/3\] {
     aspect-ratio: 2/3;
   }
@@ -563,6 +566,9 @@
   }
   .h-full {
     height: 100%;
+  }
+  .min-h-\[1\.25rem\] {
+    min-height: 1.25rem;
   }
   .min-h-screen {
     min-height: 100vh;
@@ -906,6 +912,9 @@
   }
   .border-current {
     border-color: currentcolor;
+  }
+  .border-gray-500 {
+    border-color: var(--color-gray-500);
   }
   .border-gray-600\/30 {
     border-color: color-mix(in srgb, oklch(44.6% 0.03 256.802) 30%, transparent);
@@ -1466,6 +1475,9 @@
   }
   .underline {
     text-decoration-line: underline;
+  }
+  .underline-offset-2 {
+    text-underline-offset: 2px;
   }
   .placeholder-gray-500 {
     &::placeholder {

--- a/Learnings/partial-dto-put-full-row-upsert.md
+++ b/Learnings/partial-dto-put-full-row-upsert.md
@@ -1,0 +1,55 @@
+# A Partial-DTO PUT Against a Full-Row Upsert Silently Resets the Unsent Columns
+
+> **Area:** Data | API | UI
+> **Date:** 2026-05-27
+> **Resolves:** mkerchenski/hurrah-tv#102
+
+## Context
+
+`/settings` only edits one field of `UserSettings` — `EnglishOnly` — so both the old Save button and
+the new auto-save sent `new UserSettings { EnglishOnly = value }`. But `UserSettings` grew five more
+columns over time (`ShowWatching`, `ShowWantToWatch`, `ShowFinished`, `WatchlistSort`, `MediaType`),
+all owned by *other* surfaces (the Home watchlist filters, the MediaType nav tab). And
+`SaveUserSettingsAsync` is a **full-row upsert** (`INSERT … ON CONFLICT DO UPDATE SET` on every
+column). So PUT-ing a partial DTO wrote C# defaults into the five fields the Settings page never
+loaded — silently resetting the user's home filters, sort order, and media-type tab.
+
+The Copilot review and the API-safety reviewer agent both caught it; the local simplify pass and the
+author's manual test did not (you only see it if you've customized one of the *other* surfaces first,
+then touch Settings).
+
+## Learning
+
+When a screen edits a **subset** of a DTO whose API **upserts the whole row**, constructing a fresh
+DTO with only the edited field (`new Dto { OneField = x }`) clobbers every other column with its C#
+default. The mismatch is invisible at the call site — the type is satisfied, it compiles, and it
+round-trips JSON fine. The fix is fetch-mutate-PUT: load the full current row, mutate the one field,
+send all of it back (or carry the loaded values forward in the snapshot).
+
+```csharp
+// BUG: resets the five columns this page never loaded
+Api.SetUserSettingsAsync(new UserSettings { EnglishOnly = value });
+
+// FIX: carry the loaded values forward so only EnglishOnly changes
+_settings.EnglishOnly = value;
+Api.SetUserSettingsAsync(new UserSettings
+{
+    EnglishOnly = _settings.EnglishOnly,
+    ShowWatching = _settings.ShowWatching,   // …and the rest, from the loaded row
+    /* … */
+});
+```
+
+**Auto-save amplifies this class of latent bug.** Under a deliberate Save button the overwrite fired
+once, on an explicit user action — rare and easy to miss in review. Converting to per-control
+auto-save fires it on *every* toggle, turning an occasional footgun into a constant one. When you
+make a save implicit, re-audit what each save actually writes — the blast radius of any pre-existing
+write bug just widened to "every interaction."
+
+The deeper rule (cf. memory *audit every surface new state touches*): a shared persistence shape has
+more owners than the screen in front of you. Before sending it, ask which *other* surfaces write the
+same row, and whether your payload carries their fields intact.
+
+## Related
+- [[orthogonal-data-dimensions]] — when independent settings share one persisted row
+- [[shared-promotion-semantic-audit]] — auditing all consumers/writers of a shared shape

--- a/Learnings/serialize-writes-when-server-ignores-aborts.md
+++ b/Learnings/serialize-writes-when-server-ignores-aborts.md
@@ -1,0 +1,75 @@
+# Last-Write-Wins Needs Client Serialization, Not Cancellation, When the Server Ignores Aborts
+
+> **Area:** WASM | API | Data
+> **Date:** 2026-05-27
+> **Resolves:** mkerchenski/hurrah-tv#102
+
+## Context
+
+The first cut of `/settings` per-control auto-save (PR #143) used a "cancel-and-race" design: a new
+change cancelled the previous request's `CancellationToken` and fired its own. A version counter
+guarded the UI/cache against a stale in-flight result (the [[optimistic-update-version-token]]
+pattern). The Copilot PR review and the API-safety reviewer agent both flagged that this still
+leaves the **server** wrong on rapid changes (off→on→off): the version token only governs what the
+*client* displays.
+
+The settings endpoints (`MapPut` → `SaveUserSettingsAsync`) take no `CancellationToken` and don't
+observe `RequestAborted`. So when the client cancels an in-flight request, the HTTP send aborts but
+the server keeps processing and commits anyway.
+
+## Learning
+
+**Cancelling an in-flight HTTP request does not stop the server from committing it.** If two writes
+to the same row overlap and the server can't be made to honor the abort, an earlier (slower) write
+can commit *after* a newer one — the final persisted state is wrong even though every client-side
+guard (optimistic revert, version token, cache) looks correct.
+
+A version/sequence token solves the *display* race, not the *persistence* race. For ordered writes
+from a single client, the fix is to **serialize**: keep at most one request in flight per logical
+target, and run the next change only after the current one fully completes (response received). Then
+requests reach the server in submission order, so it commits them in order. Pair it with a
+single-slot "newest pending" queue so a burst coalesces to the latest value (last-write-wins)
+instead of replaying every intermediate.
+
+This makes per-request cancellation unnecessary — saves run to completion. That's the right call
+here: aborting wouldn't have stopped the commit anyway, and completing a save the user triggered
+just before navigating away is the desired behavior, not a bug.
+
+Scope check before reaching for the heavier hammer: server-side concurrency control (rowversion /
+ETag, or threading `CancellationToken` into the DB write) is only worth it for genuinely concurrent
+*multi-client* writes to the same row. User settings are edited by one client at a time, so
+client-side serialization is sufficient and keeps the fix out of the API and schema entirely.
+
+## Example
+
+```csharp
+// the queue: newest pending replaces an un-started one; one worker drains it serially
+private void QueueAndDrain(Func<Task> save)
+{
+    _pending = save;        // last write wins
+    _ = Drain();
+}
+
+private async Task Drain()
+{
+    if (_draining) return;  // a worker is already running; it will pick up _pending
+    _draining = true;
+    try
+    {
+        while (_pending is { } save)
+        {
+            _pending = null;
+            try { await save(); } catch { /* surface Failed */ }
+            // a newer change that arrived mid-save is now in _pending → loop runs it next,
+            // strictly after this one's response. requests never overlap.
+        }
+    }
+    finally { _draining = false; }
+}
+```
+
+## Related
+- [[optimistic-update-version-token]] — guards the UI/cache race; this learning covers the
+  server-persistence race it does *not* cover
+- [[fire-and-forget-detached-writes]] — related fire-and-forget save shape
+- [[testing-wasm-async-inline-single-thread]] — how the serialization guarantee is tested

--- a/Learnings/testing-wasm-async-inline-single-thread.md
+++ b/Learnings/testing-wasm-async-inline-single-thread.md
@@ -1,0 +1,74 @@
+# Test Single-Threaded WASM Async Logic by Driving It Inline
+
+> **Area:** WASM | UI
+> **Date:** 2026-05-27
+> **Resolves:** mkerchenski/hurrah-tv#102
+
+## Context
+
+`FieldSaver` (the per-control auto-save coordinator on `/settings`, PR #143) became a
+non-trivial async state machine: debounce → single-slot queue → serial drain, with
+last-write-wins ordering. That ordering guarantee is exactly the kind of subtle logic worth a
+regression test — but it depends on Blazor WASM being single-threaded (see
+[[blazor-wasm-threading-model]]). Running the test on desktop .NET, where `Task` continuations
+hop to the thread pool, would *reintroduce* the very races that can't happen in production: a
+stale read of `_draining` could start a second drain worker and the test would flake (or worse,
+pass while exercising behavior that never occurs in the browser).
+
+The naive fixes are both bad: real `Task.Delay` waits make the test slow and timing-flaky, and
+installing a custom single-threaded `SynchronizationContext` is exactly the shared test-base
+machinery this repo's testing conventions tell us to avoid.
+
+## Learning
+
+You can drive a single-threaded-WASM async component **inline on the test thread** — no waiting,
+no sync-context — by removing every source of a thread hop:
+
+1. **`debounceMs: 0`** — `Task.Delay(0)` returns an already-completed task, so `await`-ing it
+   continues synchronously on the same thread instead of posting to a timer/pool.
+2. **Gate each unit of work on a `TaskCompletionSource`** — a plain TCS (no
+   `RunContinuationsAsynchronously`) runs its continuations *synchronously on the thread that
+   calls `SetResult`*. So when the test thread completes a gate, the component's continuation
+   (and everything it triggers) runs inline on the test thread too.
+
+The result: calling `Schedule(...)` runs the save lambda synchronously up to its first *real*
+pending await (the gate); `gate.SetResult()` resumes it — and the next queued save — inline. The
+whole state machine executes deterministically on one thread, faithfully matching WASM. Assertions
+read shared state with no locks because nothing else is running.
+
+Keep the *terminal* save gated-but-uncompleted so the drain parks at `await save()` and never
+reaches a real delay (e.g. the post-save "Saved" display `Task.Delay(1500)`), which *would* hop.
+Then `Dispose()` and let the parked task be abandoned.
+
+## Example
+
+```csharp
+private static FieldSaver NewSaver() => new(() => Task.CompletedTask, debounceMs: 0);
+
+[Fact]
+public void Saves_DoNotOverlap_SecondWaitsForFirstToComplete()
+{
+    List<int> started = [];
+    TaskCompletionSource gate1 = new();
+    TaskCompletionSource gate2 = new();
+    FieldSaver saver = NewSaver();
+
+    saver.Schedule(async () => { started.Add(1); await gate1.Task; });
+    Assert.Equal(new[] { 1 }, started);      // ran inline up to the gate
+
+    saver.Schedule(async () => { started.Add(2); await gate2.Task; });
+    Assert.Equal(new[] { 1 }, started);      // queued, not started — serialized
+
+    gate1.SetResult();                        // resumes #1, then the drain runs #2 — all inline
+    Assert.Equal(new[] { 1, 2 }, started);
+
+    saver.Dispose();                          // #2 parked on gate2, abandoned; no background work
+}
+```
+
+38 tests, 28 ms, zero flake. The trick only works for logic that *assumes* single-threading — which
+is the point: the test is faithful precisely because it can't tolerate a hop, same as the runtime.
+
+## Related
+- [[blazor-wasm-threading-model]] — why the single-thread assumption is valid in production
+- [[serialize-writes-when-server-ignores-aborts]] — the ordering logic these tests pin


### PR DESCRIPTION
## What
Replace the page-wide **Save** button on `/settings` with inline per-control auto-save — flip a toggle or edit a field and it persists on its own, with an inline status next to each section. Makes `/settings` feel like a modern preferences pane and removes the class of bug where a new control sits below the shared Save and never gets wired in (cf. #100).

## How
- New `FieldSaver` (Client service), one per control: debounces rapid changes into a single PUT (250ms for toggles/pickers, 1.5s idle for the name field). A version counter guards against a stale in-flight save clobbering a newer change — the off→on→off race ends at `off`.
- New `SaveIndicator` component: shows Saving… / Saved / "Couldn't save" + inline **Retry** next to each section heading, replacing the green-text-with-fadeout pattern.
- Cache (`UserServicesCache`) and profile-token updates run only *after* a successful save, so a failed request never leaves stale client state.
- The English-only toggle now renders inside the `_loaded` guard (previously it was outside).

## Acceptance criteria
- [x] English originals only persists immediately (debounced)
- [x] Streaming services persist per change
- [x] Genres persist per change
- [x] Name field auto-saves on 1.5s idle; inline Save button removed
- [x] Shared **Save** button removed
- [x] Single inline "Saved" indicator replaces green-text fadeout
- [x] Failures surface inline at the field with a Retry affordance — not a global toast

## Testing
- Manual: edited/toggled every control, confirmed inline status transitions and persistence across reload.
- `dotnet build HurrahTv.slnx` clean (0 warnings); `dotnet format --verify-no-changes --severity info` clean.
- Aligns with `blazor-wasm-threading-model.md` (single-threaded, `_disposed` guard) and `blazor-wasm-async-event-exceptions.md` (state mutations inside the try) — no tests added: Client UI-adjacent service, verified in-browser per repo convention.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)