### PR TITLE
Queue Position race + Home hero media-filter fixes + drag-reorder off-by-one + dev OTP login

### DIFF
--- a/HurrahTv.Api.Tests/QueueEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/QueueEndpointsTests.cs
@@ -237,6 +237,29 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         Assert.Single(list!.Items);
     }
 
+    // pins #163 — concurrent adds of DISTINCT titles for one user must land on distinct
+    // Position values. Before the per-user advisory lock, both calls read the same
+    // COALESCE(MAX(Position),0) before either INSERT committed and wrote the same Position,
+    // leaving GetQueueAsync's Position-keyed ORDER BY to pick an arbitrary relative order.
+    [Fact]
+    public async Task ConcurrentAdds_DistinctTitles_GetDistinctPositions()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "user-pos-race");
+
+        const int n = 8;
+        HttpResponseMessage[] responses = await Task.WhenAll(
+            Enumerable.Range(0, n).Select(i =>
+                client.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1000 + i, title: $"Show {i}"))));
+
+        Assert.All(responses, r => Assert.True(r.IsSuccessStatusCode, $"unexpected {(int)r.StatusCode}"));
+
+        QueueResponse? list = await client.GetFromJsonAsync<QueueResponse>("/api/queue");
+        Assert.Equal(n, list!.Items.Count);
+
+        int[] positions = [.. list.Items.Select(i => i.Position)];
+        Assert.Equal(n, positions.Distinct().Count());
+    }
+
     private static async Task<QueueItem?> PostAsync(HttpClient client, QueueItem payload)
     {
         HttpResponseMessage resp = await client.PostAsJsonAsync("/api/queue", payload);

--- a/HurrahTv.Api/Endpoints/CurationEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/CurationEndpoints.cs
@@ -24,7 +24,7 @@ public static class CurationEndpoints
 
                 // active Home media filter — narrows the cached reservoir to a movie/TV pick (#147).
                 // anything other than a valid media type means "all" (no narrowing).
-                string filter = MediaTypes.IsValid(mediaType) ? mediaType! : "all";
+                string filter = MediaTypes.IsValid(mediaType) ? mediaType! : MediaTypes.All;
 
                 // a shuffle always advances the pick (free); only the paid reservoir regen is
                 // rate-limited, so a second shuffle inside the cooldown still moves to a new pick.

--- a/HurrahTv.Api/Endpoints/CurationEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/CurationEndpoints.cs
@@ -16,11 +16,15 @@ public static class CurationEndpoints
         // single rotating AI hero pick for the home page (replaces the curated-rows section).
         // ?refresh=true regenerates the reservoir and advances past today's pick (rate-limited).
         group.MapGet("/hero", async (ClaimsPrincipal user, DbService db, CurationService curation,
-            TmdbService tmdb, IMemoryCache cache, ILogger<CurationService> logger, bool? refresh, CancellationToken ct) =>
+            TmdbService tmdb, IMemoryCache cache, ILogger<CurationService> logger, bool? refresh, string? mediaType, CancellationToken ct) =>
         {
             try
             {
                 string userId = user.GetUserId();
+
+                // active Home media filter — narrows the cached reservoir to a movie/TV pick (#147).
+                // anything other than a valid media type means "all" (no narrowing).
+                string filter = MediaTypes.IsValid(mediaType) ? mediaType! : "all";
 
                 // a shuffle always advances the pick (free); only the paid reservoir regen is
                 // rate-limited, so a second shuffle inside the cooldown still moves to a new pick.
@@ -41,7 +45,7 @@ public static class CurationEndpoints
                 DbService.UserPreferences prefs = prefsTask.Result;
                 List<int> providerIds = prefs.ProviderIds;
                 HeroResult result = await curation.GetCuratedHeroAsync(userId, watchlistTask.Result, providerIds, prefs.GenreIds,
-                    prefs.EnglishOnly, regenerateReservoir: regenerate, advancePick: doRefresh, cancellationToken: ct);
+                    prefs.EnglishOnly, regenerateReservoir: regenerate, advancePick: doRefresh, mediaType: filter, cancellationToken: ct);
 
                 CuratedHero? hero = await ResolveHeroAsync(result, providerIds, tmdb, ct);
 

--- a/HurrahTv.Api/Services/CurationService.cs
+++ b/HurrahTv.Api/Services/CurationService.cs
@@ -168,7 +168,7 @@ public partial class CurationService
     //     the next-best — every shuffle changes the pick, even when regen is rate-limited.
     //   - regenerateReservoir (paid AI, rate-limited): pull genuinely new candidate material.
     public async Task<HeroResult> GetCuratedHeroAsync(string userId, List<QueueItem> watchlist, List<int> providerIds, List<int> genreIds,
-        bool englishOnly = false, bool regenerateReservoir = false, bool advancePick = false, CancellationToken cancellationToken = default)
+        bool englishOnly = false, bool regenerateReservoir = false, bool advancePick = false, string mediaType = "all", CancellationToken cancellationToken = default)
     {
         CurationResult reservoir = await GetCuratedRowsAsync(userId, watchlist, providerIds, genreIds, englishOnly, regenerateReservoir, cancellationToken);
         AICuratedRow? row = reservoir.Rows.FirstOrDefault();
@@ -178,9 +178,12 @@ public partial class CurationService
         // drop anything already on the watchlist, so a title the user has (or just added) can't
         // come back as a recommendation. Keyed on (TmdbId, MediaType) because TMDb ids are
         // namespaced per media type — a movie and a TV show can share a numeric id.
+        // mediaType narrows the SAME cached reservoir to the active Home filter (#147) — a filter
+        // toggle re-selects from existing material, never triggers a paid regen.
         HashSet<(int, string)> onWatchlist = [.. watchlist.Select(i => (i.TmdbId, i.MediaType))];
         List<HeroCandidate> candidates = [.. row.Picks
             .Where(p => !onWatchlist.Contains((p.TmdbId, p.MediaType)))
+            .Where(p => mediaType == "all" || p.MediaType == mediaType)
             .Select(p => new HeroCandidate(p.TmdbId, p.MediaType, p.Score))];
 
         Dictionary<(int TmdbId, string MediaType), DateTime> lastShown = await _db.GetHeroImpressionsAsync(userId, cancellationToken);

--- a/HurrahTv.Api/Services/CurationService.cs
+++ b/HurrahTv.Api/Services/CurationService.cs
@@ -168,7 +168,7 @@ public partial class CurationService
     //     the next-best — every shuffle changes the pick, even when regen is rate-limited.
     //   - regenerateReservoir (paid AI, rate-limited): pull genuinely new candidate material.
     public async Task<HeroResult> GetCuratedHeroAsync(string userId, List<QueueItem> watchlist, List<int> providerIds, List<int> genreIds,
-        bool englishOnly = false, bool regenerateReservoir = false, bool advancePick = false, string mediaType = "all", CancellationToken cancellationToken = default)
+        bool englishOnly = false, bool regenerateReservoir = false, bool advancePick = false, string mediaType = MediaTypes.All, CancellationToken cancellationToken = default)
     {
         CurationResult reservoir = await GetCuratedRowsAsync(userId, watchlist, providerIds, genreIds, englishOnly, regenerateReservoir, cancellationToken);
         AICuratedRow? row = reservoir.Rows.FirstOrDefault();
@@ -183,7 +183,7 @@ public partial class CurationService
         HashSet<(int, string)> onWatchlist = [.. watchlist.Select(i => (i.TmdbId, i.MediaType))];
         List<HeroCandidate> candidates = [.. row.Picks
             .Where(p => !onWatchlist.Contains((p.TmdbId, p.MediaType)))
-            .Where(p => mediaType == "all" || p.MediaType == mediaType)
+            .Where(p => mediaType == MediaTypes.All || p.MediaType == mediaType)
             .Select(p => new HeroCandidate(p.TmdbId, p.MediaType, p.Score))];
 
         Dictionary<(int TmdbId, string MediaType), DateTime> lastShown = await _db.GetHeroImpressionsAsync(userId, cancellationToken);

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -262,11 +262,17 @@ public class DbService(IConfiguration config)
     public async Task<QueueItem?> AddToQueueAsync(QueueItem item, string userId)
     {
         using NpgsqlConnection db = await OpenAsync();
+        using NpgsqlTransaction tx = await db.BeginTransactionAsync();
+
+        // serialize concurrent adds for THIS user so two distinct-title adds can't read the
+        // same MAX(Position) and collide on Position. xact-scoped — auto-released on commit.
+        // keyed per-user (not global) so unrelated users never contend. pins #163.
+        await LockUserQueueAsync(db, userId, tx);
 
         // next position — only consumed when the INSERT actually lands a row
         int maxPos = await db.QuerySingleOrDefaultAsync<int>(
             "SELECT COALESCE(MAX(Position), 0) FROM QueueItems WHERE UserId = @UserId",
-            new { UserId = userId });
+            new { UserId = userId }, tx);
 
         item.Position = maxPos + 1;
 
@@ -292,18 +298,27 @@ public class DbService(IConfiguration config)
             item.Sentiment,
             item.AvailableOnJson,
             AddedAt = DateTime.UtcNow
-        });
+        }, tx);
 
         if (id is not null)
         {
+            await tx.CommitAsync();
             item.Id = id.Value;
             return item;
         }
 
         // conflict — the title is already queued. Return the existing row so the add is
         // idempotent (the caller surfaces it as success, not a 409). pins #155.
