### PR TITLE
Watching-status override for Home Available Now (#145)

### DIFF
--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -277,15 +277,18 @@ public class WatchlistFiltersTests
         Assert.Contains(item, result.AvailableNow);
     }
 
-    // bypass is bounded by the 18h staleness window — a Watching show whose latest
-    // episode aired hours ago (fresh) and is marked watched still respects the gate,
-    // because we have no reason to think TMDb's data is stale yet.
+    // bypass uses calendar-day comparison — a Watching show whose latest known episode
+    // aired today (same calendar date as todayUtc) and is marked watched still respects
+    // the gate, because no plausible new episode exists yet. Pins the lower boundary of
+    // the calendar-day rule. Catches the same-day-trip Copilot flagged on PR #156:
+    // TMDb's air_date is date-only and lands at midnight UTC, so an hour-based threshold
+    // would trip later the same day even though no new episode is out.
     [Fact]
-    public void AvailableNow_Excludes_Watching_Item_With_FreshWatchedLatestEpisode()
+    public void AvailableNow_Excludes_Watching_Item_That_Watched_TodaysEpisode()
     {
         QueueItem item = TvItem(
             status: QueueStatus.Watching,
-            latestEpisode: Today.AddHours(-6),
+            latestEpisode: Today,
             latestWatched: true);
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
@@ -341,32 +344,4 @@ public class WatchlistFiltersTests
         Assert.DoesNotContain(item, result.AvailableLater);
     }
 
-    // pin the exact 18h fence with both sides — `(todayUtc - led).TotalHours > 18`.
-    // 17h must NOT trigger the bypass; 19h MUST. Catches a regression that flips the
-    // operator (>= vs >) or shifts the constant (12, 24, etc.) without updating tests.
-    [Fact]
-    public void AvailableNow_Excludes_Watching_Item_Just_Below_18h_Boundary()
-    {
-        QueueItem item = TvItem(
-            status: QueueStatus.Watching,
-            latestEpisode: Today.AddHours(-17),
-            latestWatched: true);
-        WatchlistFilters.Partition result = WatchlistFilters.Apply(
-            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
-
-        Assert.DoesNotContain(item, result.AvailableNow);
-    }
-
-    [Fact]
-    public void AvailableNow_Includes_Watching_Item_Just_Above_18h_Boundary()
-    {
-        QueueItem item = TvItem(
-            status: QueueStatus.Watching,
-            latestEpisode: Today.AddHours(-19),
-            latestWatched: true);
-        WatchlistFilters.Partition result = WatchlistFilters.Apply(
-            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
-
-        Assert.Contains(item, result.AvailableNow);
-    }
 }

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -340,4 +340,33 @@ public class WatchlistFiltersTests
 
         Assert.DoesNotContain(item, result.AvailableLater);
     }
+
+    // pin the exact 18h fence with both sides — `(todayUtc - led).TotalHours > 18`.
+    // 17h must NOT trigger the bypass; 19h MUST. Catches a regression that flips the
+    // operator (>= vs >) or shifts the constant (12, 24, etc.) without updating tests.
+    [Fact]
+    public void AvailableNow_Excludes_Watching_Item_Just_Below_18h_Boundary()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            latestEpisode: Today.AddHours(-17),
+            latestWatched: true);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableNow);
+    }
+
+    [Fact]
+    public void AvailableNow_Includes_Watching_Item_Just_Above_18h_Boundary()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            latestEpisode: Today.AddHours(-19),
+            latestWatched: true);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableNow);
+    }
 }

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -258,4 +258,86 @@ public class WatchlistFiltersTests
         Assert.True(result.HasTvContent);
         Assert.True(result.HasMovieContent);
     }
