### PR TITLE
Queue dedup + composite hero key + Home hero CTS (#155, #146, #131)

### DIFF
--- a/HurrahTv.Api.Tests/CurationHeroImpressionsTests.cs
+++ b/HurrahTv.Api.Tests/CurationHeroImpressionsTests.cs
@@ -1,12 +1,15 @@
 using HurrahTv.Api.Services;
+using HurrahTv.Shared.Models;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace HurrahTv.Api.Tests;
 
 // pins #135 — the hero rotation cooldown depends on per-user last-shown timestamps.
 // These tests cover the DbService round-trip (record → read-back) and the upsert
-// behavior that keeps "last shown" a single row per (user, title). The cooldown
-// *decision* logic lives in HurrahTv.Shared.HeroSelector and is unit-tested there.
+// behavior that keeps "last shown" a single row per (user, title, media type). The
+// cooldown *decision* logic lives in HurrahTv.Shared.HeroSelector and is unit-tested there.
+//
+// Keyed by (TmdbId, MediaType) since #146 — a movie and a TV show can share a numeric id.
 [Collection("postgres")]
 public class CurationHeroImpressionsTests(PostgresFixture fx) : IAsyncLifetime
 {
@@ -19,11 +22,11 @@ public class CurationHeroImpressionsTests(PostgresFixture fx) : IAsyncLifetime
         DbService db = fx.Factory.Services.GetRequiredService<DbService>();
         DateTime before = DateTime.UtcNow.AddSeconds(-5);
 
-        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1396);
+        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1396, MediaTypes.Tv);
 
-        Dictionary<int, DateTime> impressions = await db.GetHeroImpressionsAsync("hero-user");
-        Assert.True(impressions.ContainsKey(1396));
-        Assert.True(impressions[1396] >= before, "ShownAt should be set to roughly now");
+        Dictionary<(int, string), DateTime> impressions = await db.GetHeroImpressionsAsync("hero-user");
+        Assert.True(impressions.ContainsKey((1396, MediaTypes.Tv)));
+        Assert.True(impressions[(1396, MediaTypes.Tv)] >= before, "ShownAt should be set to roughly now");
     }
 
     [Fact]
@@ -31,16 +34,16 @@ public class CurationHeroImpressionsTests(PostgresFixture fx) : IAsyncLifetime
     {
         DbService db = fx.Factory.Services.GetRequiredService<DbService>();
 
-        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1396);
-        DateTime first = (await db.GetHeroImpressionsAsync("hero-user"))[1396];
+        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1396, MediaTypes.Tv);
+        DateTime first = (await db.GetHeroImpressionsAsync("hero-user"))[(1396, MediaTypes.Tv)];
 
         // small gap so the second NOW() is observably later
         await Task.Delay(20);
-        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1396);
+        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1396, MediaTypes.Tv);
 
-        Dictionary<int, DateTime> impressions = await db.GetHeroImpressionsAsync("hero-user");
-        Assert.Single(impressions);                 // still one row for the title
-        Assert.True(impressions[1396] >= first);    // ShownAt advanced on conflict
+        Dictionary<(int, string), DateTime> impressions = await db.GetHeroImpressionsAsync("hero-user");
+        Assert.Single(impressions);                              // still one row for the title
+        Assert.True(impressions[(1396, MediaTypes.Tv)] >= first); // ShownAt advanced on conflict
     }
 
     [Fact]
@@ -48,11 +51,27 @@ public class CurationHeroImpressionsTests(PostgresFixture fx) : IAsyncLifetime
     {
         DbService db = fx.Factory.Services.GetRequiredService<DbService>();
 
-        await db.RecordHeroImpressionAsync("user-a", tmdbId: 100);
-        await db.RecordHeroImpressionAsync("user-b", tmdbId: 200);
+        await db.RecordHeroImpressionAsync("user-a", tmdbId: 100, MediaTypes.Tv);
+        await db.RecordHeroImpressionAsync("user-b", tmdbId: 200, MediaTypes.Tv);
 
-        Dictionary<int, DateTime> a = await db.GetHeroImpressionsAsync("user-a");
-        Assert.True(a.ContainsKey(100));
-        Assert.False(a.ContainsKey(200));
+        Dictionary<(int, string), DateTime> a = await db.GetHeroImpressionsAsync("user-a");
+        Assert.True(a.ContainsKey((100, MediaTypes.Tv)));
+        Assert.False(a.ContainsKey((200, MediaTypes.Tv)));
+    }
+
+    // pins #146 — a movie and a TV show sharing a numeric id are tracked as separate rows,
+    // so featuring one never burns the other's cooldown.
+    [Fact]
+    public async Task SameTmdbId_DifferentMediaType_AreSeparateRows()
+    {
+        DbService db = fx.Factory.Services.GetRequiredService<DbService>();
+
+        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1399, MediaTypes.Tv);
+        await db.RecordHeroImpressionAsync("hero-user", tmdbId: 1399, MediaTypes.Movie);
+
+        Dictionary<(int, string), DateTime> impressions = await db.GetHeroImpressionsAsync("hero-user");
+        Assert.Equal(2, impressions.Count);
+        Assert.True(impressions.ContainsKey((1399, MediaTypes.Tv)));
+        Assert.True(impressions.ContainsKey((1399, MediaTypes.Movie)));
     }
 }

--- a/HurrahTv.Api.Tests/QueueEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/QueueEndpointsTests.cs
@@ -193,6 +193,50 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         Assert.Equal([100, 200, 300], secondOrder);
     }
 