-        return await SelectQueueItemAsync(db, userId, item.TmdbId, item.MediaType);
+        QueueItem? existing = await SelectQueueItemAsync(db, userId, item.TmdbId, item.MediaType, tx);
+        await tx.CommitAsync();
+        return existing;
     }
+
+    // per-user transaction-scoped advisory lock. hashtext(userId) maps the string UserId to the
+    // bigint key pg_advisory_xact_lock expects; the lock is released automatically when tx
+    // commits or rolls back, so callers never have to unlock explicitly. pins #163.
+    private static Task<int> LockUserQueueAsync(NpgsqlConnection db, string userId, NpgsqlTransaction tx) =>
+        db.ExecuteAsync("SELECT pg_advisory_xact_lock(hashtext(@UserId))", new { UserId = userId }, tx);
 
     public async Task<bool> RemoveFromQueueAsync(int id, string userId)
     {
@@ -428,9 +443,15 @@ public class DbService(IConfiguration config)
         if (existing != null)
             return await ApplyUpdatePolicy(existing);
 
+        // insert branch — serialize per-user so concurrent distinct-title adds can't read the
+        // same MAX(Position) and collide. only the insert path takes the lock; the fast path
+        // above mutates a single row by Id and never allocates a Position. pins #163.
+        using NpgsqlTransaction tx = await db.BeginTransactionAsync();
+        await LockUserQueueAsync(db, userId, tx);
+
         int maxPos = await db.QuerySingleOrDefaultAsync<int>(
             "SELECT COALESCE(MAX(Position), 0) FROM QueueItems WHERE UserId = @UserId",
-            new { UserId = userId });
+            new { UserId = userId }, tx);
 
         // ON CONFLICT DO NOTHING guards against a concurrent caller inserting the same
         // (UserId, TmdbId, MediaType) between our SELECT and INSERT — without it the new
