### PR TITLE
Reconcile StateHasChanged learnings (#164) + drop dead AddToQueue fallbacks (#165)

### DIFF
--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -524,13 +524,19 @@ else
     {
         if (_details == null) return;
 
+        // snapshot the navigation identity — OnParametersSetAsync nulls _queueItem on navigation,
+        // so after an await we must confirm we're still on the same title before mutating state.
+        int startTmdbId = TmdbId;
+        string startMediaType = MediaType;
         try
         {
             if (_queueItem != null)
             {
-                if (_queueItem.Status == status)
+                QueueItem existing = _queueItem;
+                if (existing.Status == status)
                     return;
-                QueueItem? updated = await Api.UpdateStatusAsync(_queueItem.Id, status);
+                QueueItem? updated = await Api.UpdateStatusAsync(existing.Id, status);
+                if (Navigated(startTmdbId, startMediaType)) return;
                 if (updated != null)
                 {
                     _queueItem = updated;
@@ -538,7 +544,7 @@ else
                 }
                 else
                 {
-                    _queueItem.Status = status; // optimistic fallback
+                    existing.Status = status; // optimistic fallback
                 }
             }
             else
@@ -547,13 +553,15 @@ else
                 item.Status = status;
                 // idempotent post-#155: AddToQueueAsync returns the existing row on a duplicate,
                 // so null here means a genuine add failure, not a conflict to recover from.
-                _queueItem = await Api.AddToQueueAsync(item);
-                if (_queueItem == null)
+                QueueItem? added = await Api.AddToQueueAsync(item);
+                if (Navigated(startTmdbId, startMediaType)) return;
+                if (added == null)
                 {
                     await Toast.ShowAsync("Couldn't update your list — try again");
                     return;
                 }
-                QuickActionSvc.NotifyItemUpdated(_queueItem);
+                _queueItem = added;
+                QuickActionSvc.NotifyItemUpdated(added);
             }
         }
         catch
@@ -563,32 +571,38 @@ else
             await Toast.ShowAsync("Couldn't update your list — try again");
             return;
         }
-        StateHasChanged();
+        if (!_disposed) StateHasChanged();
     }
 
     private async Task SetSentiment(int sentiment)
     {
         if (_details == null) return;
 
+        int startTmdbId = TmdbId;
+        string startMediaType = MediaType;
         try
         {
             if (_queueItem == null)
             {
                 // idempotent post-#155 — null means a genuine add failure, so surface it and bail.
-                _queueItem = await Api.AddToQueueAsync(_details.ToQueueItem());
-                if (_queueItem == null)
+                QueueItem? added = await Api.AddToQueueAsync(_details.ToQueueItem());
+                if (Navigated(startTmdbId, startMediaType)) return;
+                if (added == null)
                 {
                     await Toast.ShowAsync("Couldn't update your list — try again");
                     return;
                 }
+                _queueItem = added;
                 // commit the add to the UI before the sentiment call — if that throws, the item
                 // is still shown as added (it exists server-side) rather than silently vanishing.
-                QuickActionSvc.NotifyItemUpdated(_queueItem);
+                QuickActionSvc.NotifyItemUpdated(added);
                 StateHasChanged();
             }
 
-            int? newSentiment = _queueItem.Sentiment == sentiment ? null : sentiment;
-            QueueItem? updated = await Api.UpdateSentimentAsync(_queueItem.Id, newSentiment);
+            QueueItem current = _queueItem;
+            int? newSentiment = current.Sentiment == sentiment ? null : sentiment;
+            QueueItem? updated = await Api.UpdateSentimentAsync(current.Id, newSentiment);
+            if (Navigated(startTmdbId, startMediaType)) return;
             if (updated != null)
             {
                 _queueItem = updated;
@@ -596,7 +610,7 @@ else
             }
             else
             {
-                _queueItem.Sentiment = newSentiment; // optimistic fallback
+                current.Sentiment = newSentiment; // optimistic fallback
             }
         }
         catch
@@ -604,8 +618,14 @@ else
             await Toast.ShowAsync("Couldn't update your list — try again");
             return;
         }