+    // pins #155 — duplicate adds are idempotent at the DB level. A double-tap, two tabs, or a
+    // re-add from another surface must collapse to ONE (UserId, TmdbId, MediaType) row, and the
+    // second add returns the existing item as success (not a 409).
+    [Fact]
+    public async Task DuplicateAdd_IsIdempotent_OneRow_SecondReturnsExisting()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "user-dedup");
+
+        QueueItem payload = NewQueueItem(tmdbId: 1399, title: "Game of Thrones");
+        HttpResponseMessage first = await client.PostAsJsonAsync("/api/queue", payload);
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+        QueueItem firstItem = (await first.Content.ReadFromJsonAsync<QueueItem>())!;
+
+        // second add of the same (TmdbId, MediaType) — must NOT be a 409, and must return the
+        // already-queued row rather than creating a duplicate.
+        HttpResponseMessage second = await client.PostAsJsonAsync("/api/queue", payload);
+        Assert.NotEqual(HttpStatusCode.Conflict, second.StatusCode);
+        Assert.True(second.IsSuccessStatusCode);
+        QueueItem secondItem = (await second.Content.ReadFromJsonAsync<QueueItem>())!;
+        Assert.Equal(firstItem.Id, secondItem.Id);
+
+        QueueResponse? list = await client.GetFromJsonAsync<QueueResponse>("/api/queue");
+        Assert.Single(list!.Items);
+    }
+
+    // pins #155 — the UNIQUE constraint + ON CONFLICT must hold under a race. Fire several
+    // concurrent adds of the same title (the double-tap / two-tabs scenario) and assert exactly
+    // one row lands. Before the constraint, two SELECT-then-INSERT calls could both pass the
+    // application-level dup check and write two rows.
+    [Fact]
+    public async Task ConcurrentAdds_SameTitle_ResultInExactlyOneRow()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "user-race");
+        QueueItem payload = NewQueueItem(tmdbId: 1399, title: "Game of Thrones");
+
+        HttpResponseMessage[] responses = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(_ => client.PostAsJsonAsync("/api/queue", payload)));
+
+        Assert.All(responses, r => Assert.True(r.IsSuccessStatusCode, $"unexpected {(int)r.StatusCode}"));
+
+        QueueResponse? list = await client.GetFromJsonAsync<QueueResponse>("/api/queue");
+        Assert.Single(list!.Items);
+    }
+
     private static async Task<QueueItem?> PostAsync(HttpClient client, QueueItem payload)
     {
         HttpResponseMessage resp = await client.PostAsJsonAsync("/api/queue", payload);

--- a/HurrahTv.Api/Endpoints/CurationEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/CurationEndpoints.cs
@@ -49,7 +49,7 @@ public static class CurationEndpoints
                 // strong pick's 14-day cooldown without ever showing it. ShouldRecordImpression is
                 // false when it's already today's pick, avoiding a redundant write per page load.
                 if (hero is not null && result.ShouldRecordImpression)
-                    await db.RecordHeroImpressionAsync(userId, result.TmdbId!.Value, ct);
+                    await db.RecordHeroImpressionAsync(userId, result.TmdbId!.Value, result.MediaType, ct);
 
                 return Results.Ok(new CuratedHeroResponse
                 {

--- a/HurrahTv.Api/Endpoints/QueueEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/QueueEndpoints.cs
@@ -72,8 +72,10 @@ public static class QueueEndpoints
                 return Results.BadRequest("Invalid status");
 
             string userId = user.GetUserId();
+            // idempotent: a duplicate add returns the existing row (not a 409) so a double-tap
+            // or a re-add from another surface is a no-op success, not an error. pins #155.
             QueueItem? added = await db.AddToQueueAsync(item, userId);
-            return added != null ? Results.Created($"/api/queue/{added.Id}", added) : Results.Conflict("Already in queue");
+            return added != null ? Results.Created($"/api/queue/{added.Id}", added) : Results.Problem("Failed to add to queue");
         });
 
         group.MapDelete("/{id:int}", async (int id, ClaimsPrincipal user, DbService db) =>

--- a/HurrahTv.Api/Services/CurationService.cs
+++ b/HurrahTv.Api/Services/CurationService.cs
@@ -117,7 +117,10 @@ public partial class CurationService
             && cached.Value.generatedAt is { } gen && gen > DateTime.UtcNow.AddDays(-ReservoirMaxAgeDays))
         {
             List<AICuratedRow> cachedRows = JsonSerializer.Deserialize<List<AICuratedRow>>(cached.Value.rowsJson) ?? [];
-            if (cachedRows.Count > 0)
+            // require non-empty Picks: a pre-#146 cache row (old TmdbIds/Scores shape)
+            // deserializes into an empty Picks list, so this forces a one-time regenerate
+            // after deploy rather than serving a hero-less reservoir for up to a week.
+            if (cachedRows.Count > 0 && cachedRows.All(r => r.Picks.Count > 0))
                 return new CurationResult { Rows = cachedRows, FromCache = true, WatchlistChanged = false };
         }
 
@@ -169,18 +172,18 @@ public partial class CurationService
     {
         CurationResult reservoir = await GetCuratedRowsAsync(userId, watchlist, providerIds, genreIds, englishOnly, regenerateReservoir, cancellationToken);
         AICuratedRow? row = reservoir.Rows.FirstOrDefault();
-        if (row is null || row.TmdbIds.Count == 0)
+        if (row is null || row.Picks.Count == 0)
             return new HeroResult { Error = reservoir.Error };
 
         // drop anything already on the watchlist, so a title the user has (or just added) can't
         // come back as a recommendation. Keyed on (TmdbId, MediaType) because TMDb ids are
         // namespaced per media type — a movie and a TV show can share a numeric id.
         HashSet<(int, string)> onWatchlist = [.. watchlist.Select(i => (i.TmdbId, i.MediaType))];
-        List<HeroCandidate> candidates = [.. row.TmdbIds
-            .Select(id => new HeroCandidate(id, row.ItemMediaTypes.GetValueOrDefault(id, MediaTypes.Tv), row.Scores.GetValueOrDefault(id)))
-            .Where(c => !onWatchlist.Contains((c.TmdbId, c.MediaType)))];
+        List<HeroCandidate> candidates = [.. row.Picks
+            .Where(p => !onWatchlist.Contains((p.TmdbId, p.MediaType)))
+            .Select(p => new HeroCandidate(p.TmdbId, p.MediaType, p.Score))];
 
-        Dictionary<int, DateTime> lastShown = await _db.GetHeroImpressionsAsync(userId, cancellationToken);
+        Dictionary<(int TmdbId, string MediaType), DateTime> lastShown = await _db.GetHeroImpressionsAsync(userId, cancellationToken);
         HeroCandidate? pick = HeroSelector.Select(candidates, lastShown, DateTime.UtcNow, keepTodaysPickEligible: !advancePick);
         if (pick is null)
             return new HeroResult { Error = reservoir.Error };
@@ -188,13 +191,15 @@ public partial class CurationService
         // the impression is recorded by the caller AFTER it confirms the pick hydrated (so a TMDb
         // failure can't burn a strong pick's cooldown without ever showing it), and only when it
         // isn't already today's pick (avoids a redundant write on every page load).
-        bool alreadyShownToday = lastShown.TryGetValue(pick.TmdbId, out DateTime last) && last.Date == DateTime.UtcNow.Date;
+        bool alreadyShownToday = lastShown.TryGetValue((pick.TmdbId, pick.MediaType), out DateTime last) && last.Date == DateTime.UtcNow.Date;
+
+        string reason = row.Picks.FirstOrDefault(p => p.TmdbId == pick.TmdbId && p.MediaType == pick.MediaType)?.Reason ?? "";
 
         return new HeroResult
         {
             TmdbId = pick.TmdbId,
             MediaType = pick.MediaType,
-            Reason = row.Reasons.GetValueOrDefault(pick.TmdbId, ""),
+            Reason = reason,
             Score = pick.Score,
             ShouldRecordImpression = !alreadyShownToday
         };
@@ -320,38 +325,35 @@ public partial class CurationService
 
             List<AIPick> picks = JsonSerializer.Deserialize<List<AIPick>>(text, CaseInsensitive) ?? [];
 
-            // build the scored reservoir — a single ranked list the hero rotation draws from
-            List<int> tmdbIds = [];
-            Dictionary<int, string> reasons = [];
-            Dictionary<int, string> itemMediaTypes = [];
-            Dictionary<int, int> scores = [];
+            // build the scored reservoir — a single ranked (best-first) list the hero rotation
+            // draws from. Dedup on (TmdbId, MediaType): a movie and a TV show sharing a numeric
+            // id are distinct picks, so a TmdbId-only key would drop one of the pair (#146).
+            List<AICuratedPick> reservoirPicks = [];
+            HashSet<(int, string)> seen = [];
 
             foreach (AIPick pick in picks)
             {
                 if (pick.Id >= 1 && pick.Id <= candidates.Count)
                 {
                     SearchResult candidate = candidates[pick.Id - 1];
-                    if (!tmdbIds.Contains(candidate.TmdbId))
+                    if (seen.Add((candidate.TmdbId, candidate.MediaType)))
                     {
-                        tmdbIds.Add(candidate.TmdbId);
-                        itemMediaTypes[candidate.TmdbId] = candidate.MediaType;
-                        scores[candidate.TmdbId] = Math.Clamp(pick.Score, 0, 100);
-                        if (!string.IsNullOrEmpty(pick.Reason))
-                            reasons[candidate.TmdbId] = pick.Reason;
+                        reservoirPicks.Add(new AICuratedPick(
+                            candidate.TmdbId,
+                            candidate.MediaType,
+                            Math.Clamp(pick.Score, 0, 100),
+                            pick.Reason ?? ""));
                     }
                 }
             }
 
-            if (tmdbIds.Count == 0) return [];
+            if (reservoirPicks.Count == 0) return [];
 
             return [new AICuratedRow
             {
                 Title = "Curated for You",
                 Subtitle = "Personalized picks based on your taste",
-                TmdbIds = tmdbIds,
-                Reasons = reasons,
-                ItemMediaTypes = itemMediaTypes,
-                Scores = scores
+                Picks = reservoirPicks
             }];
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -595,15 +597,17 @@ public partial class CurationService
     private partial void LogCurationUsage(string userId, int inputTokens, int outputTokens, decimal cost);
 }
 
-// cached row data
+// a single scored pick in the cached reservoir. Carries MediaType per pick so two titles
+// sharing a numeric TMDb id across media types stay distinct — the old parallel int-keyed
+// dicts collapsed them onto one key, dropping one of the pair (#146).
+public record AICuratedPick(int TmdbId, string MediaType, int Score, string Reason);
+
+// cached row data — an ordered (best-first) reservoir the hero rotation draws from.
 public class AICuratedRow
 {
     public string Title { get; set; } = "";
     public string Subtitle { get; set; } = "";
-    public List<int> TmdbIds { get; set; } = [];
-    public Dictionary<int, string> Reasons { get; set; } = []; // TmdbId → reason
-    public Dictionary<int, string> ItemMediaTypes { get; set; } = [];
-    public Dictionary<int, int> Scores { get; set; } = []; // TmdbId → AI match score 0-100 (#135)
+    public List<AICuratedPick> Picks { get; set; } = [];
 }
 
 public class CurationResult

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -302,9 +302,7 @@ public class DbService(IConfiguration config)
 
         // conflict — the title is already queued. Return the existing row so the add is
         // idempotent (the caller surfaces it as success, not a 409). pins #155.
-        return await db.QuerySingleOrDefaultAsync<QueueItem>(
-            "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
-            new { UserId = userId, item.TmdbId, item.MediaType });
+        return await SelectQueueItemAsync(db, userId, item.TmdbId, item.MediaType);
     }
 
     public async Task<bool> RemoveFromQueueAsync(int id, string userId)
