### PR TITLE
docs: add ONBOARDING.md start-here guide + link from README/CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Welcome. This doc is the canonical "how we work" guide. Read it once end-to-end on your first day; reference it whenever you're unsure about the workflow.
 
+New here? [`ONBOARDING.md`](ONBOARDING.md) is a 5-minute orientation that maps out which doc to read when — skim it first, then come back here.
+
 If you want to run the project locally, start with [`README.md`](README.md) for prereqs and setup commands. This doc picks up where that leaves off.
 
 > **A note on scope:** Hurrah.tv is a small passion project, not an open-source community. The "All rights reserved" license is intentional. If you're reading this as an external visitor, feel free to look around — but PRs from outside the team won't be merged.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,43 @@
+# Start Here — Hurrah.tv
+
+You're opening Hurrah.tv (a unified streaming watchlist: Blazor WASM client + .NET Minimal API + PostgreSQL, with AI curation). This page is a 5-minute orientation and a map — the real guides are linked below; this doc deliberately doesn't repeat them.
+
+> Working in **Claude Code**? Great. Read the [diff-review rule](CONTRIBUTING.md#claude-code-workflow) before you accept any AI-written code, and lean on the [project skills](CONTRIBUTING.md#claude-skills) (`/xplan` → `/xsimplify` → `/xreview` → `/compound`).
+
+## Which doc do I read?
+
+| Doc | What it's for | Read it when |
+|-----|---------------|--------------|
+| [`README.md`](README.md) | What the product is, prerequisites, clone/build/setup commands, tech stack | First — to get it running |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | **The canonical "how we work."** First-day checklist, architecture primer, signed commits, git/PR workflow, browser testing, Claude skills, code style, finding work | Once end-to-end on day one; reference forever |
+| [`CLAUDE.md`](CLAUDE.md) | Architecture, conventions, testing rules, the issue/label scheme, deploy details | When writing code or unsure of a convention |
+| [`Learnings/`](Learnings/) | Hard-won, non-obvious gotchas captured per-incident (WASM, TMDb, Postgres, Blazor lifecycle, drag-reorder, etc.) | Before debugging something tricky — someone may have already paid for the answer |
+| `Plans/` | Design docs / implementation plans (local-only, gitignored) | When `/xplan` saves one for a feature you're starting |
+
+**Don't have time to read everything?** Do exactly this: get it running per README, then work through [CONTRIBUTING → Your first day](CONTRIBUTING.md#your-first-day) top to bottom. Everything else is reference.
+
+## The two-minute mental model
+
+Three projects, one rule that prevents most mistakes (full version: [architecture primer](CONTRIBUTING.md#architecture-primer)):
+
+- **`HurrahTv.Api`** — the server. Holds every secret, owns the only DB connection, calls TMDb/Anthropic/Twilio.
+- **`HurrahTv.Client`** — Blazor WASM, runs **in the browser**. Public by definition — **never** put a secret or a DB/external call here; route it through `ApiClient` → an API endpoint.
+- **`HurrahTv.Shared`** — DTOs only, the shapes both sides agree on.
+
+## How a change reaches users
+
+```
+branch off main → PR → Copilot review → @mkerchenski approves → squash-merge to main
+   → staging auto-deploys (staging.hurrah.tv)        [GitHub Actions: main_hurrahtv.yml]
+   → smoke-test staging
+   → Mike runs /deploy → atomic slot swap to prod    [swap.yml]  (hurrah.tv)
+```
+
+You own everything up to the merge. Staging is automatic on merge; the production swap is Mike-only (`/deploy` — see the skills table). `main` is protected: signed commits, linear history (rebase/squash, never a merge commit), 1 approving review + code-owner, and PRs must be up to date with `main` before merging — the [PR workflow](CONTRIBUTING.md#pull-request-workflow) walks through all of it.
+
+## Finding your first issue
+
+Issues are the tracker (no board) — filter by label ([scheme](CONTRIBUTING.md#labels-and-how-to-find-work)). **`good first issue` / `difficulty:starter` items are curated for a new contributor** — start there, comment "I'd like to take this," and open a PR. When in doubt, ask in the issue rather than guessing.
+
+---
+*Setup problems or anything unclear: ping Mike — don't burn an hour stuck.*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ AI-curated streaming across all your services. One smart watchlist that learns w
 
 ![.NET 10](https://img.shields.io/badge/.NET-10-512BD4) ![Blazor WASM](https://img.shields.io/badge/Blazor-WebAssembly-512BD4) ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1) ![Claude AI](https://img.shields.io/badge/Claude_AI-Anthropic-D4A574)
 
+> **New to the project?** Start with [`ONBOARDING.md`](ONBOARDING.md) — a 5-minute orientation and a map to the docs below.
+
 ## What it does
 
 Hurrah.tv is an opinionated streaming platform that curates content across Netflix, Hulu, Disney+, Prime Video, Max, Peacock, Paramount+, and Apple TV+. It learns from your watch history and preferences to build a personalized home feed — like opening one app instead of eight.


### PR DESCRIPTION
## What
Adds `ONBOARDING.md` — a thin "start here" orientation — and links it from the top of `README.md` and `CONTRIBUTING.md`.

## Why
A new contributor (and the Claude Code onboarding share link) needs a fast map to the existing docs. `ONBOARDING.md` deliberately routes to `CONTRIBUTING.md`/`README.md`/`CLAUDE.md` rather than duplicating setup, the skills table, or code style (which would just drift). It adds only what isn't centralized elsewhere:
- the two-minute API/Client/Shared mental model
- the branch → PR → squash → staging → prod-swap release flow
- how to find a first issue (starter/good-first framed for the new contributor)

## Notes
- Already shared as the Claude Code onboarding guide (link generated separately).
- Setup steps intentionally stay in CONTRIBUTING; once the dev-OTP login (#182) lands there, the onboarding path is fully current.

## Acceptance criteria
- [x] `ONBOARDING.md` added, routes to existing docs without duplicating them
- [x] Linked from `README.md` and `CONTRIBUTING.md` near the top