### PR TITLE
Queue: no-callout on rows fixes iOS touch drag-reorder (#139)

### DIFF
--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -109,8 +109,12 @@ else
         <div role="status" aria-live="polite" class="sr-only">@_reorderAnnouncement</div>
         @foreach (QueueItem item in _visibleItems)
         {
+                @* no-callout suppresses iOS Safari's native long-press image callout on the poster <img>;
+                   without it, mid-drag the callout hijacks the touch sequence and SortableJS stops
+                   getting touchmoves → no gap opens → drop reverts. The standalone /dragtest.html
+                   (no <img>) confirmed SortableJS itself is fine on iOS. pins #139. *@
                 <div @key="item.Id" data-item-id="@item.Id"
-                     class="flex items-center gap-3 md:gap-4 bg-surface-50 rounded-lg p-2.5 md:p-3 hover:bg-surface-100 transition-colors group">
+                     class="flex items-center gap-3 md:gap-4 bg-surface-50 rounded-lg p-2.5 md:p-3 hover:bg-surface-100 transition-colors group no-callout">
 
                     @if (_activeTab == WantToWatchTab)
                     {


### PR DESCRIPTION
The /dragtest.html harness (PR #151) reproduced the drag on a real iPhone (Chrome iOS, WebKit) with the **default** config — gap opened, drop committed, reorder succeeded. So SortableJS + iOS + our config are all fine.

The bug is the **Queue row**. Each row contains an `<a>` with a poster `<img>`. iOS Safari's native long-press image preview/callout fires as the finger drags across the image, hijacking the touch sequence so subsequent `touchmove`s never reach SortableJS → no `onMove` → no gap → drop reverts. The standalone has no `<img>`, so it works.

## Fix

Add the existing `no-callout` class (`-webkit-touch-callout:none` + `user-select:none`, already in `Styles/input.css` per `Learnings/ios-image-callout-suppression.md`) to the queue row. One-line change.

## Verification

⚠️ Not verified on hardware yet — leaving `#139` open without a closing keyword; please test on iPhone, and if the gap opens + drop commits, close #139 manually. The diagnostic page (`/dragtest.html`, from #151) is still on main; safe to remove once this is confirmed.

Refs #139