### PR TITLE
Fix: 'Episode Watched' quick action missing on some Available Now shows (#168)

### DIFF
--- a/HurrahTv.Client/Components/QuickActions.razor
+++ b/HurrahTv.Client/Components/QuickActions.razor
@@ -20,23 +20,34 @@
                 </div>
             </div>
 
-            <!-- episode watched — only for TV shows in the queue with a recently-aired,
-                 not-yet-watched latest episode. Self-gated: no caller flag needed. -->
+            <!-- episode watched — for TV shows you're Watching whose latest aired episode
+                 isn't marked watched yet. Self-gated, no recency window (#168). Once marked,
+                 the gate hides it on reopen (the modal closes optimistically on tap). -->
             @if (ShouldShowEpisodeWatched())
             {
-                <button class="w-full py-2.5 rounded-lg text-sm font-medium mb-4 transition-colors flex items-center justify-center gap-1.5 disabled:opacity-50
-                               @(_episodeWatched ? "bg-green-600/30 text-green-400 ring-1 ring-green-500/50" : "bg-surface-200 text-gray-300 hover:text-white")"
+                <button class="w-full py-2.5 rounded-lg text-sm font-medium mb-4 transition-colors flex items-center justify-center gap-1.5 disabled:opacity-50 bg-surface-200 text-gray-300 hover:text-white"
                         disabled="@(_busy && _pendingAction != "episode")"
-                        @onclick="ToggleEpisodeWatched" @onclick:stopPropagation="true">
+                        @onclick="MarkEpisodeWatched" @onclick:stopPropagation="true">
                     @if (_pendingAction == "episode")
                     {
                         <span class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin"></span>
                     }
                     else
                     {
-                        <span class="@(_episodeWatched ? "icon-[heroicons--check-circle-20-solid]" : "icon-[heroicons--check-circle]") w-4 h-4"></span>
+                        <span class="icon-[heroicons--check-circle] w-4 h-4"></span>
                     }
-                    @(_episodeWatched ? "Episode Marked Watched" : "Episode Watched")
+                    Episode Watched
+                </button>
+            }
+            else if (ShouldShowEpisodePending())
+            {
+                <!-- latest-episode metadata not refreshed from TMDb yet — explain the gap
+                     rather than silently hiding the action (#168). -->
+                <button disabled
+                        class="w-full py-2.5 rounded-lg text-sm font-medium mb-4 flex items-center justify-center gap-1.5 bg-surface-200/50 text-gray-500 cursor-default"
+                        @onclick:stopPropagation="true">
+                    <span class="icon-[heroicons--arrow-path] w-4 h-4"></span>
+                    Episode info updating…
                 </button>
             }
 
@@ -109,6 +120,7 @@
     private QueueStatus _currentStatus;
     private int? _currentSentiment;
     private SearchResult? _searchResult;
+    private QueueItem? _item; // backing item for queue-surface gates; null on the browse surface
 
     private static readonly (int Level, string ActiveCss, string InactiveCss, string Icon, string Label)[] _sentimentOptions =
     [
@@ -122,20 +134,19 @@
     private int _episodeSeason;
     private int _episodeNumber;
     private bool _episodeWatched;
-    private DateTime? _latestEpisodeDate;
 
-    // mirrors the Continue Watching filter; 7-day window matches DbService.GetQueueAsync.
-    // UTC on both sides so users west of UTC don't get a negative-days window for episodes
-    // that aired late-UTC the prior calendar day local-time.
-    private bool ShouldShowEpisodeWatched()
-    {
-        if (_queueId <= 0 || _mediaType != MediaTypes.Tv) return false;
-        if (_currentStatus != QueueStatus.Watching) return false;
-        if (!_hasEpisodeData || _episodeWatched) return false;
-        if (_latestEpisodeDate is not DateTime aired) return false;
-        int days = (int)(DateTime.UtcNow.Date - aired.ToUniversalTime().Date).TotalDays;
-        return days >= 0 && days <= 7;
-    }
+    // gate lives on QueueItem (CanMarkLatestEpisodeWatched) so it's unit-tested in Shared.
+    private bool ShouldShowEpisodeWatched() =>
+        _item is { } item && item.CanMarkLatestEpisodeWatched(DateTime.UtcNow);
+
+    // a Watching TV item whose episode metadata hasn't been refreshed from TMDb yet — show a
+    // disabled "updating" hint instead of silently hiding the action (#168). Distinct from the
+    // already-watched case, which intentionally shows nothing.
+    private bool ShouldShowEpisodePending() =>
+        _item is { } item
+        && item.MediaType == MediaTypes.Tv
+        && item.Status == QueueStatus.Watching
+        && !_hasEpisodeData;
 
     private void RunAction(string actionKey, Func<Task> action)
     {
@@ -188,12 +199,12 @@
         _currentStatus = item.Status;
         _currentSentiment = item.Sentiment;
         _searchResult = null;
+        _item = item;
         _hasEpisodeData = item.LatestEpisodeSeason.HasValue && item.LatestEpisodeNumber.HasValue;
         _episodeTmdbId = item.TmdbId;
         _episodeSeason = item.LatestEpisodeSeason ?? 0; // 0 only when HasValue==false; Season 0 (specials) is HasValue==true
         _episodeNumber = item.LatestEpisodeNumber ?? 0;
         _episodeWatched = item.IsLatestEpisodeWatched;
-        _latestEpisodeDate = item.LatestEpisodeDate;
         _visible = true;
         StateHasChanged();
     }
@@ -207,44 +218,39 @@
         _currentStatus = default;
         _currentSentiment = null;
         _searchResult = result;
+        _item = null;
         _hasEpisodeData = false;
         _episodeTmdbId = 0;
         _episodeSeason = 0;
         _episodeNumber = 0;
         _episodeWatched = false;
-        _latestEpisodeDate = null;
         _visible = true;
         StateHasChanged();
     }
 
-    private void ToggleEpisodeWatched()
+    private void MarkEpisodeWatched()
     {
-        // data not yet populated — skip; refresh will rehydrate and reopen will work
-        if (!_hasEpisodeData) return;
+        // gate already excludes watched + unpopulated items, but guard the action path too
+        if (!_hasEpisodeData || _episodeWatched) return;
 
-        bool previous = _episodeWatched;
-        bool target = !previous;
         int tmdbId = _episodeTmdbId;
         int season = _episodeSeason;
         int episode = _episodeNumber;
-        _episodeWatched = target;
+        _episodeWatched = true;
 
         RunAction("episode", async () =>
         {
             try
             {
-                if (target)
-                    await Api.MarkEpisodeWatchedAsync(tmdbId, season, episode);
-                else
-                    await Api.UnmarkEpisodeWatchedAsync(tmdbId, season, episode);
+                await Api.MarkEpisodeWatchedAsync(tmdbId, season, episode);
                 // targeted update — Home updates its watched-set in place, no refetch needed
-                QuickActionSvc.NotifyEpisodeWatchedChanged(tmdbId, season, episode, target);
+                QuickActionSvc.NotifyEpisodeWatchedChanged(tmdbId, season, episode, true);
             }
             catch
             {
                 // revert local state so the modal shows the truth on reopen; the broad
                 // NotifyChanged from ExecuteActionAsync's failure path also fires
-                _episodeWatched = previous;
+                _episodeWatched = false;
                 throw;
             }
         });

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -705,6 +705,9 @@
   .fade-in {
     animation: fadeIn 0.3s ease-in;
   }
+  .cursor-default {
+    cursor: default;
+  }
   .cursor-grab {
     cursor: grab;
   }
@@ -1127,6 +1130,12 @@
   }
   .bg-surface-200 {
     background-color: var(--color-surface-200);
+  }
+  .bg-surface-200\/50 {
+    background-color: color-mix(in srgb, #2e2e2e 50%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-surface-200) 50%, transparent);
+    }
   }
   .bg-white {
     background-color: var(--color-white);

--- a/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs
@@ -89,4 +89,98 @@ public class QueueItemDatePredicatesTests
         QueueItem item = new() { LatestEpisodeDate = DateTime.UtcNow.AddDays(10) };
         Assert.False(item.HasEpisodeThisMonth);
     }
+
+    // --- CanMarkLatestEpisodeWatched: the QuickActions "Episode Watched" gate (#168) ---
+    // builds a Watching TV item with populated, unwatched, already-aired latest-episode
+    // metadata — the baseline that should pass — so each test flips one condition.
+    private static QueueItem MarkableTvItem(DateTime todayUtc) => new()
+    {
+        MediaType = MediaTypes.Tv,
+        Status = QueueStatus.Watching,
+        LatestEpisodeSeason = 1,
+        LatestEpisodeNumber = 5,
+        IsLatestEpisodeWatched = false,
+        LatestEpisodeDate = todayUtc.AddDays(-3),
+    };
+
+    // pins #168 — the original bug: a 7-day recency fence hid the action on Available Now
+    // shows whose latest episode aired more than a week ago. No window now.
+    [Fact]
+    public void CanMarkLatestEpisodeWatched_IsTrue_WhenLatestEpisodeAiredMoreThan7DaysAgo()
+    {
+        DateTime today = DateTime.UtcNow;
+        QueueItem item = MarkableTvItem(today);
+        item.LatestEpisodeDate = today.AddDays(-30);
+        Assert.True(item.CanMarkLatestEpisodeWatched(today));
+    }
+
+    // today-inclusive: air_date is date-only and we'd rather over-show a live-watched episode.
+    [Fact]
+    public void CanMarkLatestEpisodeWatched_IsTrue_WhenLatestEpisodeAiredToday()
+    {
+        DateTime today = new(2026, 6, 7, 14, 0, 0, DateTimeKind.Utc);
+        QueueItem item = MarkableTvItem(today);
+        item.LatestEpisodeDate = new DateTime(2026, 6, 7, 2, 0, 0, DateTimeKind.Utc); // earlier same UTC day
+        Assert.True(item.CanMarkLatestEpisodeWatched(today));
+    }
+
+    // typed date comparison must reject a future-stamped LatestEpisodeDate (TMDb backfill
+    // quirk) — a signed day-diff <= window would have let an unaired episode through (#49/#70).
+    [Fact]
+    public void CanMarkLatestEpisodeWatched_IsFalse_WhenLatestEpisodeIsInTheFuture()
+    {
+        DateTime today = DateTime.UtcNow;
+        QueueItem item = MarkableTvItem(today);
+        item.LatestEpisodeDate = today.AddDays(2);
+        Assert.False(item.CanMarkLatestEpisodeWatched(today));
+    }
+
+    [Fact]
+    public void CanMarkLatestEpisodeWatched_IsFalse_WhenAlreadyWatched()
+    {
+        DateTime today = DateTime.UtcNow;
+        QueueItem item = MarkableTvItem(today);
+        item.IsLatestEpisodeWatched = true;
+        Assert.False(item.CanMarkLatestEpisodeWatched(today));
+    }
+
+    [Theory]
+    [InlineData(QueueStatus.WantToWatch)]
+    [InlineData(QueueStatus.Finished)]
+    [InlineData(QueueStatus.NotForMe)]
+    public void CanMarkLatestEpisodeWatched_IsFalse_WhenNotWatching(QueueStatus status)
+    {
+        DateTime today = DateTime.UtcNow;
+        QueueItem item = MarkableTvItem(today);
+        item.Status = status;
+        Assert.False(item.CanMarkLatestEpisodeWatched(today));
+    }
+
+    [Fact]
+    public void CanMarkLatestEpisodeWatched_IsFalse_ForMovies()
+    {
+        DateTime today = DateTime.UtcNow;
+        QueueItem item = MarkableTvItem(today);
+        item.MediaType = MediaTypes.Movie;
+        Assert.False(item.CanMarkLatestEpisodeWatched(today));
+    }
+
+    // episode metadata not yet refreshed from TMDb — gate is false (the QuickActions
+    // "Episode info updating…" hint covers this case instead of the action).
+    [Fact]
+    public void CanMarkLatestEpisodeWatched_IsFalse_WhenEpisodeMetadataNotPopulated()
+    {
+        DateTime today = DateTime.UtcNow;
+        QueueItem item = MarkableTvItem(today);
+        item.LatestEpisodeSeason = null;
+        item.LatestEpisodeNumber = null;
+        Assert.False(item.CanMarkLatestEpisodeWatched(today));
+    }
+
+    [Fact]
+    public void CanMarkLatestEpisodeWatched_IsTrue_ForBaselineWatchingAiredUnwatchedTvItem()
+    {
+        DateTime today = DateTime.UtcNow;
+        Assert.True(MarkableTvItem(today).CanMarkLatestEpisodeWatched(today));
+    }
 }

--- a/HurrahTv.Shared/Models/QueueItem.cs
+++ b/HurrahTv.Shared/Models/QueueItem.cs
@@ -46,6 +46,22 @@ public class QueueItem
     public bool HasEpisodeThisMonth => LatestEpisodeDate.HasValue
         && LatestEpisodeDate.Value >= DateTime.UtcNow.AddDays(-30)
         && LatestEpisodeDate.Value <= DateTime.UtcNow;
+
+    // "Episode Watched" quick action gate: a TV show you're Watching whose latest aired
+    // episode has populated metadata and hasn't been marked watched yet. Deliberately has
+    // NO recency window — Available Now membership doesn't imply the 7-day Continue-Watching
+    // window, so the old 7-day fence silently hid the action on shows whose latest episode
+    // aired more than a week ago (#168). Today-inclusive: air_date is date-only, and we'd
+    // rather over-show than hide a live-watched episode dated today. Typed date comparison,
+    // not a signed day-diff, so a future-stamped LatestEpisodeDate can't pass (#49/#70).
+    public bool CanMarkLatestEpisodeWatched(DateTime todayUtc) =>
+        MediaType == MediaTypes.Tv
+        && Status == QueueStatus.Watching
+        && LatestEpisodeSeason.HasValue
+        && LatestEpisodeNumber.HasValue
+        && !IsLatestEpisodeWatched
+        && LatestEpisodeDate is { } aired
+        && aired.Date <= todayUtc.Date;
 }
 
 public enum QueueStatus