+
+    // pins #145 mode B (Kimmel-class) — a Watching daily show with the latest known
+    // episode marked watched and more than 18h stale must STILL appear in Available
+    // Now. The 18h heuristic catches TMDb's episode-data lag: by the time TMDb has
+    // published today's Kimmel, more than 18h have passed since yesterday's marked-
+    // watched episode. Without the override the show is hidden all day.
+    [Fact]
+    public void AvailableNow_Includes_Watching_Item_With_StaleWatchedLatestEpisode_PinsIssue145()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            latestEpisode: Today.AddDays(-1),
+            latestWatched: true);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableNow);
+    }
+
+    // bypass is bounded by the 18h staleness window — a Watching show whose latest
+    // episode aired hours ago (fresh) and is marked watched still respects the gate,
+    // because we have no reason to think TMDb's data is stale yet.
+    [Fact]
+    public void AvailableNow_Excludes_Watching_Item_With_FreshWatchedLatestEpisode()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            latestEpisode: Today.AddHours(-6),
+            latestWatched: true);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableNow);
+    }
+
+    // non-Watching statuses keep the full strict gate — only Watching opts into the
+    // permissive override. A WantToWatch item with the latest episode marked watched
+    // stays hidden regardless of how stale the date is.
+    [Fact]
+    public void AvailableNow_Excludes_NonWatching_Item_With_StaleWatchedLatestEpisode()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.WantToWatch,
+            latestEpisode: Today.AddDays(-3),
+            latestWatched: true);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableNow);
+    }
+
+    // pins #145 mode B — a Watching show whose TMDb providers don't list any of the
+    // user's services must STILL surface in Available Now. TMDb's data quirks for talk
+    // shows (Kimmel on Hulu) and gray-zone content shouldn't hide what the user committed to.
+    [Fact]
+    public void AvailableNow_Includes_Watching_Item_Not_Streamable_On_UserServices_PinsIssue145()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            latestEpisode: Today.AddDays(-1),
+            providerId: Hulu); // user only has Netflix
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableNow);
+    }
+
+    // Available Later is a stronger claim — "available on a user service soon" — so it
+    // retains the strict streamability gate even for Watching items. Mirrors the plan's
+    // decision #4: the override is Available-Now-scoped, not blanket.
+    [Fact]
+    public void AvailableLater_Excludes_Watching_Item_With_NonStreamable_UpcomingEpisode()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            nextEpisode: Today.AddDays(3),
+            providerId: Hulu); // user only has Netflix
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableLater);
+    }
 }

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -259,11 +259,12 @@ public class WatchlistFiltersTests
         Assert.True(result.HasMovieContent);
     }
 
-    // pins #145 mode B (Kimmel-class) — a Watching daily show with the latest known
-    // episode marked watched and more than 18h stale must STILL appear in Available
-    // Now. The 18h heuristic catches TMDb's episode-data lag: by the time TMDb has
-    // published today's Kimmel, more than 18h have passed since yesterday's marked-
-    // watched episode. Without the override the show is hidden all day.
+    // pins #145 mode B (Kimmel-class) — a Watching daily show whose latest known
+    // episode aired on a previous calendar day and is marked watched must STILL
+    // appear in Available Now. Catches TMDb's episode-data lag: by the time TMDb
+    // has published today's Kimmel, the previous episode the user marked watched
+    // is yesterday's calendar date. Without the override the show is hidden all
+    // day until TMDb refreshes.
     [Fact]
     public void AvailableNow_Includes_Watching_Item_With_StaleWatchedLatestEpisode_PinsIssue145()
     {
@@ -324,6 +325,23 @@ public class WatchlistFiltersTests
             providerId: Hulu); // user only has Netflix
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableNow);
+    }
+
+    // pins the empty-userServices boundary: IsStreamableOn returns false when the
+    // user has no configured services (see IsStreamableOn_NoUserServices_ReturnsFalse),
+    // but the Watching override should still surface the item. The user-intent rule
+    // is unconditional — a future refactor that re-checks streamability before the
+    // Watching branch would silently regress this. (Copilot flagged the gap on PR #156.)
+    [Fact]
+    public void AvailableNow_Includes_Watching_Item_When_UserServices_Are_Empty()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            latestEpisode: Today.AddDays(-1));
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, userServices: []);
 
         Assert.Contains(item, result.AvailableNow);
     }

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -54,21 +54,38 @@ public static class WatchlistFilters
 
             if (!isTv) continue;
 