@@ -452,15 +473,18 @@ public class DbService(IConfiguration config)
             Status = (int)targetStatus,
             AvailableOnJson = availableOnJson,
             AddedAt = DateTime.UtcNow
-        });
+        }, tx);
 
         if (id is null)
         {
             // lost the insert race — the row exists now. Re-read and apply the same policy
             // the fast path would have, so a concurrent /seen + /ensure can't diverge.
-            existing = await SelectQueueItemAsync(db, userId, tmdbId, mediaType);
+            existing = await SelectQueueItemAsync(db, userId, tmdbId, mediaType, tx);
+            await tx.CommitAsync();
             return existing is null ? null : await ApplyUpdatePolicy(existing);
         }
+
+        await tx.CommitAsync();
 
         return new QueueItem
         {
@@ -1095,8 +1119,8 @@ public class DbService(IConfiguration config)
 
     // single-row lookup by the natural key (UserId, TmdbId, MediaType). Shared by the add
     // and upsert paths and their ON CONFLICT re-reads so the query lives in one place.
-    private static Task<QueueItem?> SelectQueueItemAsync(NpgsqlConnection db, string userId, int tmdbId, string mediaType) =>
+    private static Task<QueueItem?> SelectQueueItemAsync(NpgsqlConnection db, string userId, int tmdbId, string mediaType, NpgsqlTransaction? tx = null) =>
         db.QuerySingleOrDefaultAsync<QueueItem>(
             "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
-            new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType });
+            new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType }, tx);
 }

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -314,11 +314,12 @@ public class DbService(IConfiguration config)
         return existing;
     }
 
-    // per-user transaction-scoped advisory lock. hashtext(userId) maps the string UserId to the
-    // bigint key pg_advisory_xact_lock expects; the lock is released automatically when tx
-    // commits or rolls back, so callers never have to unlock explicitly. pins #163.
+    // per-user transaction-scoped advisory lock. hashtextextended returns a 64-bit key (unlike
+    // hashtext's 32-bit value, which would share lock slots across unrelated users via collision),
+    // so distinct users never contend. The lock is released automatically when tx commits or rolls
+    // back, so callers never have to unlock explicitly. pins #163.
     private static Task<int> LockUserQueueAsync(NpgsqlConnection db, string userId, NpgsqlTransaction tx) =>
-        db.ExecuteAsync("SELECT pg_advisory_xact_lock(hashtext(@UserId))", new { UserId = userId }, tx);
+        db.ExecuteAsync("SELECT pg_advisory_xact_lock(hashtextextended(@UserId, 0))", new { UserId = userId }, tx);
 
     public async Task<bool> RemoveFromQueueAsync(int id, string userId)
     {

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -315,9 +315,10 @@ public class DbService(IConfiguration config)
     }
 
     // per-user transaction-scoped advisory lock. hashtextextended returns a 64-bit key (unlike
-    // hashtext's 32-bit value, which would share lock slots across unrelated users via collision),
-    // so distinct users never contend. The lock is released automatically when tx commits or rolls
-    // back, so callers never have to unlock explicitly. pins #163.
+    // hashtext's 32-bit value, whose narrow space made cross-user slot collisions plausible at
+    // scale), so distinct users effectively never contend (a 64-bit collision is astronomically
+    // unlikely). The lock is released automatically when tx commits or rolls back, so callers
+    // never have to unlock explicitly. pins #163.
     private static Task<int> LockUserQueueAsync(NpgsqlConnection db, string userId, NpgsqlTransaction tx) =>
         db.ExecuteAsync("SELECT pg_advisory_xact_lock(hashtextextended(@UserId, 0))", new { UserId = userId }, tx);
 

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -319,8 +319,8 @@ public class DbService(IConfiguration config)
     // scale), so distinct users effectively never contend (a 64-bit collision is astronomically
     // unlikely). The lock is released automatically when tx commits or rolls back, so callers
     // never have to unlock explicitly. pins #163.