### PR DESCRIPTION
## What

QuickActions' "Episode Watched" gate copied the Continue Watching **7-day recency fence**, which silently hid the action on Available Now shows whose latest episode aired more than a week ago. Available Now membership is a different rule (streamable / committed-to) and doesn't imply recency — so the availability looked arbitrary.

## Why

`ShouldShowEpisodeWatched()` required the latest episode to have aired within the last 7 days. A show you're actively watching whose latest episode aired, say, 10 days ago appeared in Available Now with no "Episode Watched" option. The 7-day window is intentional for the Continue Watching hero, but wrong for the QuickActions context.

## Changes

- **`HurrahTv.Shared/Models/QueueItem.cs`** — new testable predicate `CanMarkLatestEpisodeWatched(DateTime todayUtc)`: `Watching` + `Tv` + populated episode metadata + **not** already watched + latest episode aired (`aired.Date <= todayUtc.Date`, today-inclusive). **No recency window.** Typed date comparison (not a signed day-diff) so a future-stamped `LatestEpisodeDate` can't slip through (#49/#70 trap).
- **`HurrahTv.Client/Components/QuickActions.razor`** — gate delegates to the Shared predicate. Added a disabled **"Episode info updating…"** hint for `Watching` TV items whose TMDb metadata hasn't refreshed yet, instead of silently hiding the action. Simplified the now-unreachable unmark branch to a mark-only action (unmark is still available via `EpisodeBrowser`).
- **`HurrahTv.Shared.Tests/QueueItemDatePredicatesTests.cs`** — 9 regressions pinning #168.

## Acceptance criteria

- [x] Intended rule decided: any `Watching` TV item with a populated, unwatched, aired latest episode — independent of the 7-day window
- [x] "Episode Watched" appears consistently for matching Available Now TV shows
- [x] `_hasEpisodeData == false` degrades gracefully (disabled "updating…" hint) rather than silently hiding
- [ ] Verify on device: hard-press several Available Now shows, including one with a latest episode older than 7 days

## Verification

- Shared tests pass (21), Client builds with 0 warnings, `npm run build:css` clean, CI formatter gate clean.

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)