-            // streamability parses AvailableOnJson — keep it inside the single pass so each
-            // item is touched at most once regardless of how many target rows it qualifies for.
-            if (!item.IsStreamableOn(userServices)) continue;
+            // streamability parses AvailableOnJson — compute once and reuse for both rows below.
+            bool isStreamable = item.IsStreamableOn(userServices);
+            bool isWatching = item.Status == QueueStatus.Watching;
 
+            // Available Now: Watching status bypasses the streamability gate (the user committed;
+            // we trust them even when TMDb has no recognized providers — pins #145 mode B for
+            // shows like Kimmel where TMDb doesn't list Hulu). Non-Watching items keep the strict
+            // gate so the row stays "things you can actually watch".
             // chip filter gates AvailableNow (the active watchlist) but not AvailableLater —
             // a new-season premiere on a Finished show should still surface when the Finished
             // chip is off, since "later" is forward-looking and independent of watch state.
-            if (isStatusActive(item.Status)
-                && !item.IsLatestEpisodeWatched
-                && HasAiredOrIsActivelyWatching(item, today))
+            if (isWatching || isStreamable)
             {
-                availableNow.Add(item);
+                // for Watching, bypass IsLatestEpisodeWatched when LatestEpisodeDate is more
+                // than 18h stale — TMDb's episode-data lag hides daily talk shows the day after
+                // the user marks the previous episode watched (#145 mode B). The 6-hour episode
+                // refresh on /api/queue (Phase 3) limits how often this safety net fires.
+                bool overrideLatestWatched = isWatching
+                    && item.LatestEpisodeDate is { } led
+                    && (todayUtc - led).TotalHours > 18;
+
+                if (isStatusActive(item.Status)
+                    && (!item.IsLatestEpisodeWatched || overrideLatestWatched)
+                    && HasAiredOrIsActivelyWatching(item, today))
+                {
+                    availableNow.Add(item);
+                }
             }
 
