### PR TITLE
Cover UpsertWithStatusAsync race-lost mutation with the advisory lock (#183)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+# Copilot instructions — Hurrah.tv
+
+Hurrah.tv is a unified streaming-queue app: one watchlist across all streaming services. When reviewing a PR, apply the project conventions below. Flag violations; don't restate them as praise.
+
+## Architecture
+
+Blazor WebAssembly (standalone) frontend + .NET 10 Minimal API backend. Three projects:
+
+- **HurrahTv.Api** — Minimal API (not controllers). TMDb proxy, auth, PostgreSQL via Dapper/Npgsql.
+- **HurrahTv.Client** — Blazor WASM. UI runs in the browser; no client-side state store — state lives on the server and the client fetches on page load.
+- **HurrahTv.Shared** — DTOs and pure logic shared across the wire. The contract layer.
+
+State flows server → client. The WASM client never calls TMDb directly; the API key stays server-side.
+
+## What to focus on in review
+
+### Correctness (highest priority)
+- **Authorization scoping.** Every user-data SQL mutation must be scoped by the authenticated `UserId` (e.g. `WHERE Id = @Id AND UserId = @UserId`). A missing `AND UserId =` clause is a high-severity finding — it lets one user mutate another's data.
+- **Transaction / lock coverage.** Postgres advisory locks (`pg_advisory_xact_lock`) only cover work that runs *before* `CommitAsync()`. A mutation that the lock's intent implies should be covered must run inside the transaction and be enlisted (pass the `NpgsqlTransaction`), or Npgsql throws / the work escapes the lock.
+- **Idempotent schema migrations.** Tables/columns are created on startup in `DbService.InitializeAsync` — there are no migration files. Any schema change must be idempotent (`CREATE TABLE IF NOT EXISTS`, `ALTER TABLE … ADD COLUMN IF NOT EXISTS`) and consider backfill for existing rows.
+- **WASM is single-threaded.** Don't flag missing locks/thread-safety on client code, and don't suggest server threading patterns there. Conversely, `DateTime.Now` vs `UtcNow` matters: prefer `UtcNow` and compare `DateTime` values directly rather than via signed day-diff integers (a wrong-sign value silently passes `<= 7`).
+
+### Patterns this codebase commits to
+- **Self-gating predicates over caller-supplied flags.** If a control's "show me" rule can be derived from the item's own data, encode it inside the component, not as a `showX` boolean threaded from every call site. Flag new visibility flags that duplicate a derivable rule.
+- **`QueueStatusOrdering` is canonical.** `DisplayOrder` / `SortPriority(status)` in `HurrahTv.Shared.Models` drives Queue tabs, QuickActions, and Home sort, and must match the SQL `CASE` in `DbService.GetQueueAsync`. Flag divergent ad-hoc status ordering.
+- **Mutating API endpoints return the updated entity** so the client can splice it in place. Flag mutations that return only a status code when the client needs the new row.
+- **Pre-compute per-status/per-tab counts** with `GroupBy().ToDictionary()` after data mutations — never `Count()` per tab inside a render loop.
+- **Background/fire-and-forget work** uses `IServiceScopeFactory.CreateAsyncScope()` for fresh transients; don't capture request-scoped services.
+- **Cache external calls.** TMDb responses are cached in `TmdbService` (search 30min, trending 1hr, providers 12hr, details 6hr). Every Anthropic call costs money — AI results are cached server-side in `CurationCache` keyed by watchlist hash. Flag new uncached TMDb/Anthropic calls on hot paths.
+
+## Testing expectations
+
+- **Pure `HurrahTv.Shared` logic must have tests** — predicates, filters, sort keys, parsers, extension methods. Bug fixes pin a named regression test referencing the issue number.
+- **Blazor components, CSS, page wiring, DI scaffolding do NOT need tests** — they're verified in the browser. Don't ask for unit tests on these surfaces.
+- When a feature mixes pure logic with Blazor state, the pure piece should be extracted into `HurrahTv.Shared` and tested there (inject `DateTime todayUtc` as a parameter so tests don't drift across midnight UTC).
+- No mocking frameworks, no fluent-assertion libraries — plain `Assert`. Test helpers live inside the test class. Prefer explicit, independent tests over flag-parameterized shared helpers when the cases assert different things.
+- `HurrahTv.Api.Tests` uses `WebApplicationFactory<Program>` against real Postgres. Integration-only behavior (concurrency, race paths) that can't be tested deterministically should NOT get a flaky timing-based test.
+
+## Code style
+
+- 4-space indentation. Nullable reference types and implicit usings enabled.
+- Prefer `Type variableName` over `var` when the type isn't complex.
+- Comments use `//`, start lowercase, and explain *why* when the code isn't self-explanatory. No XML doc comments.
+- C# is formatted by `dotnet format` at info severity — CI runs the bare `dotnet format --verify-no-changes --severity info HurrahTv.slnx`, which catches rules (e.g. `IDE0305`, `IDE0330`) that targeted sub-commands miss. Don't nitpick formatting a reviewer can't see; trust the gate.
+
+## DTO / Shared changes
+
+- Adding a property to a Shared DTO is generally safe (default value). Removing or renaming requires Api and Client to change in lockstep in the same change.
+- Everything in Shared crosses the wire as JSON — nullable fields, default values, and enum representations all matter. No `ref`/`out` in DTOs. No DI, no platform APIs (`HttpClient`, `IJSRuntime`, `Dapper`, `Npgsql`, ASP.NET/Components types) in Shared.
+
+## Attribution (don't regress)
+
+The UI footer must keep "Data provided by TMDb" and "Watch provider data by JustWatch" with links.

--- a/HurrahTv.Api.Tests/QueueEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/QueueEndpointsTests.cs
@@ -260,6 +260,56 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         Assert.Equal(n, positions.Distinct().Count());
     }
 
+    // pins #183 — UpsertWithStatusAsync's ApplyUpdatePolicy was refactored to thread the caller's
+    // transaction through (so the race-lost path's UPDATE stays inside the advisory lock). These
+    // pin that the policy behavior #155 codified is unchanged on the fast path (existing row): a
+    // forgotten tx arg or a broken reorder would surface as a wrong status / missing backfill here.
+    [Fact]
+    public async Task Seen_OnExistingItem_TransitionsToFinished_AndBackfillsBackdrop()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "user-seen");
+
+        // add as WantToWatch with no backdrop, then /seen with a backdrop → status flips to
+        // Finished AND the empty backdrop is backfilled (the willUpdate && needsBackdropBackfill branch)
+        QueueItem added = (await PostAsync(client, NewQueueItem(tmdbId: 1399, title: "Game of Thrones")))!;
+        Assert.Equal(QueueStatus.WantToWatch, added.Status);
+        Assert.Equal("", added.BackdropPath);
+
+        HttpResponseMessage seenResp = await client.PostAsJsonAsync("/api/queue/seen",
+            new SeenRequest(1399, MediaTypes.Tv, "Game of Thrones", "/poster.jpg", "[]", BackdropPath: "/backdrop.jpg"));
+        Assert.Equal(HttpStatusCode.OK, seenResp.StatusCode);
+        QueueItem seen = (await seenResp.Content.ReadFromJsonAsync<QueueItem>())!;
+
+        Assert.Equal(added.Id, seen.Id); // same row — fast path, no duplicate
+        Assert.Equal(QueueStatus.Finished, seen.Status);
+        Assert.Equal("/backdrop.jpg", seen.BackdropPath);
+    }
+
+    // pins #183 — /ensure never changes status (shouldUpdate => false) but must still backfill a
+    // missing backdrop (the needsBackdropBackfill-only branch). Guards the backdrop-only path of
+    // ApplyUpdatePolicy under the tx-threading refactor.
+    [Fact]
+    public async Task Ensure_OnExistingItem_LeavesStatus_ButBackfillsBackdrop()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "user-ensure");
+
+        QueueItem added = (await PostAsync(client, NewQueueItem(tmdbId: 1399, title: "Game of Thrones")))!;
+
+        // move it to Watching so we can prove /ensure does NOT touch status
+        HttpResponseMessage statusResp = await client.PutAsJsonAsync(
+            $"/api/queue/{added.Id}/status", new QueueStatusUpdate(QueueStatus.Watching));
+        Assert.Equal(HttpStatusCode.OK, statusResp.StatusCode);
+
+        HttpResponseMessage ensureResp = await client.PostAsJsonAsync("/api/queue/ensure",
+            new SeenRequest(1399, MediaTypes.Tv, "Game of Thrones", "/poster.jpg", "[]", BackdropPath: "/backdrop.jpg"));
+        Assert.Equal(HttpStatusCode.OK, ensureResp.StatusCode);
+        QueueItem ensured = (await ensureResp.Content.ReadFromJsonAsync<QueueItem>())!;
+
+        Assert.Equal(added.Id, ensured.Id);
+        Assert.Equal(QueueStatus.Watching, ensured.Status); // status untouched by /ensure
+        Assert.Equal("/backdrop.jpg", ensured.BackdropPath); // but backdrop backfilled
+    }
+
     private static async Task<QueueItem?> PostAsync(HttpClient client, QueueItem payload)
     {
         HttpResponseMessage resp = await client.PostAsJsonAsync("/api/queue", payload);

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -410,7 +410,12 @@ public class DbService(IConfiguration config)
         // applies the status / backdrop-backfill policy to a row that already exists. Shared
         // between the fast path (row found by the initial SELECT) and the race-lost path (the
         // INSERT below hit the unique constraint), so both behave identically. pins #155.
-        async Task<QueueItem> ApplyUpdatePolicy(QueueItem row)
+        // INVARIANT (#183): every branch sets an absolute value keyed by primary Id and is
+        // idempotent — so it's safe to run outside the advisory lock (fast path) or enlisted in the
+        // caller's tx (race-lost path). A future read-modify-write or relative-update policy would
+        // NOT be safe this way and MUST run inside the tx/lock on both paths. The optional tx must
+        // be passed when an open transaction exists on db, or Npgsql throws.
+        async Task<QueueItem> ApplyUpdatePolicy(QueueItem row, NpgsqlTransaction? tx = null)
         {
             // backfill backdrop on existing rows that pre-date the column — same row touch as status update
             bool needsBackdropBackfill = string.IsNullOrEmpty(row.BackdropPath) && !string.IsNullOrEmpty(backdropPath);
@@ -419,7 +424,7 @@ public class DbService(IConfiguration config)
             {
                 await db.ExecuteAsync(
                     "UPDATE QueueItems SET Status = @Status, BackdropPath = @BackdropPath WHERE Id = @Id",
-                    new { Status = (int)targetStatus, BackdropPath = backdropPath, row.Id });
+                    new { Status = (int)targetStatus, BackdropPath = backdropPath, row.Id }, tx);
                 row.Status = targetStatus;
                 row.BackdropPath = backdropPath;
             }
@@ -427,14 +432,14 @@ public class DbService(IConfiguration config)
             {
                 await db.ExecuteAsync(
                     "UPDATE QueueItems SET Status = @Status WHERE Id = @Id",
-                    new { Status = (int)targetStatus, row.Id });
+                    new { Status = (int)targetStatus, row.Id }, tx);
                 row.Status = targetStatus;
             }
             else if (needsBackdropBackfill)
             {
                 await db.ExecuteAsync(
                     "UPDATE QueueItems SET BackdropPath = @BackdropPath WHERE Id = @Id",
-                    new { BackdropPath = backdropPath, row.Id });
+                    new { BackdropPath = backdropPath, row.Id }, tx);
                 row.BackdropPath = backdropPath;
             }
             return row;
