### PR TITLE
Fix: watched episodes not removed from Available Now (#170)

### DIFF
--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -501,8 +501,13 @@ public class TmdbService
         int? lastSeason = null, lastEpisode = null;
         if (json.TryGetProperty("last_episode_to_air", out JsonElement lastEp) && lastEp.ValueKind != JsonValueKind.Null)
         {
+            // air_date is date-only; parse as midnight UTC so it stores + round-trips with
+            // Kind=Utc. The Home watchlist filter compares LatestEpisodeDate.Date against
+            // todayUtc.Date — an Unspecified-Kind value could drift a calendar day near
+            // midnight UTC. pins the date-only convention in tmdb-air-date-is-date-only.
             if (lastEp.TryGetProperty("air_date", out JsonElement lastDate) && lastDate.ValueKind == JsonValueKind.String
-                && DateTime.TryParse(lastDate.GetString(), out DateTime parsedLast))
+                && DateTime.TryParse(lastDate.GetString(), CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime parsedLast))
             {
                 lastAired = parsedLast;
             }
@@ -518,8 +523,11 @@ public class TmdbService
         int? nextSeason = null, nextEpisode = null;
         if (json.TryGetProperty("next_episode_to_air", out JsonElement nextEp) && nextEp.ValueKind != JsonValueKind.Null)
         {
+            // same date-only → midnight UTC convention as last_episode_to_air above; the filter
+            // also compares NextEpisodeDate.Date against todayUtc.Date (#170 override).
             if (nextEp.TryGetProperty("air_date", out JsonElement nextDate) && nextDate.ValueKind == JsonValueKind.String
-                && DateTime.TryParse(nextDate.GetString(), out DateTime parsedNext))
+                && DateTime.TryParse(nextDate.GetString(), CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime parsedNext))
             {
                 nextAir = parsedNext;
             }

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -114,6 +114,22 @@ public class WatchlistFiltersTests
         Assert.DoesNotContain(item, result.AvailableNow);
     }
 
+    // pins #170 — #145's Watching override keyed on "LatestEpisodeDate.Date < today",
+    // which is true for nearly every show, so marking the latest watched never removed a
+    // Watching show from Available Now. The earlier already-watched test missed this
+    // because TvItem defaults to WantToWatch (the override only fires for Watching).
+    [Fact]
+    public void AvailableNow_Excludes_Watching_LatestEpisode_Watched_When_No_NewerEpisode()
+    {
+        // caught up: latest aired 2 days ago and is watched; next episode is still upcoming.
+        QueueItem item = TvItem(status: QueueStatus.Watching,
+            latestEpisode: Today.AddDays(-2), nextEpisode: Today.AddDays(5), latestWatched: true);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableNow);
+    }
+
     [Fact]
     public void AvailableNow_Respects_StatusChipFilter()
     {
@@ -259,18 +275,19 @@ public class WatchlistFiltersTests
         Assert.True(result.HasMovieContent);
     }
 
-    // pins #145 mode B (Kimmel-class) — a Watching daily show whose latest known
-    // episode aired on a previous calendar day and is marked watched must STILL
-    // appear in Available Now. Catches TMDb's episode-data lag: by the time TMDb
-    // has published today's Kimmel, the previous episode the user marked watched
-    // is yesterday's calendar date. Without the override the show is hidden all
-    // day until TMDb refreshes.
+    // pins #145 mode B (Kimmel-class), corrected by #170 — a Watching daily show stays in
+    // Available Now after the user watches the latest known episode ONLY because a new
+    // episode airs today (NextEpisodeDate == today), catching TMDb's episode-data lag before
+    // the 12h refresh advances LatestEpisode*. #145's original signal ("latest aired on a
+    // prior calendar day") matched essentially every show, so caught-up shows never left
+    // Available Now — see AvailableNow_Excludes_Watching_LatestEpisode_Watched_When_No_NewerEpisode.
     [Fact]
-    public void AvailableNow_Includes_Watching_Item_With_StaleWatchedLatestEpisode_PinsIssue145()
+    public void AvailableNow_Includes_Watching_DailyShow_WithEpisodeAiringToday_PinsIssue145()
     {
         QueueItem item = TvItem(
             status: QueueStatus.Watching,
             latestEpisode: Today.AddDays(-1),
+            nextEpisode: Today,
             latestWatched: true);
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -295,18 +295,17 @@ public class WatchlistFiltersTests
         Assert.Contains(item, result.AvailableNow);
     }
 
-    // bypass uses calendar-day comparison — a Watching show whose latest known episode
-    // aired today (same calendar date as todayUtc) and is marked watched still respects
-    // the gate, because no plausible new episode exists yet. Pins the lower boundary of
-    // the calendar-day rule. Catches the same-day-trip Copilot flagged on PR #156:
-    // TMDb's air_date is date-only and lands at midnight UTC, so an hour-based threshold
-    // would trip later the same day even though no new episode is out.
+    // #170: the override fires only on NextEpisodeDate having aired, so a caught-up Watching
+    // show with NO scheduled next episode (hiatus, or a season finale TMDb hasn't followed
+    // with a next season) leaves Available Now once the latest is marked watched — there's
+    // genuinely nothing new to surface. Pins the null-NextEpisodeDate branch of the override.
     [Fact]