-            if (item.NextEpisodeDate is { } next && next.Date > today && next.Date <= windowEnd)
+            // Available Later still requires streamability — "available on a user service soon"
+            // is a stronger claim than Available Now's "you've committed to this".
+            if (isStreamable && item.NextEpisodeDate is { } next && next.Date > today && next.Date <= windowEnd)
             {
                 availableLater.Add(item);
             }

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -67,13 +67,16 @@ public static class WatchlistFilters
             // chip is off, since "later" is forward-looking and independent of watch state.
             if (isWatching || isStreamable)
             {
-                // for Watching, bypass IsLatestEpisodeWatched when LatestEpisodeDate is more
-                // than 18h stale — TMDb's episode-data lag hides daily talk shows the day after
-                // the user marks the previous episode watched (#145 mode B). The 12h
-                // LastEpisodeCheckAt refresh on /api/queue limits how often this safety net fires.
+                // for Watching, bypass IsLatestEpisodeWatched once the calendar day has
+                // advanced past LatestEpisodeDate.Date — TMDb's air_date is date-only and
+                // parsed as midnight UTC, so an hour-based threshold could trip the SAME
+                // day the user marked the episode watched and resurface a caught-up show.
+                // Calendar-day comparison fires only when a new episode is plausibly
+                // available (#145 mode B). The 12h LastEpisodeCheckAt refresh on /api/queue
+                // keeps LatestEpisodeDate fresh enough for daily shows TMDb tracks promptly.
                 bool overrideLatestWatched = isWatching
                     && item.LatestEpisodeDate is { } led
-                    && (todayUtc - led).TotalHours > 18;
+                    && led.Date < today;
 
                 if (isStatusActive(item.Status)
                     && (!item.IsLatestEpisodeWatched || overrideLatestWatched)

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -69,8 +69,8 @@ public static class WatchlistFilters
             {
                 // for Watching, bypass IsLatestEpisodeWatched when LatestEpisodeDate is more
                 // than 18h stale — TMDb's episode-data lag hides daily talk shows the day after
-                // the user marks the previous episode watched (#145 mode B). The 6-hour episode
-                // refresh on /api/queue (Phase 3) limits how often this safety net fires.
+                // the user marks the previous episode watched (#145 mode B). The 12h
+                // LastEpisodeCheckAt refresh on /api/queue limits how often this safety net fires.
                 bool overrideLatestWatched = isWatching
                     && item.LatestEpisodeDate is { } led
                     && (todayUtc - led).TotalHours > 18;

--- a/Learnings/tmdb-air-date-is-date-only.md
+++ b/Learnings/tmdb-air-date-is-date-only.md
@@ -1,0 +1,71 @@
+# TMDb `air_date` Is Date-Only and Lands at Midnight UTC
+
+> **Area:** TMDb | Data | Date
+> **Date:** 2026-05-28
+> **Resolves:** mkerchenski/hurrah-tv#145
+
+## Context
+
+During the PR #156 review for the Watching-status override (#145), GitHub Copilot caught a same-day-trip bug in the staleness comparison that none of the four hurrah-tv reviewer agents — or my own pass — surfaced. The original code:
+
+```csharp
+// commit e2a1154 (before the fix):
+bool overrideLatestWatched = isWatching
+    && item.LatestEpisodeDate is { } led
+    && (todayUtc - led).TotalHours > 18;
+```
+
+reads as "bypass the gate if more than 18 wall-clock hours have passed since the episode aired." That mental model is wrong, because TMDb's `air_date` field is **date-only** (`"YYYY-MM-DD"`) and Dapper / `System.Text.Json` deserializes it as midnight UTC of that date.
+
+Concrete failure: user watches today's Kimmel at 10am ET (14:00 UTC). `IsLatestEpisodeWatched = true`. They open Home at 7pm ET (23:00 UTC) **the same day**. The math:
+
+```
+(23:00 UTC today - 00:00 UTC today).TotalHours = 23h
+23 > 18 → bypass fires → caught-up show resurfaces in Available Now
+```
+
+The user just watched today's episode 5 hours ago and TMDb hasn't published anything newer. The row appearing is a regression, not a feature.
+
+## Learning
+
+When doing time math against a TMDb `air_date` (or anything else deserialized from a date-only field), treat it as **date-only semantics**, not a wall-clock timestamp:
+
+1. **Date-only is the correct mental model.** TMDb returns `air_date: "2026-05-28"` with no hour-of-day. Any hour-precision math against it is computing differences from midnight UTC, not from when the episode actually aired (which the API doesn't tell you).
+2. **Prefer calendar-day comparison.** `led.Date < today` reads as its own intent ("a previous calendar day"), no magic number, no hour-of-day surprise. Pairs with the broader typed-comparison principle in [[date-predicates-prefer-typed-comparisons]] — both are about avoiding silent sign/precision drift from comparisons that look correct.
+3. **If hour-precision really is required**, normalize first. If a particular show's airing time matters (e.g., "12 hours after the episode actually aired"), add an assumed airing time to the date: `led.Date.AddHours(20)` to assume an 8pm UTC airing. But this is rarely the right tool — calendar-day rules are usually closer to user intent and don't depend on hidden assumptions.
+
+## Example
+
+The fix in `HurrahTv.Shared/Filters/WatchlistFilters.cs` (PR #156 commit `6b1b3b3`):
+
+```csharp
+// for Watching, bypass IsLatestEpisodeWatched once the calendar day has
+// advanced past LatestEpisodeDate.Date — TMDb's air_date is date-only and
+// parsed as midnight UTC, so an hour-based threshold could trip the SAME
+// day the user marked the episode watched and resurface a caught-up show.
+bool overrideLatestWatched = isWatching
+    && item.LatestEpisodeDate is { } led
+    && led.Date < today;
+```
+
+Where `today = todayUtc.Date` (computed earlier in the method).
+
+## Test boundary the calendar-day rule pins
+
+| Scenario | `led.Date` | `today` | `led.Date < today` | Outcome |
+|---|---|---|---|---|
+| User watched today's episode | today | today | false | gate fires → hidden (correct, no new episode yet) |
+| User watched yesterday's episode | yesterday | today | true | bypass fires → visible (correct, new episode plausibly available) |
+| Weekly show, watched Sunday, today is Monday | Sun | Mon | true | bypass fires → visible (acceptable false-positive per the plan) |
+
+The "today" + "yesterday" pair of tests catches both `<` → `<=` (would let same-day bypass) and `<` → `>` (would block yesterday's bypass) mutations without needing artificial hour boundaries.
+
+## Anti-pattern
+
+Reading TMDb's `air_date` as a wall-clock timestamp — phrases like "the episode aired at X o'clock UTC" or "12 hours after airing" — when the field doesn't contain hour-of-airing information. Any such inference is computed from midnight UTC of the date, not from when the show actually went out. Bugs in this shape are subtle: the code reads sensibly, passes typed-comparison sniff tests, and only fails when the wall-clock hour crosses the chosen threshold *within the same calendar day as the air_date*.
+
+## How to spot it in review
+
+- Any `TimeSpan` subtraction or `TotalHours` / `TotalMinutes` math involving a field sourced from a TMDb date (`air_date`, `release_date`, `first_air_date`, `last_episode_to_air.air_date`, etc.).
+- Hour-based thresholds (`> 18`, `>= 24`) anchored to a date-only field — the threshold likely models a wall-clock relationship that the underlying data can't actually express.
+- Tests that anchor `latestEpisode` to `Today.AddHours(N)` for a fixed-midnight `Today`. These can pass in test while the production scenario (where `todayUtc` is the current moment) crosses the threshold during the same calendar day.

--- a/Learnings/tmdb-providers-empty.md
+++ b/Learnings/tmdb-providers-empty.md
@@ -11,6 +11,7 @@ TMDb's watch provider data (sourced from JustWatch) has significant gaps:
 - **Non-US originals** (Japanese anime, Korean dramas) often have zero US provider data
 - **Very new releases** may not be catalogued yet by JustWatch
 - **Region-exclusive content** on niche platforms may not appear
+- **Live-TV / next-day-VOD content** — late-night talk shows on Hulu (Kimmel, Fallon, Colbert) are silently invisible. JustWatch tracks Hulu's on-demand catalog (`provider_id: 15`) but doesn't surface Hulu's live-TV / next-day overlap, so `watch/providers` returns `{}` for Jimmy Kimmel Live even though users actively watch it on Hulu daily. Verified empirically against `#145` (2026-05-28): `availableonjson = "[]"` even after a fresh refresh.
 - TMDb returns `"results":{}` (empty object) — not a US entry with empty arrays, but literally no region data at all
 
 The provider fetch code must handle this gracefully at every layer:

--- a/Learnings/user-intent-overrides-external-data.md
+++ b/Learnings/user-intent-overrides-external-data.md
@@ -18,7 +18,7 @@ When the user has explicitly committed to something — opted in, said "yes I wa
 
 Concretely, for any filter that gates an active-user surface on external/cached/derived data, ask:
 
-1. **What does the user already told us?** Status flags, subscriptions, dismissals, recent actions.
+1. **What has the user already told us?** Status flags, subscriptions, dismissals, recent actions.
 2. **Is the gate trying to keep noise out, or is it trying to verify a positive claim?** Noise-out is fine for unselected items; positive-verification often misfires on incomplete external data.
 3. **What does the user lose if the gate fires a false negative?** If they lose visibility on something they actively committed to, that's worse than a small amount of noise.
 

--- a/Learnings/user-intent-overrides-external-data.md
+++ b/Learnings/user-intent-overrides-external-data.md
@@ -1,0 +1,72 @@
+# User Intent Should Override External-Data Gates
+
+> **Area:** UI | Data | Design
+> **Date:** 2026-05-28
+> **Resolves:** mkerchenski/hurrah-tv#145
+
+## Context
+
+`WatchlistFilters.Apply` (the canonical Home partition in `HurrahTv.Shared`) used to gate every queue item through `IsStreamableOn(userServices)` regardless of status. That predicate checks the item's parsed `AvailableOnJson` against the user's subscribed providers, with the post-#141 carve-out that empty provider data is "don't hide" rather than "hide".
+
+The carve-out covered the case where TMDb hadn't *yet* populated provider data (stale-refresh window). It didn't cover the case where TMDb *permanently* has nothing (see [[tmdb-providers-empty]] for the four classes). For Kimmel-class shows on Hulu, `availableonjson` is permanently `[]` after a fresh refresh, and a similar `IsLatestEpisodeWatched` gate would hide the show all day after the user marked yesterday's episode watched, because TMDb's episode-data lag meant `LatestEpisodeDate` hadn't yet advanced.
+
+Net effect: a user who'd explicitly added a show to their queue *and* set its status to `Watching` could see it disappear from Home Available Now because two independent external-data signals (provider list, episode date) both came up dry.
+
+## Learning
+
+When the user has explicitly committed to something — opted in, said "yes I want this", flagged active intent — that signal should generally beat external data that contradicts or fails to confirm the commitment. The gates exist to filter *unselected* noise out of a surface; for *selected* items the gates often become false negatives.
+
+Concretely, for any filter that gates an active-user surface on external/cached/derived data, ask:
+
+1. **What does the user already told us?** Status flags, subscriptions, dismissals, recent actions.
+2. **Is the gate trying to keep noise out, or is it trying to verify a positive claim?** Noise-out is fine for unselected items; positive-verification often misfires on incomplete external data.
+3. **What does the user lose if the gate fires a false negative?** If they lose visibility on something they actively committed to, that's worse than a small amount of noise.
+
+Implement the override as a *status-aware bypass* of the gate, not a removal of the gate. Non-active statuses keep the strict rule (the noise filter is still useful there); active statuses bypass it.
+
+## Example
+
+The override in `HurrahTv.Shared/Filters/WatchlistFilters.cs` (post-#145):
+
+```csharp
+bool isStreamable = item.IsStreamableOn(userServices);
+bool isWatching = item.Status == QueueStatus.Watching;
+
+// Available Now: Watching status bypasses the streamability gate entirely.
+// Non-Watching items keep the strict gate so the row stays "things you can
+// actually watch" (the noise filter is still useful for WantToWatch / Finished).
+if (isWatching || isStreamable)
+{
+    // for Watching, additionally bypass IsLatestEpisodeWatched when
+    // LatestEpisodeDate is more than 18h stale — TMDb's episode-data lag is
+    // another external-data gap that hides committed shows.
+    bool overrideLatestWatched = isWatching
+        && item.LatestEpisodeDate is { } led
+        && (todayUtc - led).TotalHours > 18;
+
+    if (isStatusActive(item.Status)
+        && (!item.IsLatestEpisodeWatched || overrideLatestWatched)
+        && HasAiredOrIsActivelyWatching(item, today))
+    {
+        availableNow.Add(item);
+    }
+}
+```
+
+Two bypasses, one principle: user said `Watching`, so we trust them over (a) "TMDb doesn't list this on a service you have" and (b) "you already watched the latest known episode."
+
+## When to apply
+
+- Any filter with the shape `if (externalDataAvailable && externalDataMatches) show()` — if the externalData is sometimes missing or stale, the filter's "false" branch may be the wrong default for items the user has actively committed to.
+- Specifically: streaming-service gates, last-watched gates, region-availability gates, age-restriction gates inherited from upstream metadata.
+
+## Anti-pattern
+
+Layering ever-more-aggressive **refresh / backfill / cache-invalidation** machinery to keep external data fresh enough to satisfy the gate. Sometimes the data is *permanently* missing (see [[tmdb-providers-empty]] and [[verify-plan-premise-against-live-data]]) — no refresh cadence will fill it. The user-intent override is the deeper fix; refresh aggressiveness is a workaround.
+
+## Counter-cases (when *not* to apply)
+
+- For surfaces that explicitly answer "what can I watch on `<service>`" (a per-service chip filter), the gate is asking a narrower question and the override doesn't apply. Don't promote shows to a "demonstrably on Netflix" view just because the user is Watching them.
+- For dismissed items (`Status == NotForMe`), the user committed in the *opposite* direction — surfacing them anywhere would be wrong.
+
+The principle is "trust the user's signal where the signal *says yes*", not "ignore external data wholesale."

--- a/Learnings/user-intent-overrides-external-data.md
+++ b/Learnings/user-intent-overrides-external-data.md
@@ -37,12 +37,14 @@ bool isWatching = item.Status == QueueStatus.Watching;
 // actually watch" (the noise filter is still useful for WantToWatch / Finished).
 if (isWatching || isStreamable)
 {
-    // for Watching, additionally bypass IsLatestEpisodeWatched when
-    // LatestEpisodeDate is more than 18h stale — TMDb's episode-data lag is
-    // another external-data gap that hides committed shows.
+    // for Watching, additionally bypass IsLatestEpisodeWatched once the calendar
+    // day has advanced past LatestEpisodeDate — TMDb's episode-data lag is
+    // another external-data gap that hides committed shows. Calendar-day rather
+    // than hour-based because TMDb's air_date is date-only — see
+    // [[tmdb-air-date-is-date-only]] for the same-day-trip Copilot caught on PR #156.
     bool overrideLatestWatched = isWatching
         && item.LatestEpisodeDate is { } led
-        && (todayUtc - led).TotalHours > 18;
+        && led.Date < today;
 
     if (isStatusActive(item.Status)
         && (!item.IsLatestEpisodeWatched || overrideLatestWatched)

--- a/Learnings/verify-plan-premise-against-live-data.md
+++ b/Learnings/verify-plan-premise-against-live-data.md
@@ -1,0 +1,69 @@
+# Verify a Plan's Central Premise Against Live Data Before Building Infrastructure
+
+> **Area:** Workflow | Design
+> **Date:** 2026-05-28
+> **Resolves:** mkerchenski/hurrah-tv#145
+
+## Context
+
+#145 reported "queue items render with no streaming-service badge despite being surfaced in Home's Available Now row." The diagnostic discussion identified two failure modes and we wrote a 5-phase plan (`Plans/available-now-backfill-and-watching-override.md`):
+
+1. Shared changes — `BackfillPending` DTO field, `IsOnService` predicate, Watching override
+2. Bounded synchronous provider backfill on `/api/queue` (2s ceiling, race-then-fallback)
+3. Episode-data freshness refresh for Watching items
+4. Skeleton renderer in `WatchlistRow.razor` for `BackfillPending == true`
+5. Queue chip-filter alignment via `IsOnService`
+
+All 5 phases shipped on a feature branch (4 commits, ~270 lines added). The work passed tests and formatter. Then the user ran the app, looked at the actual UI, asked for the dev-DB row, and we discovered Jimmy Kimmel Live's `availableonjson` was `"[]"` *even after a fresh backfill* — TMDb genuinely has nothing for talk shows (see [[tmdb-providers-empty]]). The backfill machinery in Phase 2/3 was refreshing data that TMDb couldn't supply; the skeleton in Phase 4 almost never fired because the backfill *did* complete (with empty); the predicate alignment in Phase 5 was code-quality only with no behavior change.
+
+We reverted phases 2-5 to a single commit (the Watching override from Phase 1, the only piece that actually changed user-visible behavior for Kimmel-class shows). The reverted code was never wrong; it just didn't pay back for the specific problem it was designed to solve.
+
+## Learning
+
+A plan's central premise is the *unstated assumption that makes the design pay back*. For #145 that premise was: **"the data is stale and we can refresh it."** The plan was sound IF that premise held. It didn't.
+
+Before building infrastructure around an assumption about external data, verify the assumption against live data — directly, in 30 seconds, not 5 phases of code later. Specifically:
+
+- **If the design hinges on retry/refresh** — query the live DB or hit the live API for one canonical example. If the answer comes back empty *after* a refresh, retry isn't the lever.
+- **If the design hinges on a TMDb / external-provider field being populated** — fetch one item by hand and look at the actual JSON. Don't assume the contract is fully populated.
+- **If the design hinges on a particular failure mode** — find the bug surface in production data first. The DB query for #145 (`SELECT availableonjson FROM queueitems WHERE title ILIKE '%kimmel%'`) would have surfaced the empty-permanent state in under a minute and changed the whole plan's shape.
+
+This isn't about being timid with plans — broad plans are fine when the central premise is right. It's about catching the *false* central premise before it ladders into a multi-day implementation. The premise check is cheap; the implementation isn't.
+
+## Example
+
+The Kimmel row from the dev DB during #145 verification:
+
+```
+ id | title              | availableonjson | availableoncheckedat
+----+--------------------+-----------------+-------------------------------
+ 67 | Jimmy Kimmel Live! | []              | 2026-05-28 10:01:13.859756-04
+```
+
+`availableonjson = []`, `availableoncheckedat` from minutes ago. The empty bracket is the truth, not a stale-data symptom. Any plan whose value depended on backfill turning that `[]` into a non-empty list was building on sand.
+
+What the plan should have done first:
+
+```bash
+# 1. find a canonical instance of the bug
+psql -h localhost -U postgres -d HurrahTv \
+  -c "SELECT availableonjson, availableoncheckedat
+      FROM queueitems
+      WHERE title ILIKE '%kimmel%';"
+
+# 2. ask: does this state survive a fresh refresh?
+#    If availableoncheckedat is recent and the value is still empty → the data
+#    gap is intrinsic. Backfill is not the lever. Design something else.
+```
+
+Total cost: 30 seconds. Saved cost: 4 commits, ~270 lines, and a revert.
+
+## When to apply
+
+- Before writing a `Plans/` document where any phase depends on an external-data refresh, freshness, or transformation.
+- Before promising "we'll catch this in a backfill" in a design discussion.
+- After `/xplan` produces a multi-phase plan — the verification belongs at the top of Phase 1, not implicitly inside Phase N's "verify" step.
+
+## Anti-pattern
+
+Designing a multi-phase plan, implementing it, *then* verifying. The implementation cost is sunk and the temptation to keep what was built (rather than admit the premise was wrong) is real. Verify first; build second.


### PR DESCRIPTION
## Summary

- Adds a `Status == Watching` override in `WatchlistFilters.Apply` so actively-Watching shows stay visible on Home Available Now even when TMDb has no recognized providers (Kimmel-class — TMDb returns `{}` for talk shows) AND when the user's marked-as-watched state combined with TMDb's daily-show ingest lag would otherwise hide the row.
- 5 new tests in `WatchlistFiltersTests` pin the override matrix (Watching+stale+watched=visible, Watching+fresh+watched=hidden, non-Watching+stale+watched=hidden, Watching+unstreamable=visible, AvailableLater retains streamability gate).
- Drops 4 of the 5 phases from the broader plan in #145 — bounded backfill, episode-data refresh, skeleton renderer, and predicate alignment — after verifying against live data that the scaffolding doesn't pay back for the intrinsic-TMDb-gap case (Kimmel's `AvailableOnJson` came back `"[]"` after a fresh refresh, so the backfill/skeleton machinery wouldn't have surfaced a badge regardless). The Watching override alone delivers the visible fix.

## Test plan

- [x] `dotnet test HurrahTv.slnx` — Shared.Tests 77/77, Client.Tests 39/39. Api.Tests blocked locally by `dotnet watch` file-lock (per `Learnings/dotnet-watch-locks-shared-dll.md`); change is Shared-only so Api.Tests are expected to pass once CI runs them
- [x] `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` clean
- [x] Verified empirically against the user's dev DB: Jimmy Kimmel Live! (id 67, status Watching, `AvailableOnJson="[]"`, `LatestEpisodeDate=2026-05-27`) surfaces on Home Available Now today (>18h after the latest episode), confirming the 18h+Watching bypass is what makes it visible

## Out of scope follow-up

The duplicate queue rows discovered during verification (Kimmel rows 67 and 112) are filed as a separate issue with a write-time UNIQUE constraint + legacy cleanup plan. Not addressed here.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)