### PR TITLE
Fix queue drag-reorder off-by-one + dev-only OTP console login

### DIFF
--- a/HurrahTv.Api/Services/SmsService.cs
+++ b/HurrahTv.Api/Services/SmsService.cs
@@ -8,13 +8,15 @@ public class SmsService
     private readonly string? _accountSid;
     private readonly string? _authToken;
     private readonly string? _fromNumber;
+    private readonly bool _isDevelopment;
     private readonly ILogger<SmsService> _logger;
 
-    public SmsService(IConfiguration config, ILogger<SmsService> logger)
+    public SmsService(IConfiguration config, IHostEnvironment env, ILogger<SmsService> logger)
     {
         _accountSid = config["Twilio:AccountSid"];
         _authToken = config["Twilio:AuthToken"];
         _fromNumber = config["Twilio:FromNumber"];
+        _isDevelopment = env.IsDevelopment();
         _logger = logger;
 
         // IsNullOrEmpty (not != null) so the appsettings.json placeholder values
@@ -27,9 +29,13 @@ public class SmsService
 
     public async Task SendCodeAsync(string phoneNumber, string code)
     {
-        if (string.IsNullOrEmpty(_accountSid))
+        // In Development we never hit Twilio (no real SMS, no spent credits) — the code is
+        // logged to the API console so a local/agent session can sign in by reading it. Gated
+        // strictly on IsDevelopment, so production always sends a real SMS. This logs the
+        // genuine generated OTP, not a fixed backdoor code, so no static bypass exists.
+        if (_isDevelopment || string.IsNullOrEmpty(_accountSid))
         {
-            _logger.LogWarning("Twilio not configured — OTP for {Phone}: {Code}", phoneNumber, code);
+            _logger.LogWarning("OTP (dev — not SMS'd) for {Phone}: {Code}", phoneNumber, code);
             return;
         }
 

--- a/HurrahTv.Client/wwwroot/js/sortable.js
+++ b/HurrahTv.Client/wwwroot/js/sortable.js
@@ -23,10 +23,18 @@ export function init(el, dotNetRef, callbackName, options) {
         dragClass: 'sortable-drag',
     }, options || {});
     opts.onEnd = (evt) => {
-        if (evt.oldIndex === evt.newIndex) return;
+        // use the *DraggableIndex variants, not oldIndex/newIndex. The container's first child is a
+        // non-draggable aria-live status <div>, so evt.oldIndex/newIndex (which count ALL children)
+        // are shifted +1 versus the visible row order the C# side indexes by _visibleItems. The
+        // draggable-filtered indices exclude that status div. Without this, every downward drag
+        // landed one slot too low. The `draggable` option above gates what can be dragged but does
+        // NOT change what evt.newIndex counts — only newDraggableIndex is row-relative.
+        const oldIndex = evt.oldDraggableIndex;
+        const newIndex = evt.newDraggableIndex;
+        if (oldIndex === newIndex) return;
         const itemId = parseInt(evt.item?.dataset?.itemId, 10);
         if (isNaN(itemId)) return;
-        dotNetRef.invokeMethodAsync(callbackName, itemId, evt.oldIndex, evt.newIndex);
+        dotNetRef.invokeMethodAsync(callbackName, itemId, oldIndex, newIndex);
     };
     const instance = window.Sortable.create(el, opts);
     return { instance };


### PR DESCRIPTION
Two small, independent changes surfaced while testing #163/#167/#147.

## Fix: queue drag-reorder off-by-one (moving down)
The Want-to-Watch drag handler passed `evt.oldIndex`/`evt.newIndex` to the C# `OnReorder` callback. Those count **all** children of the sortable container — including the non-draggable aria-live `<div role="status">` at child index 0 — so indices were shifted +1 versus the visible rows `OnReorder` indexes by `_visibleItems`. A drag to visible slot 2 reported `newIndex=2` → targeted `_visibleItems[2]` = slot 3, dropping the item one slot too low on every downward move.

Fix: use SortableJS's draggable-filtered indices (`evt.oldDraggableIndex` / `evt.newDraggableIndex`), which exclude the status div. The pre-existing `draggable: "[data-item-id]"` option gates what can be dragged but does **not** change what `evt.newIndex` counts.

Diagnosed and verified in-browser (DevTools): reproduced the off-by-one with `newIndex=2`, confirmed the fix lands a slot-1→slot-2 drag in slot 2.

## Dev: log OTP to console instead of SMS in Development
In `IsDevelopment()`, `SmsService.SendCodeAsync` logs the generated OTP to the API console and skips Twilio (no real SMS, no spent credits), so a local/automated session can sign in by reading the code. Production always sends a real SMS — unchanged. Logs the genuine generated code, not a fixed value, so no static bypass exists.

## Notes
- Browser-verified surfaces (JS interop + dev tooling); no Shared logic changed, so no unit tests per the project testing rule.
- Heads-up: Blazor WASM hot-reload does **not** re-fingerprint static JS, so editing `wwwroot/js/sortable.js` breaks its Subresource-Integrity check until a full client rebuild.