@@ -425,9 +423,7 @@ public class DbService(IConfiguration config)
             return row;
         }
 
-        QueueItem? existing = await db.QuerySingleOrDefaultAsync<QueueItem>(
-            "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
-            new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType });
+        QueueItem? existing = await SelectQueueItemAsync(db, userId, tmdbId, mediaType);
 
         if (existing != null)
             return await ApplyUpdatePolicy(existing);
@@ -462,9 +458,7 @@ public class DbService(IConfiguration config)
         {
             // lost the insert race — the row exists now. Re-read and apply the same policy
             // the fast path would have, so a concurrent /seen + /ensure can't diverge.
-            existing = await db.QuerySingleOrDefaultAsync<QueueItem>(
-                "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
-                new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType });
+            existing = await SelectQueueItemAsync(db, userId, tmdbId, mediaType);
             return existing is null ? null : await ApplyUpdatePolicy(existing);
         }
 
@@ -1098,4 +1092,11 @@ public class DbService(IConfiguration config)
         await conn.OpenAsync(cancellationToken);
         return conn;
     }
+
+    // single-row lookup by the natural key (UserId, TmdbId, MediaType). Shared by the add
+    // and upsert paths and their ON CONFLICT re-reads so the query lives in one place.
+    private static Task<QueueItem?> SelectQueueItemAsync(NpgsqlConnection db, string userId, int tmdbId, string mediaType) =>
+        db.QuerySingleOrDefaultAsync<QueueItem>(
+            "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
+            new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType });
 }

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -89,13 +89,37 @@ public class DbService(IConfiguration config)
             );
 
             -- per-user record of when a title was last featured in the Home hero, so the
