### PR TITLE
Fix: don't resurface caught-up daily show until next episode has aired (#172)

### DIFF
--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -275,14 +275,31 @@ public class WatchlistFiltersTests
         Assert.True(result.HasMovieContent);
     }
 
-    // pins #145 mode B (Kimmel-class), corrected by #170 — a Watching daily show stays in
-    // Available Now after the user watches the latest known episode ONLY because a new
-    // episode airs today (NextEpisodeDate == today), catching TMDb's episode-data lag before
-    // the 12h refresh advances LatestEpisode*. #145's original signal ("latest aired on a
-    // prior calendar day") matched essentially every show, so caught-up shows never left
-    // Available Now — see AvailableNow_Excludes_Watching_LatestEpisode_Watched_When_No_NewerEpisode.
+    // pins #145 mode B (Kimmel-class), corrected by #170/#172 — a caught-up Watching show
+    // resurfaces ONLY when a newer episode's air day has *fully passed* (NextEpisodeDate.Date
+    // < today), meaning it definitely aired and the 12h refresh simply hasn't advanced
+    // LatestEpisode* yet. Strictly-past, not <= today, so a show airing later *today* doesn't
+    // resurface before its episode is watchable (#172).
     [Fact]
-    public void AvailableNow_Includes_Watching_DailyShow_WithEpisodeAiringToday_PinsIssue145()
+    public void AvailableNow_Includes_Watching_Watched_WhenNextEpisodeDayHasPassed_PinsIssue145()
+    {
+        QueueItem item = TvItem(
+            status: QueueStatus.Watching,
+            latestEpisode: Today.AddDays(-2),
+            nextEpisode: Today.AddDays(-1),  // its air day fully elapsed → genuinely aired, refresh lagging
+            latestWatched: true);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableNow);
+    }
+
+    // pins #172 — a daily show whose next episode airs *today* (but hasn't aired yet) must NOT
+    // resurface after the user watches the prior episode. air_date is date-only, so
+    // NextEpisodeDate == today can't be assumed watchable; <= today wrongly kept caught-up
+    // daily shows in Available Now all day.
+    [Fact]
+    public void AvailableNow_Excludes_Watching_Watched_WhenNextEpisodeAirsLaterToday()
     {
         QueueItem item = TvItem(
             status: QueueStatus.Watching,
@@ -292,7 +309,7 @@ public class WatchlistFiltersTests
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
 
-        Assert.Contains(item, result.AvailableNow);
+        Assert.DoesNotContain(item, result.AvailableNow);
     }
 
     // #170: the override fires only on NextEpisodeDate having aired, so a caught-up Watching

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -67,17 +67,18 @@ public static class WatchlistFilters
             // chip is off, since "later" is forward-looking and independent of watch state.
             if (isWatching || isStreamable)
             {
-                // for Watching, resurface a caught-up show (latest episode marked watched)
-                // ONLY when a genuinely newer episode has aired that the 12h /api/queue
-                // refresh hasn't folded into LatestEpisode* yet — i.e. NextEpisodeDate's air
-                // day has arrived. The original #145 override keyed on
-                // "LatestEpisodeDate.Date < today", which matched essentially every show with
-                // a past episode, so marking the latest watched never removed the show from
-                // Available Now (#170). NextEpisodeDate passing is the precise mode-B signal;
-                // AvailableLater handles the still-upcoming (next.Date > today) case.
+                // for Watching, resurface a caught-up show (latest episode marked watched) ONLY
+                // when a genuinely newer episode has aired that the 12h /api/queue refresh hasn't
+                // folded into LatestEpisode* yet — i.e. NextEpisodeDate's air day has fully
+                // PASSED (< today). air_date is date-only, so a NextEpisodeDate of *today* hasn't
+                // necessarily aired (a daily show airing tonight) — using <= today resurfaced a
+                // caught-up daily show on its air day before the episode was watchable (#172).
+                // Strictly-past means a full calendar day has elapsed, so it definitely aired and
+                // our data is merely stale. The original #145 override keyed on LatestEpisodeDate,
+                // which matched nearly every show and never removed watched shows (#170).
                 bool overrideLatestWatched = isWatching
                     && item.NextEpisodeDate is { } nextAired
-                    && nextAired.Date <= today;
+                    && nextAired.Date < today;
 
                 if (isStatusActive(item.Status)
                     && (!item.IsLatestEpisodeWatched || overrideLatestWatched)


### PR DESCRIPTION
## What
A daily show whose next episode airs **today** (but hasn't aired yet) wasn't removed from Home "Available Now" after marking the prior episode watched. Reported in production after #170 shipped.

## Why
#170's resurface override used `NextEpisodeDate.Date <= today`. TMDb's `air_date` is date-only, so `NextEpisodeDate == today` doesn't mean the episode has aired — a daily show airs later tonight. `<= today` therefore resurfaced a caught-up daily show on its air day, before the new episode was watchable, so marking the latest watched didn't remove it.

## Fix
`NextEpisodeDate.Date < today` — resurface only once the next episode's air day has **fully passed** (it definitely aired, and our 12h-refreshed `LatestEpisode*` is merely stale). A show airing later today no longer counts as "available now"; it returns via the normal `!IsLatestEpisodeWatched` path once the refresh advances `LatestEpisode*`.

This is the boundary the date-only data actually supports — `< today` means a full calendar day elapsed since the air date, so it's genuinely aired.

## Tests
- Reframed the #145 mode-B test to the strictly-past case (`NextEpisodeDate.Date < today` → genuinely aired → resurface).
- Added a #172 regression: `NextEpisodeDate == today`, latest watched → **excluded**.
- The future-next and null-next exclude cases (from #170) still hold.
- 26 WatchlistFilters tests pass; `dotnet format --verify-no-changes` clean.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