-        StateHasChanged();
+        if (!_disposed) StateHasChanged();
     }
+
+    // true if the component was disposed or navigated to a different title while an await was in
+    // flight — OnParametersSetAsync resets _queueItem on navigation, so a continuation that
+    // mutates it would NRE or clobber the new title's state. Callers bail silently when true.
+    private bool Navigated(int startTmdbId, string startMediaType) =>
+        _disposed || TmdbId != startTmdbId || MediaType != startMediaType;
 
     private static bool IsRecent(string? dateStr)
     {

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -545,7 +545,7 @@ else
             {
                 QueueItem item = _details.ToQueueItem();
                 item.Status = status;
-                // AddToQueueAsync is idempotent post-#155 — returns the existing row on a duplicate,
+                // idempotent post-#155: AddToQueueAsync returns the existing row on a duplicate,
                 // so null here means a genuine add failure, not a conflict to recover from.
                 _queueItem = await Api.AddToQueueAsync(item);
                 if (_queueItem == null)
@@ -581,6 +581,10 @@ else
                     await Toast.ShowAsync("Couldn't update your list — try again");
                     return;
                 }
+                // commit the add to the UI before the sentiment call — if that throws, the item
+                // is still shown as added (it exists server-side) rather than silently vanishing.
+                QuickActionSvc.NotifyItemUpdated(_queueItem);
+                StateHasChanged();
             }
 
             int? newSentiment = _queueItem.Sentiment == sentiment ? null : sentiment;

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -543,9 +543,9 @@ else
         {
             QueueItem item = _details.ToQueueItem();
             item.Status = status;
+            // AddToQueueAsync is idempotent post-#155 — returns the existing row on a duplicate,
+            // so null here means a genuine add failure, not a conflict to recover from.
             _queueItem = await Api.AddToQueueAsync(item);
-            if (_queueItem == null)
-                _queueItem = await FindQueueItemAsync();
             if (_queueItem != null)
                 QuickActionSvc.NotifyItemUpdated(_queueItem);
         }
@@ -558,9 +558,8 @@ else
 
         if (_queueItem == null)
         {
+            // idempotent post-#155 — null means a genuine add failure, so bail.
             _queueItem = await Api.AddToQueueAsync(_details.ToQueueItem());
-            if (_queueItem == null)
-                _queueItem = await FindQueueItemAsync();
             if (_queueItem == null) return;
         }
 
@@ -576,13 +575,6 @@ else
             _queueItem.Sentiment = newSentiment; // optimistic fallback
         }
         StateHasChanged();
