### PR TITLE
infra: serialize deploys/swaps + document shared-DB migration safety

### DIFF
--- a/.github/workflows/main_hurrahtv.yml
+++ b/.github/workflows/main_hurrahtv.yml
@@ -14,6 +14,16 @@ on:
 permissions:
   contents: read
 
+# Serialize every staging deploy and the prod swap into one queue so they can never
+# overlap. Two near-simultaneous merges to main used to race their staging deploys —
+# the later-finishing (older-commit) deploy clobbered the newer one on the slot, so a
+# swap then promoted a build missing the most recent PR. cancel-in-progress: false
+# queues runs in trigger order (latest-pending wins) rather than cancelling a deploy
+# mid-flight, which could leave the slot half-written. swap.yml shares this group.
+concurrency:
+  group: hurrahtv-deploy-pipeline
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -6,6 +6,12 @@ on:
 permissions:
   contents: read
 
+# Shares main_hurrahtv.yml's concurrency group so a swap never runs while a staging
+# deploy is in flight (and vice versa) — prevents swapping a slot that's mid-deploy.
+concurrency:
+  group: hurrahtv-deploy-pipeline
+  cancel-in-progress: false
+
 jobs:
   swap:
     runs-on: ubuntu-latest

--- a/Learnings/shared-db-slot-swaps-need-backward-compatible-migrations.md
+++ b/Learnings/shared-db-slot-swaps-need-backward-compatible-migrations.md
@@ -1,0 +1,56 @@
+# Shared-DB Slot Swaps Need Backward-Compatible (Expand/Contract) Migrations
+
+> **Area:** Infra | API
+> **Date:** 2026-06-01
+
+## Context
+
+The staging and production App Service slots share **one** PostgreSQL database. Schema
+changes live in `DbService.InitializeAsync`, which runs on every app startup. So the moment a
+staging deploy boots, its `InitializeAsync` migrates the **production** database — before any
+swap happens.
+
+#161 shipped a non-backward-compatible migration: `CurationHeroImpressions` was dropped and
+recreated with PK `(UserId, TmdbId, MediaType)` and `MediaType VARCHAR(10) NOT NULL` (no
+default). The pre-#161 code's `RecordHeroImpressionAsync` does
+`INSERT (UserId, TmdbId, ShownAt) … ON CONFLICT (UserId, TmdbId)`. Against the new schema that
+fails two ways — the INSERT omits the NOT NULL `MediaType`, and `ON CONFLICT (UserId, TmdbId)`
+no longer matches any constraint.
+
+## The trap
+
+With a shared DB + slots, **whichever slot runs the old code against the just-migrated schema
+breaks.** There are two such windows:
+
+1. **Deploy → swap gap:** staging boots new code (migrates the DB), but prod is still old code
+   until the swap. Prod breaks in the meantime.
+2. **After the swap:** the old code lands on the *staging* slot, which still shares the DB —
+   so staging breaks until its next deploy.
+
+A column default wouldn't have saved it: the old `ON CONFLICT` target breaks regardless of the
+default, because the unique constraint it names no longer exists.
+
+## Learning
+
+For schema changes on the shared DB, use **expand/contract**, never a one-shot breaking change:
+
+- **Expand (this deploy):** additive only — `ADD COLUMN … DEFAULT`, add a *new* unique index
+  alongside the old one, widen types. Old code must keep working against the expanded schema.
+  Don't drop columns, don't change a PK an old `ON CONFLICT` targets, don't add `NOT NULL`
+  without a default.
+- Deploy, swap, confirm prod is healthy on the new code.
+- **Contract (a later deploy):** once no slot runs the old code, drop the old column/constraint.
+
+If a recreate is genuinely required and the data is ephemeral (cooldown windows etc.), accept
+that both old-code windows above will error for that table, and **swap promptly** to minimize
+window #1 — but prefer expand/contract.
+
+## Related incident — deploy race
+
+The same merge cluster also hit a deploy race: #161 and #162 merged ~20s apart, their staging
+deploys ran concurrently, and the icon-only build (#162, which predated #161) finished *last*
+and overwrote #161 on the staging slot — so the first swap promoted a build missing #161
+entirely. Fixed by giving `main_hurrahtv.yml` and `swap.yml` a shared `concurrency` group
+(`hurrahtv-deploy-pipeline`, `cancel-in-progress: false`) so deploys and swaps serialize.
+
+Related: [[blazor-css-cache-busting]], [[postgres-migration-tsv-truncation]].


### PR DESCRIPTION
## What
Prevent the deploy race that just bit us, and document the shared-DB migration constraint that made #146 risky.

## Why
Two merges (#161, #162) landed ~20s apart. Their staging deploys ran concurrently against the single staging slot; the icon-only build (#162, which predates #161) finished *last* and overwrote #161 on the slot. The first prod swap then promoted a build **missing #161's DbService code** — while the shared DB had already been migrated by #161's staging boot. Recovery was a redeploy + re-swap.

## Changes
- **Shared `concurrency` group** on `main_hurrahtv.yml` and `swap.yml` (`group: hurrahtv-deploy-pipeline`, `cancel-in-progress: false`). Staging deploys and the prod swap now serialize and can never overlap; queued runs execute in trigger order so the latest commit wins cleanly, without cancelling a deploy mid-write.
- **Learning** `shared-db-slot-swaps-need-backward-compatible-migrations.md`: staging and prod share one PostgreSQL DB, so `DbService.InitializeAsync` migrates prod data the moment staging boots. Non-backward-compatible changes (drop/recreate, `NOT NULL` without default, changed PK an old `ON CONFLICT` targets) break whichever slot runs old code — both in the deploy→swap gap and on the staging slot after a swap. Use expand/contract instead.

## Notes
- YAML validated locally. No app code touched.
- The immediate operational fallout from the incident is already resolved out-of-band: prod and staging both run `526c1726` (#161 + #162) and are healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