@@ -442,6 +447,9 @@ public class DbService(IConfiguration config)
 
         QueueItem? existing = await SelectQueueItemAsync(db, userId, tmdbId, mediaType);
 
+        // fast path — no transaction/lock: the policy only issues single-row "UPDATE ... WHERE Id"
+        // statements (atomic in Postgres) and allocates no Position, so there's no MAX-read race to
+        // serialize. Safe given the idempotent-by-Id invariant documented on ApplyUpdatePolicy.
         if (existing != null)
             return await ApplyUpdatePolicy(existing);
 
@@ -481,9 +489,12 @@ public class DbService(IConfiguration config)
         {
             // lost the insert race — the row exists now. Re-read and apply the same policy
             // the fast path would have, so a concurrent /seen + /ensure can't diverge.
+            // Run the policy enlisted in tx, BEFORE commit, so the mutation stays covered by the
+            // advisory lock instead of landing after the lock is released (#183).
             existing = await SelectQueueItemAsync(db, userId, tmdbId, mediaType, tx);
+            QueueItem? result = existing is null ? null : await ApplyUpdatePolicy(existing, tx);
             await tx.CommitAsync();
-            return existing is null ? null : await ApplyUpdatePolicy(existing);
+            return result;
         }
 
         await tx.CommitAsync();