-            -- daily rotation can keep a title out of the hero for a cooldown window (#135)
+            -- daily rotation can keep a title out of the hero for a cooldown window (#135).
+            -- keyed by (TmdbId, MediaType): TMDb ids are namespaced per media type, so a
+            -- movie and a TV show sharing a numeric id must not share a cooldown (#146).
             CREATE TABLE IF NOT EXISTS CurationHeroImpressions (
                 UserId VARCHAR(50) NOT NULL,
                 TmdbId INT NOT NULL,
+                MediaType VARCHAR(10) NOT NULL,
                 ShownAt TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                PRIMARY KEY (UserId, TmdbId)
+                PRIMARY KEY (UserId, TmdbId, MediaType)
             );
+
+            -- one-time migration for pre-#146 databases where the table predates the
+            -- MediaType column / composite PK. Impression rows are ephemeral cooldown
+            -- state (a 14-day window), so a recreate is safe — at worst a hero repeats
+            -- once post-deploy. Guarded on the column so it's a no-op once migrated.
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'curationheroimpressions' AND column_name = 'mediatype'
+                ) THEN
+                    DROP TABLE CurationHeroImpressions;
+                    CREATE TABLE CurationHeroImpressions (
+                        UserId VARCHAR(50) NOT NULL,
+                        TmdbId INT NOT NULL,
+                        MediaType VARCHAR(10) NOT NULL,
+                        ShownAt TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        PRIMARY KEY (UserId, TmdbId, MediaType)
+                    );
+                END IF;
+            END $$;
 
             -- watchlist evolution: add new columns to QueueItems
             ALTER TABLE QueueItems ADD COLUMN IF NOT EXISTS LastSeasonWatched INT NULL;
@@ -170,6 +194,26 @@ public class DbService(IConfiguration config)
             -- backdrop image for hero billboard on Home; existing rows default to empty and
             -- will get backfilled via TMDb on the next AddToQueue / EnsureQueueItem touch
             ALTER TABLE QueueItems ADD COLUMN IF NOT EXISTS BackdropPath VARCHAR(500) NOT NULL DEFAULT '';
+
+            -- queue dedup (#155). Collapse any pre-constraint duplicate rows, keeping the
+            -- earliest AddedAt (tie-break: lowest Id) per (UserId, TmdbId, MediaType), then
+            -- enforce uniqueness at the DB level so races and alternative insert paths can't
+            -- land a second row. Cleanup MUST run before the index or index creation fails on
+            -- the existing dupes. Both are idempotent — no-ops once the data is clean.
+            DELETE FROM QueueItems
+            WHERE Id IN (
+                SELECT Id FROM (
+                    SELECT Id, ROW_NUMBER() OVER (
+                        PARTITION BY UserId, TmdbId, MediaType
+                        ORDER BY AddedAt ASC, Id ASC
+                    ) AS rn
+                    FROM QueueItems
+                ) ranked
+                WHERE rn > 1
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS UX_QueueItems_User_Tmdb_Media
+                ON QueueItems(UserId, TmdbId, MediaType);
             """, transaction: tx);
 
         // bootstrap admins — runs on every startup, idempotent. Owner is always admin in every environment.
@@ -219,23 +263,21 @@ public class DbService(IConfiguration config)
     {
         using NpgsqlConnection db = await OpenAsync();
 
-        // check for duplicate
-        int? existing = await db.QuerySingleOrDefaultAsync<int?>(
-            "SELECT Id FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
-            new { UserId = userId, item.TmdbId, item.MediaType });
-
-        if (existing != null) return null;
-
-        // get next position
+        // next position — only consumed when the INSERT actually lands a row
         int maxPos = await db.QuerySingleOrDefaultAsync<int>(
             "SELECT COALESCE(MAX(Position), 0) FROM QueueItems WHERE UserId = @UserId",
             new { UserId = userId });
 
         item.Position = maxPos + 1;
 
-        int id = await db.QuerySingleAsync<int>("""
+        // ON CONFLICT DO NOTHING makes the add idempotent at the DB level (#155) — a race
+        // (double-tap, two tabs) or an alternative insert path can't create a second
+        // (UserId, TmdbId, MediaType) row. RETURNING yields the new Id only when a row was
+        // actually inserted; a conflict returns no row, so we re-read the existing one below.
+        int? id = await db.QuerySingleOrDefaultAsync<int?>("""
             INSERT INTO QueueItems (UserId, TmdbId, MediaType, Title, PosterPath, BackdropPath, Position, Status, Sentiment, AvailableOnJson, AddedAt)
             VALUES (@UserId, @TmdbId, @MediaType, @Title, @PosterPath, @BackdropPath, @Position, @Status, @Sentiment, @AvailableOnJson, @AddedAt)
+            ON CONFLICT (UserId, TmdbId, MediaType) DO NOTHING
             RETURNING Id
             """, new
         {
@@ -252,8 +294,17 @@ public class DbService(IConfiguration config)
             AddedAt = DateTime.UtcNow
         });
 
-        item.Id = id;
-        return item;
+        if (id is not null)
+        {
+            item.Id = id.Value;
+            return item;
+        }
+
+        // conflict — the title is already queued. Return the existing row so the add is
+        // idempotent (the caller surfaces it as success, not a 409). pins #155.
+        return await db.QuerySingleOrDefaultAsync<QueueItem>(
+            "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
+            new { UserId = userId, item.TmdbId, item.MediaType });
     }
 
     public async Task<bool> RemoveFromQueueAsync(int id, string userId)
@@ -341,47 +392,57 @@ public class DbService(IConfiguration config)
     {
         using NpgsqlConnection db = await OpenAsync();
 
-        QueueItem? existing = await db.QuerySingleOrDefaultAsync<QueueItem>(
-            "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
-            new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType });
-
-        if (existing != null)
+        // applies the status / backdrop-backfill policy to a row that already exists. Shared
+        // between the fast path (row found by the initial SELECT) and the race-lost path (the
+        // INSERT below hit the unique constraint), so both behave identically. pins #155.
+        async Task<QueueItem> ApplyUpdatePolicy(QueueItem row)
         {
             // backfill backdrop on existing rows that pre-date the column — same row touch as status update
-            bool needsBackdropBackfill = string.IsNullOrEmpty(existing.BackdropPath) && !string.IsNullOrEmpty(backdropPath);
-            bool willUpdate = shouldUpdate == null || shouldUpdate(existing.Status);
+            bool needsBackdropBackfill = string.IsNullOrEmpty(row.BackdropPath) && !string.IsNullOrEmpty(backdropPath);
+            bool willUpdate = shouldUpdate == null || shouldUpdate(row.Status);
             if (willUpdate && needsBackdropBackfill)
             {
                 await db.ExecuteAsync(
                     "UPDATE QueueItems SET Status = @Status, BackdropPath = @BackdropPath WHERE Id = @Id",
-                    new { Status = (int)targetStatus, BackdropPath = backdropPath, existing.Id });
-                existing.Status = targetStatus;
-                existing.BackdropPath = backdropPath;
+                    new { Status = (int)targetStatus, BackdropPath = backdropPath, row.Id });
+                row.Status = targetStatus;
+                row.BackdropPath = backdropPath;
             }
             else if (willUpdate)
             {
                 await db.ExecuteAsync(
                     "UPDATE QueueItems SET Status = @Status WHERE Id = @Id",
-                    new { Status = (int)targetStatus, existing.Id });
-                existing.Status = targetStatus;
+                    new { Status = (int)targetStatus, row.Id });
+                row.Status = targetStatus;
             }
             else if (needsBackdropBackfill)
             {
                 await db.ExecuteAsync(
                     "UPDATE QueueItems SET BackdropPath = @BackdropPath WHERE Id = @Id",
-                    new { BackdropPath = backdropPath, existing.Id });
-                existing.BackdropPath = backdropPath;
+                    new { BackdropPath = backdropPath, row.Id });
+                row.BackdropPath = backdropPath;
             }
-            return existing;
+            return row;
         }
