### PR TITLE
Self-gate Home hero 'Continue Watching' on media filter (#184)

### DIFF
--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -706,7 +706,8 @@ else
 
         // 2. an item the user is actively watching, with a backdrop available
         QueueItem? watching = _availableNowItems.FirstOrDefault(i =>
-            i.Status == QueueStatus.Watching && !string.IsNullOrEmpty(i.BackdropPath));
+            i.Status == QueueStatus.Watching && !string.IsNullOrEmpty(i.BackdropPath)
+            && (MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType));
         if (watching is not null)
         {
             return new HomeHero.HeroItem(

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -704,7 +704,7 @@ else
         // during the load window; the fallbacks below only apply once curation has resolved.
         if (_heroLoading) return null;
 
-        // 2. an item the user is actively watching, with a backdrop available
+        // 2. an item the user is actively watching, with a backdrop available, matching the active media filter
         QueueItem? watching = _availableNowItems.FirstOrDefault(i =>
             i.Status == QueueStatus.Watching && !string.IsNullOrEmpty(i.BackdropPath)
             && (MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType));


### PR DESCRIPTION
## What
Add an inline media-filter guard to `SelectHero` source 2 ("Continue Watching") in `Home.razor`, matching the guards already on source 1 ("Recommended for You") and source 3 ("New This Week").

## Why
Surfaced during `/xreview` of PR #178. Source 2 reads `_availableNowItems`, which is already media-filtered upstream by `WatchlistFilters.Apply`, so it does **not** leak the wrong media type today. But the rule was enforced implicitly upstream rather than at the `SelectHero` site — fragile to a future refactor that recomputes the hero without re-running the watchlist filter. CLAUDE.md prefers self-gating predicates (rule canonical + grep-able); this makes all three hero sources answer the media-filter question consistently at the point of selection.

## Change
```csharp
QueueItem? watching = _availableNowItems.FirstOrDefault(i =>
    i.Status == QueueStatus.Watching && !string.IsNullOrEmpty(i.BackdropPath)
    && (MediaFilter.MediaType == "all" || i.MediaType == MediaFilter.MediaType));
```

No behavior change today. No test (Blazor component logic, no-op on current behavior — verified in browser).

## Verification
- All filter → hero unchanged
- Shows filter → Continue Watching hero is never a movie
- Movies filter → Continue Watching hero is never a TV show
- `dotnet format --verify-no-changes` passes

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)