### PR TITLE
HomeHero: stretch the secondary 'More info' button to match the row height

### DIFF
--- a/HurrahTv.Client/Components/HomeHero.razor
+++ b/HurrahTv.Client/Components/HomeHero.razor
@@ -61,7 +61,7 @@
                         @* self-stretch matches the primary button's height even when "More info"
                            text is hidden below the sm: breakpoint (icon-only is ~1-2px shorter
                            than text-bearing buttons, leaving this one visibly short on mobile). *@
-                        <button @onclick="OnSecondary"
+                        <button @onclick="OnSecondary" title="More info" aria-label="More info"
                                 class="bg-surface-100/70 backdrop-blur text-white hover:bg-surface-200/70 font-semibold self-stretch px-4 md:px-6 py-2 md:py-2.5 rounded-lg text-sm md:text-base flex items-center gap-2 transition-colors">
                             <span class="icon-[heroicons--information-circle] w-4 h-4 md:w-5 md:h-5"></span>
                             <span class="hidden sm:inline">More info</span>

--- a/HurrahTv.Client/Components/HomeHero.razor
+++ b/HurrahTv.Client/Components/HomeHero.razor
@@ -58,8 +58,11 @@
                        same URL is redundant — that was #138. *@
                     @if (Item.PrimaryAction != HeroAction.Resume)
                     {
+                        @* self-stretch matches the primary button's height even when "More info"
+                           text is hidden below the sm: breakpoint (icon-only is ~1-2px shorter
+                           than text-bearing buttons, leaving this one visibly short on mobile). *@
                         <button @onclick="OnSecondary"
-                                class="bg-surface-100/70 backdrop-blur text-white hover:bg-surface-200/70 font-semibold px-4 md:px-6 py-2 md:py-2.5 rounded-lg text-sm md:text-base flex items-center gap-2 transition-colors">
+                                class="bg-surface-100/70 backdrop-blur text-white hover:bg-surface-200/70 font-semibold self-stretch px-4 md:px-6 py-2 md:py-2.5 rounded-lg text-sm md:text-base flex items-center gap-2 transition-colors">
                             <span class="icon-[heroicons--information-circle] w-4 h-4 md:w-5 md:h-5"></span>
                             <span class="hidden sm:inline">More info</span>
                         </button>


### PR DESCRIPTION
Tiny visual fix. On mobile the secondary 'More info' text is hidden below `sm:` (`hidden sm:inline`), leaving the button icon-only. Its natural height becomes just `icon + py-2` (~1–2px shorter than the primary 'Add to list' which keeps its text line-height, and the shuffle which already has `self-stretch`). Adding `self-stretch` to the secondary makes all three CTAs share the row's cross-axis height.

No-op above the `sm:` breakpoint (the text is back, so the natural height already matches).