+
+        QueueItem? existing = await db.QuerySingleOrDefaultAsync<QueueItem>(
+            "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
+            new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType });
+
+        if (existing != null)
+            return await ApplyUpdatePolicy(existing);
 
         int maxPos = await db.QuerySingleOrDefaultAsync<int>(
             "SELECT COALESCE(MAX(Position), 0) FROM QueueItems WHERE UserId = @UserId",
             new { UserId = userId });
 
-        int id = await db.QuerySingleAsync<int>("""
+        // ON CONFLICT DO NOTHING guards against a concurrent caller inserting the same
+        // (UserId, TmdbId, MediaType) between our SELECT and INSERT — without it the new
+        // unique constraint (#155) would surface that race as a 500.
+        int? id = await db.QuerySingleOrDefaultAsync<int?>("""
             INSERT INTO QueueItems (UserId, TmdbId, MediaType, Title, PosterPath, BackdropPath, Position, Status, AvailableOnJson, AddedAt)
             VALUES (@UserId, @TmdbId, @MediaType, @Title, @PosterPath, @BackdropPath, @Position, @Status, @AvailableOnJson, @AddedAt)
+            ON CONFLICT (UserId, TmdbId, MediaType) DO NOTHING
             RETURNING Id
             """, new
         {
@@ -397,9 +458,19 @@ public class DbService(IConfiguration config)
             AddedAt = DateTime.UtcNow
         });
 
+        if (id is null)
+        {
+            // lost the insert race — the row exists now. Re-read and apply the same policy
+            // the fast path would have, so a concurrent /seen + /ensure can't diverge.
+            existing = await db.QuerySingleOrDefaultAsync<QueueItem>(
+                "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
+                new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType });
+            return existing is null ? null : await ApplyUpdatePolicy(existing);
+        }
+
         return new QueueItem
         {
-            Id = id,
+            Id = id.Value,
             TmdbId = tmdbId,
             MediaType = mediaType,
             Title = title,
@@ -669,25 +740,27 @@ public class DbService(IConfiguration config)
         return row;
     }
 
-    // hero rotation: last-shown timestamp per featured title, used to enforce the cooldown
-    public async Task<Dictionary<int, DateTime>> GetHeroImpressionsAsync(string userId, CancellationToken cancellationToken = default)
+    // hero rotation: last-shown timestamp per featured title, used to enforce the cooldown.
+    // keyed by (TmdbId, MediaType) — TMDb ids are namespaced per media type, so a movie and a
+    // TV show sharing a numeric id must each track their own cooldown (#146).
+    public async Task<Dictionary<(int TmdbId, string MediaType), DateTime>> GetHeroImpressionsAsync(string userId, CancellationToken cancellationToken = default)
     {
         using NpgsqlConnection db = await OpenAsync(cancellationToken);
         CommandDefinition cmd = new(
-            "SELECT TmdbId, ShownAt FROM CurationHeroImpressions WHERE UserId = @UserId",
+            "SELECT TmdbId, MediaType, ShownAt FROM CurationHeroImpressions WHERE UserId = @UserId",
             new { UserId = userId }, cancellationToken: cancellationToken);
-        IEnumerable<(int TmdbId, DateTime ShownAt)> rows = await db.QueryAsync<(int, DateTime)>(cmd);
-        return rows.ToDictionary(r => r.TmdbId, r => r.ShownAt);
+        IEnumerable<(int TmdbId, string MediaType, DateTime ShownAt)> rows = await db.QueryAsync<(int, string, DateTime)>(cmd);
+        return rows.ToDictionary(r => (r.TmdbId, r.MediaType), r => r.ShownAt);
     }
 
-    public async Task RecordHeroImpressionAsync(string userId, int tmdbId, CancellationToken cancellationToken = default)
+    public async Task RecordHeroImpressionAsync(string userId, int tmdbId, string mediaType, CancellationToken cancellationToken = default)
     {
         using NpgsqlConnection db = await OpenAsync(cancellationToken);
         CommandDefinition cmd = new("""
-            INSERT INTO CurationHeroImpressions (UserId, TmdbId, ShownAt)
-            VALUES (@UserId, @TmdbId, NOW())
-            ON CONFLICT (UserId, TmdbId) DO UPDATE SET ShownAt = NOW()
-            """, new { UserId = userId, TmdbId = tmdbId }, cancellationToken: cancellationToken);
+            INSERT INTO CurationHeroImpressions (UserId, TmdbId, MediaType, ShownAt)
+            VALUES (@UserId, @TmdbId, @MediaType, NOW())
+            ON CONFLICT (UserId, TmdbId, MediaType) DO UPDATE SET ShownAt = NOW()
+            """, new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType }, cancellationToken: cancellationToken);
         await db.ExecuteAsync(cmd);
     }
 

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -310,6 +310,10 @@ else
     private bool _heroLoading;
     private int _heroRequestSeq; // latest-wins guard so overlapping fetches don't both apply
     private bool _disposed;      // LoadHero is fire-and-forget + slow; don't render after disposal