-    private static Task<int> LockUserQueueAsync(NpgsqlConnection db, string userId, NpgsqlTransaction tx) =>
-        db.ExecuteAsync("SELECT pg_advisory_xact_lock(hashtextextended(@UserId, 0))", new { UserId = userId }, tx);
+    private static async Task LockUserQueueAsync(NpgsqlConnection db, string userId, NpgsqlTransaction tx) =>
+        await db.ExecuteAsync("SELECT pg_advisory_xact_lock(hashtextextended(@UserId, 0))", new { UserId = userId }, tx);
 
     public async Task<bool> RemoveFromQueueAsync(int id, string userId)
     {

--- a/HurrahTv.Api/Services/SmsService.cs
+++ b/HurrahTv.Api/Services/SmsService.cs
@@ -8,13 +8,15 @@ public class SmsService
     private readonly string? _accountSid;
     private readonly string? _authToken;
     private readonly string? _fromNumber;
+    private readonly bool _isDevelopment;
     private readonly ILogger<SmsService> _logger;
 
-    public SmsService(IConfiguration config, ILogger<SmsService> logger)
+    public SmsService(IConfiguration config, IHostEnvironment env, ILogger<SmsService> logger)
     {
         _accountSid = config["Twilio:AccountSid"];
         _authToken = config["Twilio:AuthToken"];
         _fromNumber = config["Twilio:FromNumber"];
+        _isDevelopment = env.IsDevelopment();
         _logger = logger;
 
         // IsNullOrEmpty (not != null) so the appsettings.json placeholder values
@@ -27,9 +29,13 @@ public class SmsService
 
     public async Task SendCodeAsync(string phoneNumber, string code)
     {
-        if (string.IsNullOrEmpty(_accountSid))
+        // In Development we never hit Twilio (no real SMS, no spent credits) — the code is
+        // logged to the API console so a local/agent session can sign in by reading it. Gated
+        // strictly on IsDevelopment, so production always sends a real SMS. This logs the
+        // genuine generated OTP, not a fixed backdoor code, so no static bypass exists.
+        if (_isDevelopment || string.IsNullOrEmpty(_accountSid))
         {
-            _logger.LogWarning("Twilio not configured — OTP for {Phone}: {Code}", phoneNumber, code);
+            _logger.LogWarning("OTP (dev — not SMS'd) for {Phone}: {Code}", phoneNumber, code);
             return;
         }
 

--- a/HurrahTv.Api/Services/SmsService.cs
+++ b/HurrahTv.Api/Services/SmsService.cs
@@ -29,13 +29,18 @@ public class SmsService
 
     public async Task SendCodeAsync(string phoneNumber, string code)
     {
+        // strip CR/LF from the user-provided phone before it reaches the log lines below — the
+        // boundary only checks for whitespace, so a newline-bearing value could otherwise forge log
+        // entries (CWE-117). Only used for logging; the real Twilio send below uses the raw value.
+        string safePhone = phoneNumber.Replace("\r", "").Replace("\n", "");
+
         // in Development we never hit Twilio (no real SMS, no spent credits) — the code is logged
         // to the API console so a local/agent session can sign in by reading it. Gated strictly on
         // IsDevelopment, so production sends a real SMS. Logs the genuine generated OTP, not a
         // fixed backdoor code, so no static bypass exists.
         if (_isDevelopment)
         {
-            _logger.LogWarning("OTP (dev — not SMS'd) for {Phone}: {Code}", phoneNumber, code);
+            _logger.LogWarning("OTP (dev — not SMS'd) for {Phone}: {Code}", safePhone, code);
             return;
         }
 
@@ -43,7 +48,7 @@ public class SmsService
         // rather than throwing — distinct message so it's not mistaken for the dev path above.
         if (string.IsNullOrEmpty(_accountSid))
         {
-            _logger.LogWarning("Twilio not configured — OTP for {Phone}: {Code}", phoneNumber, code);
+            _logger.LogWarning("Twilio not configured — OTP for {Phone}: {Code}", safePhone, code);
             return;
         }
 

--- a/HurrahTv.Api/Services/SmsService.cs
+++ b/HurrahTv.Api/Services/SmsService.cs
@@ -29,13 +29,21 @@ public class SmsService
 
     public async Task SendCodeAsync(string phoneNumber, string code)
     {
-        // In Development we never hit Twilio (no real SMS, no spent credits) — the code is
-        // logged to the API console so a local/agent session can sign in by reading it. Gated
-        // strictly on IsDevelopment, so production always sends a real SMS. This logs the
-        // genuine generated OTP, not a fixed backdoor code, so no static bypass exists.
-        if (_isDevelopment || string.IsNullOrEmpty(_accountSid))
+        // in Development we never hit Twilio (no real SMS, no spent credits) — the code is logged
+        // to the API console so a local/agent session can sign in by reading it. Gated strictly on
+        // IsDevelopment, so production sends a real SMS. Logs the genuine generated OTP, not a
+        // fixed backdoor code, so no static bypass exists.
+        if (_isDevelopment)
         {
             _logger.LogWarning("OTP (dev — not SMS'd) for {Phone}: {Code}", phoneNumber, code);
+            return;
+        }
+
+        // production safety valve: if Twilio is misconfigured (blank credentials), log the code
+        // rather than throwing — distinct message so it's not mistaken for the dev path above.
+        if (string.IsNullOrEmpty(_accountSid))
+        {
+            _logger.LogWarning("Twilio not configured — OTP for {Phone}: {Code}", phoneNumber, code);
             return;
         }
 

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -708,8 +708,10 @@ else
                 PrimaryAction: HomeHero.HeroAction.Resume);
         }
 
-        // 3. a TV show whose latest episode aired in the last 7 days (regardless of status)
-        QueueItem? recent = _allItems
+        // 3. a TV show whose latest episode aired in the last 7 days (regardless of status).
+        // inherently TV-only ("new episode this week" has no movie analogue), so it's suppressed
+        // under the Movies filter — otherwise the hero would leak a TV show under Movies (#167).
+        QueueItem? recent = MediaFilter.MediaType == "movie" ? null : _allItems
             .Where(i => i.MediaType == MediaTypes.Tv
                 && i.HasNewEpisode
                 && i.Status != QueueStatus.NotForMe

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -540,7 +540,7 @@ else
         int seq = ++_heroRequestSeq;
         try
         {
-            CuratedHeroResponse? response = await Api.GetCuratedHeroAsync(refresh, _cts.Token);
+            CuratedHeroResponse? response = await Api.GetCuratedHeroAsync(refresh, MediaFilter.MediaType, _cts.Token);
             if (seq == _heroRequestSeq && response?.Hero is not null)
                 _heroPick = response.Hero;
         }
@@ -640,8 +640,14 @@ else
 
     private void OnMediaFilterChanged() => _ = InvokeAsync(async () =>
     {
+        // re-fetch a media-appropriate AI hero for the new filter (#147). The single client-held
+        // pick may be the other media type; the server re-selects from the SAME cached reservoir
+        // (no paid regen). Set _heroLoading first so SelectHero renders the skeleton during the
+        // refetch instead of flashing the now-filtered-out pick or a watchlist fallback.
+        _heroLoading = true;
         try { await ReloadWatchlist(); }
         catch { }
+        _ = LoadHero();
     });
 
     // user changed services in Settings — refresh the cached list and re-run the partition

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -645,9 +645,12 @@ else
         // (no paid regen). Set _heroLoading first so SelectHero renders the skeleton during the
         // refetch instead of flashing the now-filtered-out pick or a watchlist fallback.
         _heroLoading = true;
+        // the hero fetch and the watchlist reload are independent (the server reads its own
+        // watchlist for the hero, not the client's), so kick the hero off concurrently rather
+        // than after the awaited reload — the new pick lands sooner.
+        _ = LoadHero();
         try { await ReloadWatchlist(); }
         catch { }
-        _ = LoadHero();
     });
 
     // user changed services in Settings — refresh the cached list and re-run the partition

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -642,15 +642,20 @@ else
     {
         // re-fetch a media-appropriate AI hero for the new filter (#147). The single client-held
         // pick may be the other media type; the server re-selects from the SAME cached reservoir
-        // (no paid regen). Set _heroLoading first so SelectHero renders the skeleton during the
-        // refetch instead of flashing the now-filtered-out pick or a watchlist fallback.
+        // (no paid regen). Recompute _hero with _heroLoading set BEFORE the async work so the slot
+        // reflects the new filter immediately — keeping the current pick only if it still matches,
+        // else showing the skeleton — instead of flashing the now-filtered-out pick during the
+        // in-flight refetch. The flag gates a derived value (_hero), so it must be set before that
+        // value is recomputed, not just before the async call (see #135 learning).
         _heroLoading = true;
+        _hero = SelectHero();
+        StateHasChanged();
         // the hero fetch and the watchlist reload are independent (the server reads its own
         // watchlist for the hero, not the client's), so kick the hero off concurrently rather
         // than after the awaited reload — the new pick lands sooner.
         _ = LoadHero();
         try { await ReloadWatchlist(); }
-        catch { }
+        catch { /* leave stale data in place on network failure */ }
     });
 
     // user changed services in Settings — refresh the cached list and re-run the partition

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -144,11 +144,11 @@ public class ApiClient(HttpClient http)
     // curation — single rotating AI hero pick for Home (#135). refresh=true asks the server
     // for a different pick (manual escape hatch). Returns null on any failure; Home falls back
     // to a watchlist-derived hero, so there's no user-facing error path here.
-    public async Task<CuratedHeroResponse?> GetCuratedHeroAsync(bool refresh = false, CancellationToken cancellationToken = default)
+    public async Task<CuratedHeroResponse?> GetCuratedHeroAsync(bool refresh = false, string mediaType = "all", CancellationToken cancellationToken = default)
     {
         try
         {
-            return await _http.GetFromJsonAsync<CuratedHeroResponse>($"api/curation/hero?refresh={refresh}", cancellationToken);
+            return await _http.GetFromJsonAsync<CuratedHeroResponse>($"api/curation/hero?refresh={refresh}&mediaType={mediaType}", cancellationToken);
         }
         // only rethrow caller-driven cancellation. HttpClient.Timeout surfaces as
         // TaskCanceledException with our token NOT cancelled — keep the "errors return null"

--- a/HurrahTv.Client/wwwroot/js/sortable.js
+++ b/HurrahTv.Client/wwwroot/js/sortable.js
@@ -23,10 +23,18 @@ export function init(el, dotNetRef, callbackName, options) {
         dragClass: 'sortable-drag',
     }, options || {});
     opts.onEnd = (evt) => {
-        if (evt.oldIndex === evt.newIndex) return;
+        // use the *DraggableIndex variants, not oldIndex/newIndex. The container's first child is a
+        // non-draggable aria-live status <div>, so evt.oldIndex/newIndex (which count ALL children)
+        // are shifted +1 versus the visible row order the C# side indexes by _visibleItems. The
+        // draggable-filtered indices exclude that status div. Without this, every downward drag
+        // landed one slot too low. The `draggable` option above gates what can be dragged but does
+        // NOT change what evt.newIndex counts — only newDraggableIndex is row-relative.
+        const oldIndex = evt.oldDraggableIndex;
+        const newIndex = evt.newDraggableIndex;
+        if (oldIndex === newIndex) return;
         const itemId = parseInt(evt.item?.dataset?.itemId, 10);
         if (isNaN(itemId)) return;
-        dotNetRef.invokeMethodAsync(callbackName, itemId, evt.oldIndex, evt.newIndex);
+        dotNetRef.invokeMethodAsync(callbackName, itemId, oldIndex, newIndex);
     };
     const instance = window.Sortable.create(el, opts);
     return { instance };

--- a/Learnings/blazor-set-loading-flag-before-derived-state.md
+++ b/Learnings/blazor-set-loading-flag-before-derived-state.md
@@ -35,5 +35,22 @@ _ = LoadHero();                          // LoadHero clears _heroLoading in its 
 
 This is easy to get wrong because the natural home for a "start loading" flag is next to the async call that does the loading — but that call runs *after* the synchronous derived-state computation. Both this author and GitHub Copilot independently shipped/flagged the wrong order (it took two passes to actually fix). Whenever a flag suppresses a fallback inside a derived getter, trace where the derived value is first computed and set the flag above that line.
 
+## Update (2026-06-09): recurs in non-lifecycle handlers, and `StateHasChanged()` alone is a no-op
+The same trap reappeared in `OnMediaFilterChanged` (a handler subscribed to `MediaFilter.OnChanged`, dispatched via `_ = InvokeAsync(...)`). Two extra wrinkles surfaced:
+
+1. **No automatic render.** `OnInitializedAsync`/`LoadWatchlistData` are lifecycle methods, so Blazor auto-renders at their await points — the derived value (`_hero`) gets recomputed and shown for free. A plain event-subscription handler gets **no** auto-render, so you must trigger it yourself.
+
+2. **`StateHasChanged()` alone doesn't fix it — you must recompute the derived value.** During /xreview, four independent LLM reviewers all proposed "add `StateHasChanged()` after `_heroLoading = true`." That's a no-op for the skeleton: the render gate is `@if (_hero is not null)`, and `_hero` is still the *old* non-null pick at that point (it's only recomputed later, inside `ProcessQueueResponse` after the queue GET). So a bare `StateHasChanged` just re-renders the stale hero. The fix recomputes the gated value with the flag already set:
+
+```csharp
+_heroLoading = true;
+_hero = SelectHero();   // recompute NOW with the flag set → null (skeleton) or still-valid pick
+StateHasChanged();      // non-lifecycle handler: render explicitly
+_ = LoadHero();         // refetch in the background
+await ReloadWatchlist();
+```
+
+Generalization: when a flag gates a *derived* value, "set the flag" means "set the flag **and recompute the derived value**, then render" — not just flip the flag or just call `StateHasChanged`.
+
 ## File pointers
-- `HurrahTv.Client/Pages/Home.razor` — `OnInitializedAsync` / `LoadWatchlistData` set `_heroLoading` before `ProcessQueueResponse`; `SelectHero` early-returns null while `_heroLoading`
+- `HurrahTv.Client/Pages/Home.razor` — `OnInitializedAsync` / `LoadWatchlistData` set `_heroLoading` before `ProcessQueueResponse`; `OnMediaFilterChanged` recomputes `_hero` + `StateHasChanged` before the async refetch; `SelectHero` early-returns null while `_heroLoading`

--- a/Learnings/postgres-advisory-lock-key-hashtextextended.md
+++ b/Learnings/postgres-advisory-lock-key-hashtextextended.md
@@ -18,7 +18,7 @@ The intent (and the code comment) was "keyed per-user, so unrelated users never 
 
 Use **`hashtextextended(text, seed)`**, which returns `bigint` — the full 64-bit key space. Available since Postgres 11 (Azure PG Flexible Server qualifies). Verify quickly: `SELECT pg_typeof(hashtextextended('abc', 0));` → `bigint`.
 
-The 32-bit form is functionally fine at tiny scale (collision needs two specific users adding concurrently), but `hashtextextended` is a one-word change that makes the per-key guarantee real and the comment honest.
+The 32-bit form is functionally fine at tiny scale (collision needs two specific users adding concurrently), but `hashtextextended` is a one-word change that dramatically reduces collision risk (any fixed-size hash can still theoretically collide) and makes the comment honest.
 
 ## Example
 ```sql

--- a/Learnings/postgres-advisory-lock-key-hashtextextended.md
+++ b/Learnings/postgres-advisory-lock-key-hashtextextended.md
@@ -1,0 +1,31 @@
+# Use `hashtextextended` (64-bit), Not `hashtext` (32-bit), for Per-Key Advisory Locks
+
+> **Area:** Data | API
+> **Date:** 2026-06-09
+> **Resolves:** mkerchenski/hurrah-tv#163
+
+## Context
+The fix for #163 (concurrent same-user queue adds colliding on `Position`) wraps the `MAX(Position)+INSERT` in a transaction guarded by a per-user advisory lock:
+
+```sql
+SELECT pg_advisory_xact_lock(hashtext(@UserId))
+```
+
+The intent (and the code comment) was "keyed per-user, so unrelated users never contend." During /xreview, multiple reviewers flagged that this isn't quite true.
+
+## Learning
+`pg_advisory_xact_lock(bigint)` takes a 64-bit key, but **`hashtext()` returns `int4` (32-bit)**. The int4 is implicitly widened to bigint, so the effective key space is only 2³² (~4.3 billion) values, not 2⁶⁴. Two distinct keys (here, user IDs) whose 32-bit hashes collide map to the **same lock slot** and serialize against each other — so a "per-user" lock can occasionally block unrelated users. No data corruption (the lock still prevents the position race for both), just surprise contention, and a comment that's subtly false.
+
+Use **`hashtextextended(text, seed)`**, which returns `bigint` — the full 64-bit key space. Available since Postgres 11 (Azure PG Flexible Server qualifies). Verify quickly: `SELECT pg_typeof(hashtextextended('abc', 0));` → `bigint`.
+
+The 32-bit form is functionally fine at tiny scale (collision needs two specific users adding concurrently), but `hashtextextended` is a one-word change that makes the per-key guarantee real and the comment honest.
+
+## Example
+```sql
+-- 32-bit: int4 silently widened → only 2^32 distinct lock slots, cross-key collisions possible
+SELECT pg_advisory_xact_lock(hashtext(@UserId));
+
+-- 64-bit: full key space, distinct keys never share a slot
+SELECT pg_advisory_xact_lock(hashtextextended(@UserId, 0));
+```
+Related: [[serialize-writes-when-server-ignores-aborts]] (the other "serialize concurrent writes" angle — client serialization vs. DB-side locking).

--- a/Learnings/sortablejs-newindex-counts-all-children.md
+++ b/Learnings/sortablejs-newindex-counts-all-children.md
@@ -1,0 +1,33 @@
+# SortableJS `newIndex`/`oldIndex` Count ALL Children — Use the `*DraggableIndex` Variants
+
+> **Area:** UI | WASM
+
+> **Date:** 2026-06-09
+
+## Context
+Queue Want-to-Watch drag-reorder dropped every item **one slot too low** when moving down: dragging slot 1 → slot 2 landed it in slot 3. The C# `OnReorder(itemId, oldIndex, newIndex)` and its `_visibleItems[newIndex]` targeting were correct (proved by invoking the handler synthetically with `newIndex=1` → lands in slot 2). The bug was the *index value* SortableJS reported.
+
+The list container's first child is a non-draggable aria-live `<div role="status">` (the reorder announcement region). So container children are `[statusDiv, row0, row1, ...]` — DOM child indices are shifted +1 versus the visible row order. A drag to visible slot 2 reported `evt.newIndex = 2` (counting the status div), and `OnReorder` targeted `_visibleItems[2]` = slot 3.
+
+## Learning
+SortableJS exposes **two** index pairs on its events:
+- `evt.oldIndex` / `evt.newIndex` — position among **all** children of the container, including non-draggable ones.
+- `evt.oldDraggableIndex` / `evt.newDraggableIndex` — position among only the elements matching the `draggable` selector.
+
+Setting `draggable: '[data-item-id]'` gates **what can be dragged**, but does **not** change what `evt.newIndex` counts — that still includes the status div. If the C# side indexes a filtered/row-only collection (`_visibleItems`), you must pass the **draggable-filtered** indices. Verify by `Sortable.utils.index(rowEl)` (no selector → counts the status div) vs `Sortable.utils.index(rowEl, inst.options.draggable)` (row-relative).
+
+Rule: when a sortable container has *any* non-draggable child (aria-live region, header, spacer), use `evt.oldDraggableIndex`/`evt.newDraggableIndex`. They're also the right choice generally — resilient to any future non-draggable sibling, unlike the narrower bandaid of moving the status div outside the container.
+
+## Example
+```javascript
+opts.onEnd = (evt) => {
+    // NOT evt.oldIndex/newIndex — they count the non-draggable aria-live <div> at child 0.
+    const oldIndex = evt.oldDraggableIndex;
+    const newIndex = evt.newDraggableIndex;
+    if (oldIndex === newIndex) return;
+    const itemId = parseInt(evt.item?.dataset?.itemId, 10);
+    if (isNaN(itemId)) return;
+    dotNetRef.invokeMethodAsync(callbackName, itemId, oldIndex, newIndex);
+};
+```
+Related: [[sortablejs-interop-and-gesture-conflicts]], [[sortablejs-forcefallback-for-touch]].

--- a/Learnings/static-asset-integrity-blocks-hot-edited-js.md
+++ b/Learnings/static-asset-integrity-blocks-hot-edited-js.md
@@ -1,0 +1,35 @@
+# Hot-Editing a wwwroot JS File Breaks Its Integrity Hash — the Browser Blocks It
+
+> **Area:** WASM | Deployment
+> **Date:** 2026-06-09
+
+## Context
+Debugging "drag-reorder doesn't work" on the Queue page, the drag behaved differently on every attempt — didn't work, then worked, then "grabs but nothing moves." A console diagnostic (run in a clean DevTools-controlled Chrome) showed `window.Sortable` loaded fine and the ESM module imported fine, yet `Sortable.get(listEl)` returned `null` — the instance never attached. The console held the real cause:
+
+```
+Failed to find a valid digest in the 'integrity' attribute for resource
+'https://localhost:7267/js/sortable.bcodwy7q8b.js' with computed SHA-256
+integrity 'MmBznFLzD5Kb4nU2yjjPHwuj/q8VnbktjFEh2ILVvws='. The resource has been blocked.
+```
+
+The "nothing moves" only started **after** I added a temporary `console.log` to `sortable.js` to debug — so I wrongly told the user the log couldn't affect dragging. It could, via this mechanism.
+
+## Learning
+Blazor WASM fingerprints static assets and bakes a **Subresource Integrity (SRI)** hash for each into the import map (`<script type="importmap">` / `blazor.boot`). `dotnet watch` hot-reload does **NOT** re-fingerprint static JS under `wwwroot/` — it serves the edited file, but the import map still carries the *old* content's integrity hash. The browser computes the new file's hash, finds the mismatch, and **blocks the module entirely**. Any JS-interop module import (`import('./js/sortable.js')`) silently fails, so whatever it powers (here, SortableJS attaching to the list) just never happens — no error in the C# side, only a console SRI error.
+
+Consequences:
+- You **cannot** instrument a fingerprinted `wwwroot/*.js` file by editing it at runtime — the edit disables it. Capture runtime data by wrapping the live object via DevTools `evaluate` instead (e.g. override `inst.options.onEnd`), not by editing the file.
+- A full client **rebuild** (restart `dotnet watch` for the Client, or `dotnet build`) regenerates the import map with the new integrity hash; only then does the edited file load.
+- This compounds with a stale PWA service worker serving old vs. new assets — together they make a hot-edited JS feature behave erratically across reloads.
+
+Distinct from [[dotnet-watch-locks-shared-dll.md]] (a Windows DLL file-lock during `dotnet test`); this is a browser-side integrity block on static web assets.
+
+## Example
+```javascript
+// DON'T: edit wwwroot/js/sortable.js to add a debug log — integrity mismatch blocks the whole module.
+// DO: capture runtime data without touching the file —
+const inst = window.Sortable.get(document.querySelector('[data-item-id]').parentElement);
+const original = inst.options.onEnd;
+inst.options.onEnd = (evt) => { console.log(evt.oldDraggableIndex, evt.newDraggableIndex); return original(evt); };
+```
+After a genuine fix to the file, the served `?` build must re-fingerprint before the browser will load it — restart the Client `dotnet watch` (ask the dev to do it; don't force-restart their session).

--- a/Learnings/static-asset-integrity-blocks-hot-edited-js.md
+++ b/Learnings/static-asset-integrity-blocks-hot-edited-js.md
@@ -32,4 +32,4 @@ const inst = window.Sortable.get(document.querySelector('[data-item-id]').parent
 const original = inst.options.onEnd;
 inst.options.onEnd = (evt) => { console.log(evt.oldDraggableIndex, evt.newDraggableIndex); return original(evt); };
 ```
-After a genuine fix to the file, the served `?` build must re-fingerprint before the browser will load it — restart the Client `dotnet watch` (ask the dev to do it; don't force-restart their session).
+After a genuine fix to the file, the build must re-fingerprint before the browser will load it — restart the Client `dotnet watch` (ask the dev to do it; don't force-restart their session).


### PR DESCRIPTION
Five commits across related queue/home work.

## #163 — Concurrent same-user adds collide on queue Position
`AddToQueueAsync` / `UpsertWithStatusAsync` read `COALESCE(MAX(Position),0)+1` then INSERT separately; under READ COMMITTED two concurrent distinct-title adds saw the same MAX and got the same Position. Now wrapped in a transaction guarded by a per-user `pg_advisory_xact_lock(hashtext(userId))` — serializes per-user, auto-releases on commit, no schema change, doesn't fight `ReorderAsync`'s transient duplicate positions. Regression test `ConcurrentAdds_DistinctTitles_GetDistinctPositions`.

## #167 — Hero "New This Week" fallback ignored the media filter
`SelectHero`'s TV-only source read unfiltered `_allItems` and wasn't gated by the filter, so it could show a TV show under Movies. Now self-gated: suppressed when the filter is "movie".

## #147 — AI hero not media-filter-aware
`/api/curation/hero` accepts a `mediaType` param; `CurationService` narrows the **same cached reservoir** to that type (no paid regen). Home re-fetches the hero on filter change → media-appropriate AI pick instead of an in-list fallback.

## Fix: queue drag-reorder off-by-one (moving down)
The drag handler passed `evt.oldIndex`/`evt.newIndex`, which count **all** children of the sortable container — including the non-draggable aria-live `<div role="status">` at child 0 — shifting indices +1 vs. the visible rows `OnReorder` indexes by `_visibleItems`. A drag to slot 2 reported `newIndex=2` → targeted slot 3. Fixed by using `evt.oldDraggableIndex`/`evt.newDraggableIndex`. Reproduced and verified in-browser via DevTools.

## Dev: log OTP to console instead of SMS in Development
In `IsDevelopment()`, `SmsService.SendCodeAsync` logs the generated OTP and skips Twilio (no real SMS / spent credits) so a local/automated session can sign in. Production unchanged; logs the genuine code, not a fixed bypass value.

## Verification
- `dotnet test` green (Shared + Client + Api); formatter gate clean.
- Browser-verified: hero filter toggling, queue add ordering, drag-reorder lands correctly.
- Note: Blazor WASM hot-reload does **not** re-fingerprint static JS, so editing `wwwroot/js/sortable.js` breaks its Subresource-Integrity check until a full client rebuild.

Closes #163
Closes #167
Closes #147

Related: #182 #183 #184
