### PR TITLE
Mobile drag-reorder: force touch-event tracking (supportPointer:false) (#139)

### DIFF
--- a/HurrahTv.Client/wwwroot/js/sortable.js
+++ b/HurrahTv.Client/wwwroot/js/sortable.js
@@ -11,12 +11,16 @@ export function init(el, dotNetRef, callbackName, options) {
         delay: 0,
         delayOnTouchOnly: true,
         touchStartThreshold: 5,
-        // force the JS fallback drag on every platform. without it SortableJS uses the
-        // native HTML5 drag-and-drop API, which never fires on touch — the row would lift
-        // (chosenClass) but no gap opens and it can't be dropped on mobile. forceFallback makes
-        // mouse and touch share one pointer-driven path, so behavior is identical across both.
-        // pins #139.
+        // mobile drag-reorder needs BOTH of these (#139):
+        //  - forceFallback: skip the native HTML5 drag API (touch never fires it) and use
+        //    SortableJS's own drag, so the row picks up on touch.
+        //  - supportPointer:false: track the drag with touch/mouse events instead of Pointer
+        //    Events. SortableJS defaults to Pointer Events, whose path on mobile often fails to
+        //    fire the drag-over that opens the gap — the row lifts but never slots in and the
+        //    drop reverts. The touch-event path opens the gap. (forceFallback alone doesn't fix
+        //    this; the symptom is identical with it on or off.)
         forceFallback: true,
+        supportPointer: false,
         fallbackTolerance: 5,
         ghostClass: 'sortable-ghost',
         chosenClass: 'sortable-chosen',


### PR DESCRIPTION
Follow-up to #144, which shipped `forceFallback: true` for #139 but didn't actually fix it — on-device the gap still never opens and the drop reverts (same as the original report, with `forceFallback` on or off).

## Root cause
`forceFallback` only chooses native-DnD vs SortableJS's own drag; it doesn't change drag *tracking*. SortableJS defaults to **Pointer Events**, whose path on mobile often fails to fire the drag-over that opens the gap — so SortableJS reports `oldIndex === newIndex` on drop, `onEnd` bails, and the row snaps back. The C# reorder is correct and simply never gets called.

## Fix
`supportPointer: false` forces the touch-event tracking path (kept alongside `forceFallback` — the known-good mobile combo). One-line change in `wwwroot/js/sortable.js`.

## Verification
⚠️ **Not verified on a physical device** — this is the leading, well-documented fix for this exact SortableJS symptom, but it needs an on-device check (iOS Safari + Android Chrome). Intentionally does **not** use a `Closes #139` keyword so the merge won't auto-close the issue; close #139 manually once confirmed working on a real device.

Refs #139