-    }
-
-    private async Task<QueueItem?> FindQueueItemAsync()
-    {
-        // item already exists in queue (409 conflict) — fetch it
-        List<QueueItem> queue = await Api.GetQueueAsync();
-        return queue.FirstOrDefault(i => i.TmdbId == TmdbId && i.MediaType == MediaType);
     }
 
     private static bool IsRecent(string? dateStr)

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -524,30 +524,44 @@ else
     {
         if (_details == null) return;
 
-        if (_queueItem != null)
+        try
         {
-            if (_queueItem.Status == status)
-                return;
-            QueueItem? updated = await Api.UpdateStatusAsync(_queueItem.Id, status);
-            if (updated != null)
+            if (_queueItem != null)
             {
-                _queueItem = updated;
-                QuickActionSvc.NotifyItemUpdated(updated);
+                if (_queueItem.Status == status)
+                    return;
+                QueueItem? updated = await Api.UpdateStatusAsync(_queueItem.Id, status);
+                if (updated != null)
+                {
+                    _queueItem = updated;
+                    QuickActionSvc.NotifyItemUpdated(updated);
+                }
+                else
+                {
+                    _queueItem.Status = status; // optimistic fallback
+                }
             }
             else
             {
-                _queueItem.Status = status; // optimistic fallback
+                QueueItem item = _details.ToQueueItem();
+                item.Status = status;
+                // AddToQueueAsync is idempotent post-#155 — returns the existing row on a duplicate,
+                // so null here means a genuine add failure, not a conflict to recover from.
+                _queueItem = await Api.AddToQueueAsync(item);
+                if (_queueItem == null)
+                {
+                    await Toast.ShowAsync("Couldn't update your list — try again");
+                    return;
+                }
+                QuickActionSvc.NotifyItemUpdated(_queueItem);
             }
         }
-        else
+        catch
         {
-            QueueItem item = _details.ToQueueItem();
-            item.Status = status;
-            // AddToQueueAsync is idempotent post-#155 — returns the existing row on a duplicate,
-            // so null here means a genuine add failure, not a conflict to recover from.
-            _queueItem = await Api.AddToQueueAsync(item);
-            if (_queueItem != null)
-                QuickActionSvc.NotifyItemUpdated(_queueItem);
+            // a network failure throws out of Update/AddToQueueAsync; without this the click
+            // fails silently (Blazor swallows event-handler exceptions). Matches HomeHero.
+            await Toast.ShowAsync("Couldn't update your list — try again");
+            return;
         }
         StateHasChanged();
     }
@@ -556,23 +570,35 @@ else
     {
         if (_details == null) return;
 
-        if (_queueItem == null)
+        try
         {
-            // idempotent post-#155 — null means a genuine add failure, so bail.
-            _queueItem = await Api.AddToQueueAsync(_details.ToQueueItem());
-            if (_queueItem == null) return;
-        }
+            if (_queueItem == null)
+            {
+                // idempotent post-#155 — null means a genuine add failure, so surface it and bail.
+                _queueItem = await Api.AddToQueueAsync(_details.ToQueueItem());
+                if (_queueItem == null)
+                {
+                    await Toast.ShowAsync("Couldn't update your list — try again");
+                    return;
+                }
+            }
 
-        int? newSentiment = _queueItem.Sentiment == sentiment ? null : sentiment;
-        QueueItem? updated = await Api.UpdateSentimentAsync(_queueItem.Id, newSentiment);
-        if (updated != null)
-        {
-            _queueItem = updated;
-            QuickActionSvc.NotifyItemUpdated(updated);
+            int? newSentiment = _queueItem.Sentiment == sentiment ? null : sentiment;
+            QueueItem? updated = await Api.UpdateSentimentAsync(_queueItem.Id, newSentiment);
+            if (updated != null)
+            {
+                _queueItem = updated;
+                QuickActionSvc.NotifyItemUpdated(updated);
+            }
+            else
+            {
+                _queueItem.Sentiment = newSentiment; // optimistic fallback
+            }
         }
-        else
+        catch
         {
-            _queueItem.Sentiment = newSentiment; // optimistic fallback
+            await Toast.ShowAsync("Couldn't update your list — try again");
+            return;
         }
         StateHasChanged();
     }

--- a/Learnings/blazor-async-statehaschanged.md
+++ b/Learnings/blazor-async-statehaschanged.md
@@ -1,13 +1,18 @@
-# Blazor Fire-and-Forget StateHasChanged Doesn't Work
+# Blazor Fire-and-Forget StateHasChanged May Not Re-render
 
 > **Area:** WASM | UI
-> **Date:** 2026-03-29
+> **Date:** 2026-03-29 (revised 2026-06-09)
 
 ## Context
 The AI curated section on the home page was invisible — no loading state, no error, nothing. The `LoadAICuration()` method was called via `_ = LoadAICuration()` (fire-and-forget) and called `StateHasChanged()` internally to update the UI.
 
 ## Learning
