### PR TITLE
Make Details provider badges clickable via JustWatch deep links (#140)

### DIFF
--- a/HurrahTv.Api.Tests/DetailsCacheIsolationTests.cs
+++ b/HurrahTv.Api.Tests/DetailsCacheIsolationTests.cs
@@ -66,6 +66,30 @@ public class DetailsCacheIsolationTests(PostgresFixture fx) : IAsyncLifetime
         Assert.Equal(NetflixId, aAgain.AvailableOn[0].ProviderId);
     }
 
+    [Fact]
+    public async Task Providers_CarryRegionLevelJustWatchLink_SharedAcrossServices()
+    {
+        // pins #140 — TMDb's results.US.link (a region-level JustWatch landing URL) used to be
+        // dropped by ParseProviders. It must now surface on every AvailableService, and since
+        // it's region-level (not per-provider) both Netflix and Hulu carry the identical link.
+        const string expectedLink = "https://www.themoviedb.org/tv/1234/watch?locale=US";
+
+        WebApplicationFactory<Program> factory = fx.Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(services => services.AddHttpClient<TmdbService>()
+                .ConfigurePrimaryHttpMessageHandler(() => new MultiProviderTmdbHandler())));
+
+        // user with both services so the endpoint keeps both providers in AvailableOn.
+        await SeedUserServiceAsync("user-C", NetflixId);
+        await SeedUserServiceAsync("user-C", HuluId);
+
+        HttpClient userC = AuthClient(factory, "user-C");
+        ShowDetails? response = await userC.GetFromJsonAsync<ShowDetails>($"/api/details/tv/{StubTmdbId}");
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response!.AvailableOn.Count);
+        Assert.All(response.AvailableOn, svc => Assert.Equal(expectedLink, svc.Link));
+    }
+
     private async Task SeedUserServiceAsync(string userId, int providerId)
     {
         using NpgsqlConnection db = new(fx.ConnectionString);
@@ -116,6 +140,7 @@ internal sealed class MultiProviderTmdbHandler : HttpMessageHandler
             "watch/providers": {
                 "results": {
                     "US": {
+                        "link": "https://www.themoviedb.org/tv/1234/watch?locale=US",
                         "flatrate": [
                             { "provider_id": 8,  "provider_name": "Netflix", "logo_path": "/n.png" },
                             { "provider_id": 15, "provider_name": "Hulu",    "logo_path": "/h.png" }

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -436,8 +436,11 @@ public class TmdbService
         List<AvailableService> providers = [];
         string[] types = ProviderType.All;
 
-        // region-level JustWatch landing link for the title — shared by every provider (#140)
+        // region-level JustWatch landing link for the title — shared by every provider (#140).
+        // only accept https:// — the client renders this straight into an href, and Blazor does
+        // not block non-http(s) schemes (javascript:, data:) in attributes. drop anything else.
         string link = usData.TryGetProperty("link", out JsonElement lk) ? lk.GetString() ?? "" : "";
+        if (!link.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) link = "";
 
         foreach (string type in types)
         {

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -436,6 +436,9 @@ public class TmdbService
         List<AvailableService> providers = [];
         string[] types = ProviderType.All;
 
+        // region-level JustWatch landing link for the title — shared by every provider (#140)
+        string link = usData.TryGetProperty("link", out JsonElement lk) ? lk.GetString() ?? "" : "";
+
         foreach (string type in types)
         {
             if (!usData.TryGetProperty(type, out JsonElement arr)) continue;
@@ -450,7 +453,8 @@ public class TmdbService
                     ProviderId = id,
                     ProviderName = p.GetProperty("provider_name").GetString() ?? "",
                     LogoPath = p.TryGetProperty("logo_path", out JsonElement lp) ? lp.GetString() ?? "" : "",
-                    Type = type
+                    Type = type,
+                    Link = link
                 });
             }
         }

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -299,8 +299,10 @@ else
                     {
                         @if (!string.IsNullOrEmpty(svc.Link))
                         {
+                            @* svc.Link is the region-level JustWatch page (all providers), not a
+                               provider-specific deep link — keep the tooltip destination-neutral *@
                             <a href="@svc.Link" target="_blank" rel="noopener noreferrer"
-                               title="Watch @_details.Title on @svc.ProviderName"
+                               title="Find where to watch @_details.Title"
                                class="group flex items-center gap-2 bg-surface-50 hover:bg-surface-100 transition-colors px-3 py-2 rounded-lg">
                                 @if (!string.IsNullOrEmpty(svc.LogoUrl()))
                                 {

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -297,22 +297,17 @@ else
                 <div class="flex flex-wrap gap-2 md:gap-3">
                     @foreach (AvailableService svc in _details.AvailableOn)
                     {
-                        @* shared chip body so the linked and inert variants can't drift apart *@
-                        RenderFragment logoAndName =
-                            @<text>
-                                @if (!string.IsNullOrEmpty(svc.LogoUrl()))
-                                {
-                                    <img src="@svc.LogoUrl("w45")" alt="@svc.ProviderName" class="w-6 h-6 rounded" />
-                                }
-                                <span class="text-sm">@svc.ProviderName</span>
-                            </text>;
-
                         @if (!string.IsNullOrEmpty(svc.Link))
                         {
                             <a href="@svc.Link" target="_blank" rel="noopener noreferrer"
                                title="Watch @_details.Title on @svc.ProviderName"
                                class="group flex items-center gap-2 bg-surface-50 hover:bg-surface-100 transition-colors px-3 py-2 rounded-lg">
-                                @logoAndName
+                                @if (!string.IsNullOrEmpty(svc.LogoUrl()))
+                                {
+                                    @* decorative — the provider name is already the link's visible text *@
+                                    <img src="@svc.LogoUrl("w45")" alt="" class="w-6 h-6 rounded" />
+                                }
+                                <span class="text-sm">@svc.ProviderName</span>
                                 <svg class="w-3.5 h-3.5 text-gray-500 group-hover:text-gray-300 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                                 </svg>
@@ -321,7 +316,11 @@ else
                         else
                         {
                             <div class="flex items-center gap-2 bg-surface-50 px-3 py-2 rounded-lg">
-                                @logoAndName
+                                @if (!string.IsNullOrEmpty(svc.LogoUrl()))
+                                {
+                                    <img src="@svc.LogoUrl("w45")" alt="" class="w-6 h-6 rounded" />
+                                }
+                                <span class="text-sm">@svc.ProviderName</span>
                             </div>
                         }
                     }

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -297,13 +297,31 @@ else
                 <div class="flex flex-wrap gap-2 md:gap-3">
                     @foreach (AvailableService svc in _details.AvailableOn)
                     {
-                        <div class="flex items-center gap-2 bg-surface-50 px-3 py-2 rounded-lg">
-                            @if (!string.IsNullOrEmpty(svc.LogoUrl()))
-                            {
-                                <img src="@svc.LogoUrl("w45")" alt="@svc.ProviderName" class="w-6 h-6 rounded" />
-                            }
-                            <span class="text-sm">@svc.ProviderName</span>
-                        </div>
+                        @if (!string.IsNullOrEmpty(svc.Link))
+                        {
+                            <a href="@svc.Link" target="_blank" rel="noopener noreferrer"
+                               title="Watch @_details.Title on @svc.ProviderName"
+                               class="group flex items-center gap-2 bg-surface-50 hover:bg-surface-100 transition-colors px-3 py-2 rounded-lg">
+                                @if (!string.IsNullOrEmpty(svc.LogoUrl()))
+                                {
+                                    <img src="@svc.LogoUrl("w45")" alt="@svc.ProviderName" class="w-6 h-6 rounded" />
+                                }
+                                <span class="text-sm">@svc.ProviderName</span>
+                                <svg class="w-3.5 h-3.5 text-gray-500 group-hover:text-gray-300 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                </svg>
+                            </a>
+                        }
+                        else
+                        {
+                            <div class="flex items-center gap-2 bg-surface-50 px-3 py-2 rounded-lg">
+                                @if (!string.IsNullOrEmpty(svc.LogoUrl()))
+                                {
+                                    <img src="@svc.LogoUrl("w45")" alt="@svc.ProviderName" class="w-6 h-6 rounded" />
+                                }
+                                <span class="text-sm">@svc.ProviderName</span>
+                            </div>
+                        }
                     }
                 </div>
             }

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -297,16 +297,22 @@ else
                 <div class="flex flex-wrap gap-2 md:gap-3">
                     @foreach (AvailableService svc in _details.AvailableOn)
                     {
-                        @if (!string.IsNullOrEmpty(svc.Link))
-                        {
-                            <a href="@svc.Link" target="_blank" rel="noopener noreferrer"
-                               title="Watch @_details.Title on @svc.ProviderName"
-                               class="group flex items-center gap-2 bg-surface-50 hover:bg-surface-100 transition-colors px-3 py-2 rounded-lg">
+                        @* shared chip body so the linked and inert variants can't drift apart *@
+                        RenderFragment logoAndName =
+                            @<text>
                                 @if (!string.IsNullOrEmpty(svc.LogoUrl()))
                                 {
                                     <img src="@svc.LogoUrl("w45")" alt="@svc.ProviderName" class="w-6 h-6 rounded" />
                                 }
                                 <span class="text-sm">@svc.ProviderName</span>
+                            </text>;
+
+                        @if (!string.IsNullOrEmpty(svc.Link))
+                        {
+                            <a href="@svc.Link" target="_blank" rel="noopener noreferrer"
+                               title="Watch @_details.Title on @svc.ProviderName"
+                               class="group flex items-center gap-2 bg-surface-50 hover:bg-surface-100 transition-colors px-3 py-2 rounded-lg">
+                                @logoAndName
                                 <svg class="w-3.5 h-3.5 text-gray-500 group-hover:text-gray-300 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                                 </svg>
@@ -315,11 +321,7 @@ else
                         else
                         {
                             <div class="flex items-center gap-2 bg-surface-50 px-3 py-2 rounded-lg">
-                                @if (!string.IsNullOrEmpty(svc.LogoUrl()))
-                                {
-                                    <img src="@svc.LogoUrl("w45")" alt="@svc.ProviderName" class="w-6 h-6 rounded" />
-                                }
-                                <span class="text-sm">@svc.ProviderName</span>
+                                @logoAndName
                             </div>
                         }
                     }

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -674,6 +674,9 @@
   .shrink-0 {
     flex-shrink: 0;
   }
+  .grow {
+    flex-grow: 1;
+  }
   .-translate-x-1\/2 {
     --tw-translate-x: calc(calc(1 / 2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -1617,6 +1620,13 @@
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
         background-color: var(--color-accent);
+      }
+    }
+  }
+  .group-hover\:text-gray-300 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        color: var(--color-gray-300);
       }
     }
   }

--- a/HurrahTv.Shared/Models/SearchResult.cs
+++ b/HurrahTv.Shared/Models/SearchResult.cs
@@ -55,5 +55,9 @@ public class AvailableService
     public string LogoPath { get; set; } = "";
     public string Type { get; set; } = "";
 
+    // region-level JustWatch landing URL for the title (TMDb results.US.link).
+    // not per-provider — every service on a title shares the same link. empty when TMDb omits it.
+    public string Link { get; set; } = "";
+
     public string LogoUrl(string size = "w92") => TmdbImage.Url(LogoPath, size);
 }

--- a/Learnings/blazor-href-does-not-sanitize-url-scheme.md
+++ b/Learnings/blazor-href-does-not-sanitize-url-scheme.md
@@ -1,0 +1,41 @@
+# Blazor Renders `href="@x"` Without Sanitizing the URL Scheme
+
+> **Area:** WASM | UI
+> **Date:** 2026-05-29
+> **Resolves:** mkerchenski/hurrah-tv#140
+
+## Context
+
+#140 surfaced a region-level link from TMDb (`results.US.link`) onto `AvailableService.Link`
+and bound it straight into a Details-page anchor: `<a href="@svc.Link" target="_blank" …>`.
+Three independent reviewers (Copilot + the API/data reviewer + the bug scan) flagged the same
+gap: the value goes into the `href` unvalidated.
+
+## Learning
+
+Blazor's renderer **HTML-encodes** attribute values — so `<`, `>`, `"` in a bound string can't
+break out of the attribute — but it does **not** validate or block dangerous URL *schemes* in an
+`href`. A bound value of `javascript:alert(1)` (or `data:`, `vbscript:`) renders as a live,
+clickable link and executes on click. The auto-encoding everyone relies on gives a false sense
+of safety here: it stops attribute-injection, not scheme-injection.
+
+This matters whenever you bind a URL you didn't construct yourself — a third-party API value, a
+user-supplied link, anything off the wire. TMDb returns `https://` today, so this is
+defense-in-depth against a changed/compromised upstream, but the cost of the guard is one line.
+
+**Validate the scheme at the source** (where the value is parsed/assigned), not at each render
+site — that way every consumer of the field is safe and new render sites can't forget it.
+
+## Example
+
+In `TmdbService.ParseProviders` — reject anything that isn't `https://` so the chip falls back
+to its inert (non-link) form:
+
+```csharp
+string link = usData.TryGetProperty("link", out JsonElement lk) ? lk.GetString() ?? "" : "";
+// the client renders this straight into an href and Blazor doesn't block javascript:/data: schemes
+if (!link.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) link = "";
+```
+
+The Razor side then self-gates on `!string.IsNullOrEmpty(svc.Link)`, so a rejected value renders
+a plain `<div>` chip instead of an unsafe `<a>`.

--- a/Learnings/dotnet-watch-locks-shared-dll.md
+++ b/Learnings/dotnet-watch-locks-shared-dll.md
@@ -39,3 +39,25 @@ Get-CimInstance Win32_Process -Filter "Name='dotnet.exe' OR Name='HurrahTv.Api.e
 This is platform-specific: on macOS/Linux the loader doesn't hold an exclusive
 write lock, so the same parallel `dotnet test` generally succeeds. The symptom is
 Windows-only, which is why it isn't in the (cross-platform) CLAUDE.md test notes.
+
+## Verifying without stopping the dev servers
+
+Stopping the watch isn't always desirable — e.g. you're verifying a change mid-review,
+or the servers belong to the user's session. Redirect the build/test **output** to a
+throwaway directory so MSBuild never tries to overwrite the locked `bin/`:
+
+```powershell
+dotnet build HurrahTv.Api/HurrahTv.Api.csproj    -o "$env:TEMP\hv-verify-api" -v q
+dotnet build HurrahTv.Client/HurrahTv.Client.csproj -o "$env:TEMP\hv-verify-client" -v q
+dotnet test  HurrahTv.Api.Tests/HurrahTv.Api.Tests.csproj -o "$env:TEMP\hv-verify-tests" --filter "FullyQualifiedName~SomeTest"
+```
+
+`-o` sends that project's output **and its dependencies' copies** (including `HurrahTv.Shared.dll`)
+to the temp path, so the running `dotnet watch` keeps its lock on the real `bin/` undisturbed and
+the verification still type-checks against `Shared`. The full-solution `dotnet build HurrahTv.slnx`
+can't be redirected this way (it writes each project's own `bin/`), so for a whole-solution build
+you still have to stop the servers — but for verifying a specific change, per-project `-o` is the
+non-disruptive path. Delete the temp dirs afterward.
+
+The bare formatter gate (`dotnet format --verify-no-changes`) is also lock-free — it loads the
+Roslyn workspace without writing `bin/`, so it runs fine while watch is live.

--- a/Learnings/tmdb-watch-providers-region-link.md
+++ b/Learnings/tmdb-watch-providers-region-link.md
@@ -1,0 +1,44 @@
+# TMDb `watch/providers` Gives a Region-Level `link`, Never a Per-Provider Title URL
+
+> **Area:** TMDb
+> **Date:** 2026-05-29
+> **Resolves:** mkerchenski/hurrah-tv#140
+
+## Context
+
+#140 wanted "open in app" deep links on the provider badges — tap Netflix, land in Netflix on
+that title. The data TMDb returns bounds what's possible.
+
+## Learning
+
+TMDb's `/watch/providers` response nests, per region, a single `link` that sits as a **sibling**
+of the `flatrate`/`rent`/`buy` arrays — not inside each provider object:
+
+```jsonc
+"results": {
+  "US": {
+    "link": "https://www.themoviedb.org/tv/1234/watch?locale=US",  // region-level, ONE link
+    "flatrate": [ { "provider_id": 8, "provider_name": "Netflix", "logo_path": "/n.png" }, … ]
+  }
+}
+```
+
+That `link` is a **JustWatch landing page for the whole title** (it lists every provider). There
+is **no per-provider title URL anywhere in the payload** — TMDb gives you the TMDb id, provider
+name/logo, and this one region link. So:
+
+- Every provider badge on a title shares the *same* link. Stamp it onto each `AvailableService`
+  during parse; don't try to derive a per-provider URL.
+- A chip labelled "Netflix" that opens this link lands on a page listing all providers, **not**
+  Netflix-specific. Keep any tooltip/label destination-neutral ("Find where to watch X"), or it
+  overpromises a deep link that the data can't back. (Copilot flagged exactly this on #140.)
+- **Per-provider deep links and custom schemes (`nflx://`) were rejected for #140** for this
+  reason: building any direct provider link needs that provider's *internal* title id (e.g.
+  Netflix `80100172`), which TMDb does not provide. The moment you've sourced that id you'd just
+  use the provider's plain `https://` universal link — so a custom scheme pays the same
+  id-sourcing cost plus scheme upkeep and a no-fallback error dialog, for zero added benefit.
+
+## Takeaway
+
+The JustWatch region `link` is the cheapest, attribution-correct deep link available, and it's
+the ceiling unless you separately source per-provider internal title ids (out of TMDb's scope).


### PR DESCRIPTION
## What
Capture the region-level `link` TMDb returns in its `watch/providers` response and surface it through a new `AvailableService.Link` field, then render the "Streaming on" chips on the Details page as `https://` anchors that open the title's JustWatch landing page.

## Why
Provider badges were purely informational — clicking did nothing. Per the issue's decided approach, plain `https://` universal links are the single mechanism: mobile-with-app opens the native app, mobile-without falls back to web, desktop opens the web player. No platform branching, degrades gracefully.

## How
- `TmdbService.ParseProviders` now reads `results.US.link` (previously dropped) and stamps it on every `AvailableService`. The link is region-level, so all providers on a title share it.
- `Details.razor` renders each chip as `<a target="_blank" rel="noopener noreferrer">` with an external-link glyph when a link exists; chips with no link stay inert (graceful fallback).
- TMDb/JustWatch attribution stays intact — we send users to the JustWatch page.

## Tests
- New regression test `Providers_CarryRegionLevelJustWatchLink_SharedAcrossServices` pins that the link flows through and is shared across providers.

## Verification
- `dotnet build` clean, formatter gate clean, Details tests green.
- Verified clickable chips + graceful fallback in the browser (mobile + desktop).

Closes #140