-    public void AvailableNow_Excludes_Watching_Item_That_Watched_TodaysEpisode()
+    public void AvailableNow_Excludes_Watching_Watched_WithNoUpcomingEpisode()
     {
         QueueItem item = TvItem(
             status: QueueStatus.Watching,
-            latestEpisode: Today,
+            latestEpisode: Today.AddDays(-3),
+            nextEpisode: null,
             latestWatched: true);
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -67,16 +67,17 @@ public static class WatchlistFilters
             // chip is off, since "later" is forward-looking and independent of watch state.
             if (isWatching || isStreamable)
             {
-                // for Watching, bypass IsLatestEpisodeWatched once the calendar day has
-                // advanced past LatestEpisodeDate.Date — TMDb's air_date is date-only and
-                // parsed as midnight UTC, so an hour-based threshold could trip the SAME
-                // day the user marked the episode watched and resurface a caught-up show.
-                // Calendar-day comparison fires only when a new episode is plausibly
-                // available (#145 mode B). The 12h LastEpisodeCheckAt refresh on /api/queue
-                // keeps LatestEpisodeDate fresh enough for daily shows TMDb tracks promptly.
+                // for Watching, resurface a caught-up show (latest episode marked watched)
+                // ONLY when a genuinely newer episode has aired that the 12h /api/queue
+                // refresh hasn't folded into LatestEpisode* yet — i.e. NextEpisodeDate's air
+                // day has arrived. The original #145 override keyed on
+                // "LatestEpisodeDate.Date < today", which matched essentially every show with
+                // a past episode, so marking the latest watched never removed the show from
+                // Available Now (#170). NextEpisodeDate passing is the precise mode-B signal;
+                // AvailableLater handles the still-upcoming (next.Date > today) case.
                 bool overrideLatestWatched = isWatching
-                    && item.LatestEpisodeDate is { } led
-                    && led.Date < today;
+                    && item.NextEpisodeDate is { } nextAired
+                    && nextAired.Date <= today;
 
                 if (isStatusActive(item.Status)
                     && (!item.IsLatestEpisodeWatched || overrideLatestWatched)

--- a/Learnings/state-gate-override-needs-positive-signal.md
+++ b/Learnings/state-gate-override-needs-positive-signal.md
@@ -1,0 +1,69 @@
+# A State-Gate Override Must Key on Positive Evidence, Not a Broad Proxy
+
+> **Area:** Data | UI
+> **Date:** 2026-06-02
+> **Resolves:** mkerchenski/hurrah-tv#170
+
+## Context
+
+The Home "Available Now" filter hides a show once you've watched its latest episode
+(`!IsLatestEpisodeWatched`). #145 added a Watching-only *override* that re-surfaces a
+caught-up show when a newer episode is plausibly out, because TMDb's date-only `air_date`
+plus a 12h refresh can lag behind reality:
+
+```csharp
+bool overrideLatestWatched = isWatching
+    && item.LatestEpisodeDate is { } led
+    && led.Date < today;            // <- the trap
+```
+
+`LatestEpisodeDate.Date < today` is true for essentially **every** show whose latest episode
+aired before today — i.e. almost all of them. So the override fired constantly and the
+`IsLatestEpisodeWatched` gate it was bypassing became a no-op: marking the latest episode
+watched never removed a Watching show from Available Now (#170). It only dropped if the latest
+episode aired *literally today*.
+
+## Learning
+
+1. **An override/escape-hatch that bypasses a primary gate must key on *positive evidence* of
+   the specific condition it exists to handle — not a broad proxy that happens to be true for
+   most rows.** The override's job was "resurface only when a genuinely newer episode has
+   aired." The precise signal for that is `NextEpisodeDate` having passed
+   (`NextEpisodeDate.Date <= today`), not "the last episode aired on a prior day." The broad
+   proxy didn't *narrow* the gate — it nullified it. When you add a bypass, ask: "for what
+   fraction of rows is this true?" If the answer is "nearly all," it's not a special case, it's
+   a silent override of the rule.
+
+2. **Test the dimension the override is gated on.** The regression shipped green because the
+   existing `AvailableNow_Excludes_LatestEpisode_Already_Watched` test used `TvItem`'s default
+   status (`WantToWatch`), and the override only fires for `Watching`. The
+   `Watching`-watched-stale branch — the exact path #145 introduced and #170 broke — had **no**
+   test. When a predicate grows a branch gated by some dimension (here `status == Watching`), a
+   regression test must set that dimension, or the branch is unverified no matter how many other
+   tests pass.
+
+3. **A fix that clears the immediately-reported symptom can still encode a deeper wrong
+   assumption.** #145 was itself a Copilot-praised fix for a *different* same-day bug
+   ([[tmdb-air-date-is-date-only]]), and its truth table labeled the weekly-show-stays-visible
+   case an "acceptable false-positive." That "acceptable" false-positive *was* the bug a user
+   reported as #170. Verify a fix's premise, not just that the originally-reported case is now
+   handled — a reviewer (even a sharp one) can bless a predicate that's still wrong.
+
+## Example
+
+The #170 fix — resurface only on the positive signal:
+
+```csharp
+// resurface a caught-up show ONLY when a genuinely newer episode has aired that the 12h
+// refresh hasn't folded into LatestEpisode* yet — i.e. NextEpisodeDate's air day has arrived.
+bool overrideLatestWatched = isWatching
+    && item.NextEpisodeDate is { } nextAired
+    && nextAired.Date <= today;
+```
+
+This is complementary to the AvailableLater branch (`next.Date > today`), so the two never
+gap or overlap at `today`. A daily show (Kimmel) keeps working — its next episode airs today;
+a weekly show you've caught up on correctly drops.
+
+Related: [[tmdb-air-date-is-date-only]], [[date-predicates-prefer-typed-comparisons]],
+[[predicate-alignment-truth-table]].

--- a/Learnings/tmdb-air-date-is-date-only.md
+++ b/Learnings/tmdb-air-date-is-date-only.md
@@ -3,6 +3,30 @@
 > **Area:** TMDb | Data | Date
 > **Date:** 2026-05-28
 > **Resolves:** mkerchenski/hurrah-tv#145
+> **Corrected in part by:** mkerchenski/hurrah-tv#170 (see "Correction (#170)" below — the
+> override predicate this learning endorsed was too broad; the core date-only lesson stands)
+
+## Correction (#170)
+
+The date-only / no-hour-math **core lesson below is still correct** — that's why #145 moved off
+`(todayUtc - led).TotalHours > 18`. But two things this file got wrong or omitted:
+
+1. **The endorsed override predicate (`led.Date < today`) was far too broad.** It's true for
+   nearly every show whose latest episode aired before today, so the override fired constantly
+   and nullified the `IsLatestEpisodeWatched` gate it was bypassing — marking the latest episode
+   watched stopped removing Watching shows from Available Now. The "Test boundary" table below
+   even labels the weekly-show-stays-visible row an *"acceptable false-positive per the plan"* —
+   that "acceptable" case is exactly what a user reported as the #170 bug. The resurface signal
+   must be **positive evidence of a newer episode**, i.e. `NextEpisodeDate.Date <= today`, not
+   "the latest aired on a prior day." See [[state-gate-override-needs-positive-signal]].
+
+2. **A bare `DateTime.TryParse` of a date-only string yields `Kind=Unspecified`, not UTC.** This
+   file says the value is "parsed as midnight UTC" — true for the *date* but not the *Kind*.
+   `WatchlistFilters` compares `LatestEpisodeDate.Date` / `NextEpisodeDate.Date` against
+   `todayUtc.Date`; an `Unspecified`-Kind value can drift a calendar day near midnight UTC. Parse
+   TMDb date-only fields with `CultureInfo.InvariantCulture` + `DateTimeStyles.AssumeUniversal |
+   DateTimeStyles.AdjustToUniversal` so they store and round-trip as `Kind=Utc` (fixed at the
+   `TmdbService.GetEpisodeDatesAsync` parse site, #170).
 
 ## Context
 


### PR DESCRIPTION
## What
Marking the latest episode watched now correctly removes a **Watching** TV show from the Home "Available Now" row.

## Why
`WatchlistFilters.Apply` admitted a Watching item via `!IsLatestEpisodeWatched || overrideLatestWatched`, where #145's override was:

```csharp
bool overrideLatestWatched = isWatching && item.LatestEpisodeDate is { } led && led.Date < today;
```

`LatestEpisodeDate.Date < today` is true for essentially every show whose latest episode aired before today — so once you marked the latest watched, the override kept the show in Available Now regardless. It only dropped if the latest episode aired *literally today*. Recent regression from #145 (`02df512`).

## Fix
Re-key the override on the precise mode-B signal: a genuinely newer episode has aired (`NextEpisodeDate.Date <= today`) that the 12h `/api/queue` refresh hasn't folded into `LatestEpisode*` yet.

- **Daily show (Kimmel-class):** next episode airs today → `NextEpisodeDate.Date == today` → override fires → stays visible. #145 mode B preserved.
- **Weekly show you've caught up on:** next episode is in the future → override off → `IsLatestEpisodeWatched` removes it. Bug fixed.
- `AvailableLater` still owns the upcoming `next.Date > today` case, so the two rows stay complementary.

## Tests
- Rewrote the #145 test to express mode B via `NextEpisodeDate` (the accurate signal) instead of "latest aired on a prior day."
- Added a #170 regression for the `Watching` + latest-watched + no-newer-episode case. The prior already-watched test used `WantToWatch`, so the `Watching`-only override path was never exercised — that's the gap that let #145 regress.
- Full suite green (86 Shared / 39 Client / 28 Api); `dotnet format --verify-no-changes` clean.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