-In Blazor WASM, `_ = SomeAsyncMethod()` that calls `StateHasChanged()` inside does NOT reliably trigger re-renders. The component lifecycle doesn't track fire-and-forget tasks, so `StateHasChanged()` calls from that context are silently ignored.
+Two things are easy to conflate here — keep them separate:
+
+- **Is `StateHasChanged()` safe to call from this context?** Always yes. Blazor WASM is single-threaded, so there's no thread/sync-context concern from any caller (lifecycle, event handler, timer, JS interop, or a fire-and-forget continuation). See `blazor-wasm-threading-model.md` — that's the canonical source for the threading half.
+- **Will it actually re-render?** Not reliably from an *untracked* `_ = SomeAsyncMethod()`. Blazor's renderer doesn't track fire-and-forget tasks, so a `StateHasChanged()` in that continuation isn't guaranteed to flush a render — and the original "invisible AI section" was as likely a swallowed exception in the untracked task (see `blazor-wasm-async-event-exceptions.md`) as a missed render. This is a **lifecycle** issue, not a threading one.
+
+So the earlier "silently ignored" framing was too strong: a guarded `StateHasChanged()` in the `finally` of an **`await`ed** method *does* render (Blazor renders at each yield point of a tracked task). The failure mode is specifically the `_ =` discard, not the call itself.
 
 The fix is one of:
 1. **`await` the method** from within a lifecycle method (`OnInitializedAsync`, `OnParametersSetAsync`) — Blazor renders at each yield point
@@ -43,3 +48,7 @@ In `OnParametersSetAsync`, setting `_loading = true` before the first `await` do
 
 ## Additional: System.Timers.Timer in WASM
 `System.Timers.Timer` fires on a threadpool thread and captures `this`. If the component is destroyed while the timer is pending, the `Elapsed` callback fires on a dead component. Always `@implements IDisposable` and stop/dispose the timer in `Dispose()`. Prefer `CancellationTokenSource` + `Task.Delay` (as in Search.razor) over `System.Timers.Timer` when possible.
+
+## Related
+- `blazor-wasm-threading-model.md` — canonical source for "is `StateHasChanged()` / `async void` / a timer callback **safe** to call?" (always yes in WASM). This file is the canonical source for "will a fire-and-forget `StateHasChanged()` **re-render**?" (not reliably). Threading vs lifecycle — two different questions, one source of truth each.
+- `blazor-wasm-async-event-exceptions.md` — why the original symptom may have been a swallowed exception, not a missed render.


### PR DESCRIPTION
Two small `[from review]` cleanups from PR #161's xreview, batched.

## #164 — reconcile contradictory StateHasChanged learnings
`blazor-async-statehaschanged.md` said fire-and-forget `StateHasChanged()` is "silently ignored," while `blazor-wasm-threading-model.md` said it's always safe. Not actually contradictory — they answer different questions. Reframed the older learning around two separate axes:
- **Safe to call?** Always yes (single-threaded) — `blazor-wasm-threading-model.md` owns this.
- **Will it re-render?** Not reliably from an untracked `_ = Foo()` continuation (lifecycle); a guarded call in an `await`ed method's `finally` *does* render.

Cross-linked both ways so each question has one source of truth, and noted the original symptom was likely a swallowed exception.

## #165 — drop dead AddToQueue null-fallbacks in Details.razor
After #155 made `AddToQueueAsync` idempotent (returns the existing row on a duplicate), the `FindQueueItemAsync` fallback was dead for the conflict case. Removed both fallback sites and the now-unused `FindQueueItemAsync` method; null now means a genuine add failure, documented inline.

## Verification
- `dotnet build` clean; `dotnet format --verify-no-changes` passes.
- No tests: #164 is docs; #165 is a Blazor component (browser-verified).
- Smoke test: add-to-queue / set-sentiment from Details on an already-queued title still resolves `_queueItem` (now via the idempotent return).

Closes #164
Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)