### PR DESCRIPTION
## What
Bring the race-lost path's `ApplyUpdatePolicy` UPDATE inside the per-user advisory lock in `UpsertWithStatusAsync` (`DbService.cs`), and document the fast path as safe.

## Why
Surfaced during `/xreview` of PR #178. The advisory lock (#163) serializes the `MAX(Position)+INSERT`, but on the race-lost path (`ON CONFLICT DO NOTHING`) the subsequent status/backdrop UPDATE ran **after** `tx.CommitAsync()` — i.e. after the lock was released. **Benign today** (every policy sets an absolute value keyed by `Id` and is idempotent), but a structural foot-gun the day a non-idempotent / relative-update policy is added.

Hybrid resolution (per the issue's "decide" framing): move the race-lost mutation into the lock; document — not lock — the fast path.

## Changes
- Thread an optional `NpgsqlTransaction` through `ApplyUpdatePolicy` (mirrors `SelectQueueItemAsync`) and enlist the race-lost path's UPDATE in the tx **before** commit. Threading `tx` is required, not cosmetic — Npgsql throws if a command runs on a connection with an open transaction without enlisting it, which is exactly why the policy ran post-commit before.
- Fast path unchanged (single-row by-`Id` UPDATE is atomic; no `Position` allocation). Documented as safe and pinned the **idempotent-by-Id invariant** so future policy authors know the constraint.
- Behavior-preservation regression tests in `QueueEndpointsTests.cs`: `/seen` flips status to Finished + backfills backdrop; `/ensure` leaves status but backfills backdrop.

## Verification
- `dotnet build` clean; new tests + existing #155/#163 race tests pass (5/5).
- `dotnet format --verify-no-changes` passes.

The race-lost path itself isn't deterministically unit-testable (needs a real INSERT/INSERT collision); the existing #163 concurrency test gives incidental coverage. No flaky timing test added — consistent with CLAUDE.md (Api/DB integration, not pure Shared logic).

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR
Added `.github/copilot-instructions.md` — repository custom instructions for GitHub Copilot code review (architecture, authorization scoping, advisory-lock coverage, idempotent migrations, WASM single-threading, canonical `QueueStatusOrdering`, testing expectations, format gate). Improves the quality of Copilot reviews on future PRs.