+    // page-scoped CTS, cancelled in Dispose(), so navigating away mid-fetch aborts the
+    // server-side paid AI inference (the /hero endpoint forwards the token to Claude), not
+    // just the client-side render. Mirrors Details.razor's _loadCts pattern. pins #131.
+    private readonly CancellationTokenSource _cts = new();
 
     // hero billboard — cached so it doesn't recompute on every render. recomputed in
     // ReapplyDerivedState after queue mutations and after the AI pick arrives.
@@ -536,13 +540,15 @@ else
         int seq = ++_heroRequestSeq;
         try
         {
-            CuratedHeroResponse? response = await Api.GetCuratedHeroAsync(refresh);
+            CuratedHeroResponse? response = await Api.GetCuratedHeroAsync(refresh, _cts.Token);
             if (seq == _heroRequestSeq && response?.Hero is not null)
                 _heroPick = response.Hero;
         }
         catch
         {
-            // hero is non-critical — leave any existing pick / fallback in place
+            // hero is non-critical — leave any existing pick / fallback in place. Also the
+            // catch-all swallows the OperationCanceledException raised when _cts is cancelled
+            // on disposal, so navigating away never surfaces as an error.
         }
         finally
         {
@@ -731,6 +737,8 @@ else
     public void Dispose()
     {
         _disposed = true;
+        _cts.Cancel();
+        _cts.Dispose();
         QuickActionSvc.OnChanged -= OnQuickActionChanged;
         QuickActionSvc.OnItemUpdated -= OnItemUpdated;
         QuickActionSvc.OnEpisodeWatchedChanged -= OnEpisodeWatchedChanged;

--- a/HurrahTv.Shared.Tests/HeroSelectorTests.cs
+++ b/HurrahTv.Shared.Tests/HeroSelectorTests.cs
@@ -5,11 +5,14 @@ namespace HurrahTv.Shared.Tests;
 // pins #135 — the daily Home-hero rotation. The worst bugs here are off-by-one cooldown
 // fences and within-day instability (the hero reshuffling on a page refresh), so these
 // drive the exact day boundaries with an injected `Today`.
+//
+// Impressions are keyed by (TmdbId, MediaType) — TMDb ids are namespaced per media type,
+// so a movie and a TV show can share a numeric id (#146).
 public class HeroSelectorTests
 {
     private static readonly DateTime Today = new(2026, 5, 27, 0, 0, 0, DateTimeKind.Utc);
 
-    private static Dictionary<int, DateTime> NoImpressions() => [];
+    private static Dictionary<(int TmdbId, string MediaType), DateTime> NoImpressions() => [];
 
     [Fact]
     public void EmptyReservoir_ReturnsNull() =>
@@ -34,7 +37,7 @@ public class HeroSelectorTests
     {
         // #1 is the highest score but was featured 3 days ago — well inside the window.
         List<HeroCandidate> reservoir = [new(1, "tv", 90), new(2, "tv", 80)];
-        Dictionary<int, DateTime> shown = new() { [1] = Today.AddDays(-3) };
+        Dictionary<(int, string), DateTime> shown = new() { [(1, "tv")] = Today.AddDays(-3) };
         Assert.Equal(2, HeroSelector.Select(reservoir, shown, Today)!.TmdbId);
     }
 
@@ -44,11 +47,11 @@ public class HeroSelectorTests
         List<HeroCandidate> reservoir = [new(1, "tv", 90), new(2, "tv", 50)];
 
         // exactly 14 days ago → (today - day).Days == 14, NOT > 14 → still excluded.
-        Dictionary<int, DateTime> shown = new() { [1] = Today.AddDays(-14) };
+        Dictionary<(int, string), DateTime> shown = new() { [(1, "tv")] = Today.AddDays(-14) };
         Assert.Equal(2, HeroSelector.Select(reservoir, shown, Today)!.TmdbId);
 
         // 15 days ago → cooled down, and it outscores #2.
-        shown[1] = Today.AddDays(-15);
+        shown[(1, "tv")] = Today.AddDays(-15);
         Assert.Equal(1, HeroSelector.Select(reservoir, shown, Today)!.TmdbId);
     }
 
@@ -56,10 +59,10 @@ public class HeroSelectorTests
     public void ShownToday_StaysEligible_SoPickIsStableWithinTheDay()
     {
         List<HeroCandidate> reservoir = [new(1, "tv", 90), new(2, "tv", 80)];
-        Dictionary<int, DateTime> shown = [];
+        Dictionary<(int, string), DateTime> shown = [];
 
         HeroCandidate? first = HeroSelector.Select(reservoir, shown, Today);
-        shown[first!.TmdbId] = Today; // endpoint records today's impression
+        shown[(first!.TmdbId, first.MediaType)] = Today; // endpoint records today's impression
 
         // a later visit the same day (different clock time, same calendar day) must not reshuffle.
         HeroCandidate? second = HeroSelector.Select(reservoir, shown, Today.AddHours(8));
@@ -70,7 +73,7 @@ public class HeroSelectorTests
     public void DailyRotation_TopPickYesterday_AdvancesToNextBestToday()
     {
         List<HeroCandidate> reservoir = [new(1, "tv", 90), new(2, "tv", 80), new(3, "movie", 70)];
-        Dictionary<int, DateTime> shown = new() { [1] = Today.AddDays(-1) }; // featured yesterday
+        Dictionary<(int, string), DateTime> shown = new() { [(1, "tv")] = Today.AddDays(-1) }; // featured yesterday
         Assert.Equal(2, HeroSelector.Select(reservoir, shown, Today)!.TmdbId);
     }
 
@@ -79,7 +82,7 @@ public class HeroSelectorTests
     {
         // reservoir deeper than the cooldown window so rotation never needs the fallback
         List<HeroCandidate> reservoir = [.. Enumerable.Range(1, 20).Select(i => new HeroCandidate(i, "tv", 100 - i))];
-        Dictionary<int, DateTime> shown = [];
+        Dictionary<(int, string), DateTime> shown = [];
         List<int> picks = [];
 
         DateTime day = Today;
@@ -88,7 +91,7 @@ public class HeroSelectorTests
             HeroCandidate? pick = HeroSelector.Select(reservoir, shown, day);
             Assert.NotNull(pick);
             picks.Add(pick!.TmdbId);
-            shown[pick.TmdbId] = day; // record what was featured that day
+            shown[(pick.TmdbId, pick.MediaType)] = day; // record what was featured that day
             day = day.AddDays(1);
         }
 
@@ -99,7 +102,7 @@ public class HeroSelectorTests
     public void Refresh_ExcludesTodaysPick_AndAdvancesToNext()
     {
         List<HeroCandidate> reservoir = [new(1, "tv", 90), new(2, "tv", 80)];
-        Dictionary<int, DateTime> shown = new() { [1] = Today }; // already featured today
+        Dictionary<(int, string), DateTime> shown = new() { [(1, "tv")] = Today }; // already featured today
 
         // normal path keeps today's pick (stability); refresh advances past it.
         Assert.Equal(1, HeroSelector.Select(reservoir, shown, Today)!.TmdbId);
@@ -110,13 +113,28 @@ public class HeroSelectorTests
     public void ThinReservoir_AllInCooldown_FallsBackToLeastRecentlyShown()
     {
         List<HeroCandidate> reservoir = [new(1, "tv", 90), new(2, "tv", 80)];
-        Dictionary<int, DateTime> shown = new()
+        Dictionary<(int, string), DateTime> shown = new()
         {
-            [1] = Today.AddDays(-2), // older
-            [2] = Today.AddDays(-1), // more recent
+            [(1, "tv")] = Today.AddDays(-2), // older
+            [(2, "tv")] = Today.AddDays(-1), // more recent
         };
         // both inside the cooldown and neither shown today → nothing eligible. Degrade to
         // the least-recently-shown title rather than going blank.
         Assert.Equal(1, HeroSelector.Select(reservoir, shown, Today)!.TmdbId);
+    }
+
+    // pins #146 — a movie and a TV show sharing a numeric TMDb id must not share a cooldown.
+    // The tv title was featured today; the movie with the same id has never been shown and
+    // must stay eligible (a TmdbId-only key would wrongly suppress it).
+    [Fact]
+    public void SameTmdbId_DifferentMediaType_HaveIndependentCooldowns()
+    {
+        List<HeroCandidate> reservoir = [new(1399, "tv", 90), new(1399, "movie", 80)];
+        Dictionary<(int, string), DateTime> shown = new() { [(1399, "tv")] = Today.AddDays(-1) };
+
+        // the tv title is inside its cooldown, but the movie (same id, never shown) is eligible.
+        HeroCandidate? pick = HeroSelector.Select(reservoir, shown, Today);
+        Assert.Equal(1399, pick!.TmdbId);
+        Assert.Equal("movie", pick.MediaType);
     }
 }

--- a/HurrahTv.Shared/Curation/HeroSelector.cs
+++ b/HurrahTv.Shared/Curation/HeroSelector.cs
@@ -27,7 +27,7 @@ public static class HeroSelector
     // something rather than going blank.
     public static HeroCandidate? Select(
         IReadOnlyList<HeroCandidate> reservoir,
-        IReadOnlyDictionary<int, DateTime> lastShownUtc,
+        IReadOnlyDictionary<(int TmdbId, string MediaType), DateTime> lastShownUtc,
         DateTime todayUtc,
         int cooldownDays = DefaultCooldownDays,
         bool keepTodaysPickEligible = true)
@@ -38,7 +38,9 @@ public static class HeroSelector
 
         bool IsEligible(HeroCandidate c)
         {
-            if (!lastShownUtc.TryGetValue(c.TmdbId, out DateTime shown)) return true; // never featured
+            // keyed by (TmdbId, MediaType): a movie and a TV show can share a numeric id, so a
+            // TmdbId-only lookup would let one media type's cooldown suppress the other (#146).
+            if (!lastShownUtc.TryGetValue((c.TmdbId, c.MediaType), out DateTime shown)) return true; // never featured
             DateTime shownDay = shown.Date;
             // shown today normally stays eligible (so a same-day re-fetch is stable), but a
             // manual refresh passes keepTodaysPickEligible=false to advance past today's pick.
@@ -58,7 +60,7 @@ public static class HeroSelector
         // featured longest ago (never-shown items are always eligible above, so they
         // can't reach this branch).
         return reservoir
-            .OrderBy(c => lastShownUtc.TryGetValue(c.TmdbId, out DateTime shown) ? shown : DateTime.MinValue)
+            .OrderBy(c => lastShownUtc.TryGetValue((c.TmdbId, c.MediaType), out DateTime shown) ? shown : DateTime.MinValue)
             .ThenByDescending(c => c.Score)
             .ThenBy(c => c.TmdbId)
             .First();

--- a/Learnings/addtoqueue-conflict-pitfall.md
+++ b/Learnings/addtoqueue-conflict-pitfall.md
@@ -1,32 +1,40 @@
-# AddToQueueAsync Returns Null on Conflict — Silent Failure Pitfall
+# AddToQueueAsync Is Idempotent — Returns the Existing Item on Conflict
 
 > **Area:** API | UI
-> **Date:** 2026-04-05
+> **Date:** 2026-04-05 · **Updated:** 2026-06-01 (#155)
 
-## Context
-PosterCard's "thumbs up" button and Details page's "set sentiment" both tried to add an item to the queue first, then update its sentiment. `AddToQueueAsync` returns `null` on HTTP 409 (item already exists). Both callers guarded with `if (added == null) return;` — which silently dropped the sentiment update for items already in the queue.
+## Current behavior (post-#155)
 
-## Learning
-`AddToQueueAsync` is a create-only operation. It returns `null` on conflict, meaning "this item already exists." Code that chains operations after it (set sentiment, update status) must handle the null case by finding the existing item instead of bailing out.
+`AddToQueueAsync` is **idempotent**. Adding a title already in the queue returns the
+*existing* `QueueItem` (HTTP 201 with the row), not `null`/409. The DB enforces this with a
+`UNIQUE (UserId, TmdbId, MediaType)` index, and the insert is `INSERT … ON CONFLICT DO NOTHING`
+with a re-read of the existing row on conflict. The method only returns `null` on a genuine
+failure (the pathological case where the row vanishes between insert and re-read → endpoint
+returns `Results.Problem`).
 
-Two patterns that work:
-1. **Use an upsert endpoint** (`MarkAsSeenAsync` calls `/api/queue/seen` which does INSERT...ON CONFLICT UPDATE) — this always returns the item
-2. **Fall back to finding the existing item** on null: fetch the queue and find by TmdbId+MediaType
+So a create-then-update chain just works — no fallback fetch needed:
 
-Pattern that silently fails:
 ```csharp
-// BAD — sentiment never set for existing items
-QueueItem? added = await Api.AddToQueueAsync(item);
-if (added != null)
-    await Api.UpdateSentimentAsync(added.Id, sentiment);
-
-// GOOD — falls back to finding existing item
+// GOOD (post-#155) — the add returns the existing row on a dup, so the chain is safe
 QueueItem? item = await Api.AddToQueueAsync(newItem);
-if (item == null)
-    item = await FindExistingItemAsync(tmdbId, mediaType);
-if (item != null)
+if (item is not null)
     await Api.UpdateSentimentAsync(item.Id, sentiment);
 ```
 
+A `null`-fallback to a secondary "find the existing item" fetch is now **dead code for the
+duplicate case** (it only guards the pathological-failure null). New callers should not add one.
+Existing fallbacks in `Details.razor` are harmless but redundant.
+
+## Historical pitfall (pre-#155) — kept for context
+
+`AddToQueueAsync` used to be create-only: it returned `null` on HTTP 409 ("already exists").
+PosterCard's thumbs-up and Details' set-sentiment both did `if (added == null) return;`, which
+silently dropped the sentiment update for items already in the queue. The fix at the time was to
+either route through an upsert endpoint (`/api/queue/seen`) or fall back to finding the existing
+item on `null`. #155 removed the root cause by making the add idempotent at the DB level.
+
 ## Broader pattern
-Any time you chain a create + update, handle the "already exists" case. This applies to any endpoint that returns null/409 on duplicate.
+
+Prefer making a create idempotent at the DB layer (`UNIQUE` + `ON CONFLICT`) over teaching every
+caller to handle a duplicate-signalling `null`/409. The constraint is the single source of truth;
+callers stay simple. See [[partial-dto-put-full-row-upsert]] for the related upsert-return shape.


### PR DESCRIPTION
## What

Three independent quick-win fixes bundled into one PR. The app-wide icon-sizing change (#159) is intentionally split into its own PR so its visual sweep and any revert stay isolated.

## #155 — Queue dedup
- One-shot legacy-duplicate cleanup (keep earliest `AddedAt` per `(UserId, TmdbId, MediaType)`) followed by a `UNIQUE` index in `DbService.InitializeAsync`. Cleanup runs **before** the index so creation can't fail on existing dupes. Both idempotent.
- `AddToQueueAsync` + `UpsertWithStatusAsync` (the `MarkAsSeen` / `EnsureQueueItem` paths) now `INSERT … ON CONFLICT (UserId, TmdbId, MediaType) DO NOTHING`, so a race or alternative insert path can't surface the new constraint as a 500.
- The add endpoint is now **idempotent**: a duplicate returns the existing row as success instead of a 409. Side benefit — removes a spurious "Couldn't add" toast on HomeHero and an extra round-trip on Details.

## #146 — Hero impressions + reservoir keyed by `(TmdbId, MediaType)`
- `CurationHeroImpressions` PK widened to `(UserId, TmdbId, MediaType)` with a guarded one-time migration (cooldown data is ephemeral, so recreate is safe — at worst a hero repeats once post-deploy).
- `GetHeroImpressionsAsync` / `RecordHeroImpressionAsync` + `HeroSelector.Select` carry the composite key end-to-end, so a movie and a TV show sharing a numeric id no longer share a cooldown.
- `AICuratedRow` replaces the three parallel int-keyed dicts with an ordered `List<AICuratedPick>` carrying `MediaType` per pick, so same-id cross-media titles stay distinct in the reservoir. Pre-#146 caches self-heal (empty `Picks` → treated as a miss and regenerated).

## #131 — Home hero page-scoped CancellationToken
- Added a page-lifetime `CancellationTokenSource`, cancelled + disposed in `Dispose()`, threaded into `Api.GetCuratedHeroAsync` so navigating away mid-fetch aborts the **server-side paid AI inference**, mirroring `Details.razor`. (The `_disposed` render guard was already in place.)

## Testing
- `HeroSelectorTests` + `CurationHeroImpressionsTests`: composite-key updates + new collision regressions pinning #146.
- `QueueEndpointsTests`: idempotent-add and concurrent-add (8 parallel) regressions pinning #155.
- Full suite green (146 tests). `dotnet format --verify-no-changes` clean. The `CurationHeroImpressions` migration was exercised live against the existing test DB.

No Tailwind class/icon changes, so no CSS rebuild needed.

Closes #155
Closes #146
Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
