### PR TITLE
Fix daily-show stale latest-episode: caught-up reconcile + season-sourced date (#189)

### DIFF
--- a/HurrahTv.Api.Tests/TmdbEpisodeDatesSeasonReconcileTests.cs
+++ b/HurrahTv.Api.Tests/TmdbEpisodeDatesSeasonReconcileTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Text;
+using HurrahTv.Api.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+
+namespace HurrahTv.Api.Tests;
+
+// pins #189 — GetEpisodeDatesAsync re-derives latest/next from live season episodes when a
+// show is actively airing, because TMDb's last_episode_to_air lags the season data the Details
+// browser reads for daily shows. No Postgres / WebApplicationFactory — TmdbService is exercised
+// directly with a routing fake handler + a real MemoryCache.
+public class TmdbEpisodeDatesSeasonReconcileTests
+{
+    private const int TmdbId = 123;
+
+    // routes by URL substring to canned JSON; records whether the season endpoint was hit so the
+    // recency-gate test can assert the extra fetch is skipped for dormant shows.
+    private sealed class RoutingHandler(string showJson, string? seasonJson) : HttpMessageHandler
+    {
+        public bool SeasonRequested { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri!.AbsolutePath;
+            string body;
+            if (path.Contains("/season/"))
+            {
+                SeasonRequested = true;
+                body = seasonJson ?? "{}";
+            }
+            else
+            {
+                body = showJson;
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private static TmdbService BuildService(RoutingHandler handler)
+    {
+        HttpClient http = new(handler);
+        IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Tmdb:ApiKey"] = "test-key" })
+            .Build();
+        return new TmdbService(http, cache, config);
+    }
+
+    private static string Iso(DateTime d) => d.ToString("yyyy-MM-dd");
+
+    // the daily-show repro: last_episode_to_air lags at S12E1 (4 days ago), but the live season
+    // has a newer aired S12E2 (1 day ago) plus an upcoming S12E3 — latest/next must reconcile to
+    // the season data so Home's "X days ago" matches Details.
+    [Fact]
+    public async Task GetEpisodeDates_ActiveShow_RederivesLatestAndNextFromSeason()
+    {
+        DateTime today = DateTime.UtcNow.Date;
+        string showJson = $$"""
+        {
+          "last_episode_to_air": { "air_date": "{{Iso(today.AddDays(-4))}}", "season_number": 12, "episode_number": 1 },
+          "next_episode_to_air": null
+        }
+        """;
+        string seasonJson = $$"""
+        {
+          "name": "Season 12",
+          "episodes": [
+            { "episode_number": 1, "air_date": "{{Iso(today.AddDays(-4))}}" },
+            { "episode_number": 2, "air_date": "{{Iso(today.AddDays(-1))}}" },
+            { "episode_number": 3, "air_date": "{{Iso(today.AddDays(6))}}" }
+          ]
+        }
+        """;
+
+        RoutingHandler handler = new(showJson, seasonJson);
+        TmdbService tmdb = BuildService(handler);
+
+        (DateTime? lastAired, int? lastSeason, int? lastEpisode, DateTime? nextAir, int? nextSeason, int? nextEpisode)
+            = await tmdb.GetEpisodeDatesAsync(TmdbId);
+
+        Assert.True(handler.SeasonRequested);
+        Assert.Equal(today.AddDays(-1), lastAired!.Value.Date);
+        Assert.Equal(12, lastSeason);
+        Assert.Equal(2, lastEpisode);
+        Assert.Equal(today.AddDays(6), nextAir!.Value.Date);
+        Assert.Equal(12, nextSeason);
+        Assert.Equal(3, nextEpisode);
+    }
+
+    // dormant show (latest aired well outside the ~10-day active window): the season fetch is
+    // skipped entirely and the stored values stay as last_episode_to_air reported them.
+    [Fact]
+    public async Task GetEpisodeDates_DormantShow_SkipsSeasonFetch()
+    {
+        DateTime today = DateTime.UtcNow.Date;
+        string showJson = $$"""
+        {
+          "last_episode_to_air": { "air_date": "{{Iso(today.AddDays(-40))}}", "season_number": 3, "episode_number": 10 },
+          "next_episode_to_air": null
+        }
+        """;
+
+        RoutingHandler handler = new(showJson, seasonJson: null);
+        TmdbService tmdb = BuildService(handler);
+
+        (DateTime? lastAired, int? lastSeason, int? lastEpisode, DateTime? nextAir, _, _)
+            = await tmdb.GetEpisodeDatesAsync(TmdbId);
+
+        Assert.False(handler.SeasonRequested);
+        Assert.Equal(today.AddDays(-40), lastAired!.Value.Date);
+        Assert.Equal(3, lastSeason);
+        Assert.Equal(10, lastEpisode);
+        Assert.Null(nextAir);
+    }
+}

--- a/HurrahTv.Api.Tests/TmdbEpisodeDatesSeasonReconcileTests.cs
+++ b/HurrahTv.Api.Tests/TmdbEpisodeDatesSeasonReconcileTests.cs
@@ -117,4 +117,39 @@ public class TmdbEpisodeDatesSeasonReconcileTests
         Assert.Equal(10, lastEpisode);
         Assert.Null(nextAir);
     }
+
+    // pins the same-air-date tie-break (xreview/Copilot): last_episode_to_air lags at E1 while
+    // a SECOND episode (E2) aired the SAME day. The date isn't strictly newer, so a date-only
+    // override gate would keep E1 — but the newest aired is really E2. Latest episode number
+    // must reconcile to E2 even though the dates match.
+    [Fact]
+    public async Task GetEpisodeDates_TwoEpisodesSameDay_RederivesHigherEpisodeNumber()
+    {
+        DateTime today = DateTime.UtcNow.Date;
+        string showJson = $$"""
+        {
+          "last_episode_to_air": { "air_date": "{{Iso(today)}}", "season_number": 13, "episode_number": 1 },
+          "next_episode_to_air": null
+        }
+        """;
+        string seasonJson = $$"""
+        {
+          "name": "Season 13",
+          "episodes": [
+            { "episode_number": 1, "air_date": "{{Iso(today)}}" },
+            { "episode_number": 2, "air_date": "{{Iso(today)}}" }
+          ]
+        }
+        """;
+
+        RoutingHandler handler = new(showJson, seasonJson);
+        TmdbService tmdb = BuildService(handler);
+
+        (DateTime? lastAired, int? lastSeason, int? lastEpisode, _, _, _)
+            = await tmdb.GetEpisodeDatesAsync(TmdbId);
+
+        Assert.Equal(today, lastAired!.Value.Date);
+        Assert.Equal(13, lastSeason);
+        Assert.Equal(2, lastEpisode);
+    }
 }

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -12,6 +12,11 @@ public class TmdbService
     private readonly HttpClient _http;
     private readonly IMemoryCache _cache;
     private readonly string _apiKey;
+
+    // a TV show whose latest episode aired within this window is treated as "actively airing":
+    // GetEpisodeDatesAsync re-derives latest/next from live season data to beat TMDb's
+    // last_episode_to_air ingestion lag (#189). Dormant back-catalog skips the extra fetch.
+    private static readonly TimeSpan SeasonScanActiveWindow = TimeSpan.FromDays(10);
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -506,8 +511,7 @@ public class TmdbService
             // todayUtc.Date — an Unspecified-Kind value could drift a calendar day near
             // midnight UTC. pins the date-only convention in tmdb-air-date-is-date-only.
             if (lastEp.TryGetProperty("air_date", out JsonElement lastDate) && lastDate.ValueKind == JsonValueKind.String
-                && DateTime.TryParse(lastDate.GetString(), CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime parsedLast))
+                && TryParseTmdbDate(lastDate.GetString(), out DateTime parsedLast))
             {
                 lastAired = parsedLast;
             }
@@ -526,8 +530,7 @@ public class TmdbService
             // same date-only → midnight UTC convention as last_episode_to_air above; the filter
             // also compares NextEpisodeDate.Date against todayUtc.Date (#170 override).
             if (nextEp.TryGetProperty("air_date", out JsonElement nextDate) && nextDate.ValueKind == JsonValueKind.String
-                && DateTime.TryParse(nextDate.GetString(), CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime parsedNext))
+                && TryParseTmdbDate(nextDate.GetString(), out DateTime parsedNext))
             {
                 nextAir = parsedNext;
             }
@@ -539,19 +542,51 @@ public class TmdbService
                 nextEpisode = nextEn.GetInt32();
         }
 
+        // TMDb's last_episode_to_air can lag the live season data the Details episode browser
+        // reads (GetSeasonAsync) — for a daily show that produced a stale "X days ago" on Home
+        // vs. a newer episode shown in Details (#189). For an actively-airing show, re-derive
+        // latest/next from the season's episodes so the stored values match Details. Gated on
+        // recency so we only pay the extra (6h-cached) season fetch for shows actually airing.
+        DateTime today = DateTime.UtcNow.Date;
+        if (lastAired is { } recentlyAired && lastSeason is { } season
+            && recentlyAired.Date >= today - SeasonScanActiveWindow)
+        {
+            SeasonDetail? seasonDetail = await GetSeasonAsync(tmdbId, season, cancellationToken);
+            if (seasonDetail is not null)
+            {
+                (DateTime? freshLatest, int? freshLatestEp, DateTime? freshNext, int? freshNextEp)
+                    = PickFreshestFromSeason(seasonDetail, today);
+
+                // override only when the season scan found something genuinely fresher than the
+                // show-endpoint values — never regress to older data on a thin/partial payload.
+                if (freshLatest is { } sld && sld.Date > lastAired.Value.Date)
+                {
+                    lastAired = sld;
+                    lastSeason = season;
+                    lastEpisode = freshLatestEp;
+                }
+                if (freshNext is { } snd && (nextAir is null || snd.Date < nextAir.Value.Date))
+                {
+                    nextAir = snd;
+                    nextSeason = season;
+                    nextEpisode = freshNextEp;
+                }
+            }
+        }
+
         (DateTime? lastAired, int? lastSeason, int? lastEpisode, DateTime? nextAir, int? nextSeason, int? nextEpisode) result = (lastAired, lastSeason, lastEpisode, nextAir, nextSeason, nextEpisode);
         _cache.Set(cacheKey, result, TimeSpan.FromHours(6));
         return result;
     }
 
-    public async Task<SeasonDetail?> GetSeasonAsync(int tmdbId, int seasonNumber)
+    public async Task<SeasonDetail?> GetSeasonAsync(int tmdbId, int seasonNumber, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"season:{tmdbId}:{seasonNumber}";
         if (_cache.TryGetValue(cacheKey, out SeasonDetail? cached))
             return cached!.Clone(); // defensive copy — same rationale as ShowDetails.Clone (#109)
 
         string url = $"tv/{tmdbId}/season/{seasonNumber}?api_key={_apiKey}&language=en-US";
-        JsonElement? raw = await GetAsync<JsonElement?>(url);
+        JsonElement? raw = await GetAsync<JsonElement?>(url, cancellationToken);
         if (raw == null) return null;
 
         JsonElement json = raw.Value;
@@ -595,6 +630,48 @@ public class TmdbService
         GenreIds = r.GenreIds ?? [],
         OriginalLanguage = r.OriginalLanguage ?? "",
     };
+
+    // TMDb date-only fields (air_date / first_air_date) carry no hour-of-day. Parse with
+    // AssumeUniversal|AdjustToUniversal so the value stores + round-trips as Kind=Utc — an
+    // Unspecified-Kind value can drift a calendar day against todayUtc.Date in the Home
+    // filters. See Learnings/tmdb-air-date-is-date-only.md.
+    private static bool TryParseTmdbDate(string? raw, out DateTime parsed) =>
+        DateTime.TryParse(raw, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out parsed);
+
+    // scans a season's episodes for the newest already-aired episode (later date wins, tie-break
+    // on higher episode number) and the earliest still-upcoming one. Pure given a SeasonDetail +
+    // today; the caller decides whether these beat the show-endpoint's last/next_episode_to_air.
+    private static (DateTime? Latest, int? LatestEp, DateTime? Next, int? NextEp) PickFreshestFromSeason(
+        SeasonDetail season, DateTime today)
+    {
+        DateTime? latestDate = null;
+        int? latestEp = null;
+        DateTime? nextDate = null;
+        int? nextEp = null;
+
+        foreach (EpisodeInfo ep in season.Episodes)
+        {
+            if (!TryParseTmdbDate(ep.AirDate, out DateTime epDate)) continue;
+
+            if (epDate.Date <= today)
+            {
+                if (latestDate is null || epDate.Date > latestDate.Value.Date
+                    || (epDate.Date == latestDate.Value.Date && ep.EpisodeNumber > (latestEp ?? 0)))
+                {
+                    latestDate = epDate;
+                    latestEp = ep.EpisodeNumber;
+                }
+            }
+            else if (nextDate is null || epDate.Date < nextDate.Value.Date)
+            {
+                nextDate = epDate;
+                nextEp = ep.EpisodeNumber;
+            }
+        }
+
+        return (latestDate, latestEp, nextDate, nextEp);
+    }
 
     private async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken = default)
     {

--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -559,17 +559,25 @@ public class TmdbService
 
                 // override only when the season scan found something genuinely fresher than the
                 // show-endpoint values — never regress to older data on a thin/partial payload.
-                if (freshLatest is { } sld && sld.Date > lastAired.Value.Date)
+                // Compare (date, episode), not date alone: when last_episode_to_air lags by
+                // episode number on the SAME day (a show airing twice in a day, the exact
+                // ingestion-lag case this guards), the higher-numbered season episode still wins.
+                if (freshLatest is { } sld && freshLatestEp is { } sEp
+                    && (sld.Date, sEp).CompareTo((lastAired.Value.Date, lastEpisode ?? -1)) > 0)
                 {
                     lastAired = sld;
                     lastSeason = season;
-                    lastEpisode = freshLatestEp;
+                    lastEpisode = sEp;
                 }
-                if (freshNext is { } snd && (nextAir is null || snd.Date < nextAir.Value.Date))
+                // symmetric for next: a sooner date — or the same date with a lower episode
+                // number — is the more-correct "next" than next_episode_to_air.
+                if (freshNext is { } snd && freshNextEp is { } nEp
+                    && (nextAir is null
+                        || (snd.Date, nEp).CompareTo((nextAir.Value.Date, nextEpisode ?? int.MaxValue)) < 0))
                 {
                     nextAir = snd;
                     nextSeason = season;
-                    nextEpisode = freshNextEp;
+                    nextEpisode = nEp;
                 }
             }
         }
@@ -663,7 +671,11 @@ public class TmdbService
                     latestEp = ep.EpisodeNumber;
                 }
             }
-            else if (nextDate is null || epDate.Date < nextDate.Value.Date)
+            // earliest still-upcoming: sooner date wins, tie-break on LOWER episode number
+            // (mirror of the latest branch above) so a same-day multi-episode payload or an
+            // out-of-order season array can't pick the wrong "next".
+            else if (nextDate is null || epDate.Date < nextDate.Value.Date
+                || (epDate.Date == nextDate.Value.Date && ep.EpisodeNumber < (nextEp ?? int.MaxValue)))
             {
                 nextDate = epDate;
                 nextEp = ep.EpisodeNumber;

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -437,10 +437,21 @@ else
 
     private void StampWatchedFlags()
     {
+        // high-water mark per show: the newest (season, episode) the user has watched.
+        // Pre-computed once (not per-item) so the caught-up check below is O(1) per item.
+        // We compare against this rather than exact-matching the stored latest S/E, because
+        // for daily shows the stored latest lags the truly-newest aired episode — watching
+        // the newer one must still count as caught up (#189).
+        Dictionary<int, (int Season, int Episode)> highWater = _watchedSet
+            .GroupBy(w => w.TmdbId)
+            .ToDictionary(g => g.Key, g => g.Max(w => (w.Season, w.Episode)));
+
         foreach (QueueItem item in _allItems)
         {
-            if (item.LatestEpisodeSeason.HasValue && item.LatestEpisodeNumber.HasValue)
-                item.IsLatestEpisodeWatched = _watchedSet.Contains((item.TmdbId, item.LatestEpisodeSeason.Value, item.LatestEpisodeNumber.Value));
+            item.IsLatestEpisodeWatched = QueueItemExtensions.IsLatestEpisodeWatched(
+                item.LatestEpisodeSeason,
+                item.LatestEpisodeNumber,
+                highWater.TryGetValue(item.TmdbId, out (int Season, int Episode) hw) ? hw : null);
         }
     }
 

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -438,8 +438,8 @@ else
     private void StampWatchedFlags()
     {
         // high-water mark per show: the newest (season, episode) the user has watched.
-        // Pre-computed once (not per-item) so the caught-up check below is O(1) per item.
-        // We compare against this rather than exact-matching the stored latest S/E, because
+        // pre-computed once (not per-item) so the caught-up check below is O(1) per item.
+        // we compare against this rather than exact-matching the stored latest S/E, because
         // for daily shows the stored latest lags the truly-newest aired episode — watching
         // the newer one must still count as caught up (#189).
         Dictionary<int, (int Season, int Episode)> highWater = _watchedSet

--- a/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
@@ -69,6 +69,38 @@ public class QueueItemExtensionsTests
         Assert.Null(item.DaysSinceLatestEpisode(TodayUtc));
     }
 
+    // pins #189 — the daily-show bug. Stored latest lags at (S,E1); the user watched the
+    // genuinely-newer (S,E2) via the live Details browser. High-water reconciliation must
+    // treat the show as caught up so it drops out of Available Now, even though the stored
+    // LatestEpisode* fields haven't refreshed to (S,E2) yet.
+    [Fact]
+    public void IsLatestEpisodeWatched_Caught_Up_When_Watched_Newer_Than_Stale_Stored_Latest() =>
+        Assert.True(QueueItemExtensions.IsLatestEpisodeWatched(latestSeason: 12, latestEpisode: 1, highWaterWatched: (12, 2)));
+
+    [Fact]
+    public void IsLatestEpisodeWatched_ExactMatch_ReturnsTrue() =>
+        Assert.True(QueueItemExtensions.IsLatestEpisodeWatched(latestSeason: 12, latestEpisode: 5, highWaterWatched: (12, 5)));
+
+    // user is behind the stored latest — still has an unwatched newest episode, so NOT caught up.
+    [Fact]
+    public void IsLatestEpisodeWatched_WatchedOlderThanStoredLatest_ReturnsFalse() =>
+        Assert.False(QueueItemExtensions.IsLatestEpisodeWatched(latestSeason: 12, latestEpisode: 5, highWaterWatched: (12, 1)));
+
+    // watched a later SEASON than the stored latest — our season data is stale-behind; caught up.
+    [Fact]
+    public void IsLatestEpisodeWatched_WatchedLaterSeason_ReturnsTrue() =>
+        Assert.True(QueueItemExtensions.IsLatestEpisodeWatched(latestSeason: 12, latestEpisode: 5, highWaterWatched: (13, 1)));
+
+    // no stored latest → no notion of "caught up"; preserves the prior exact-match behavior.
+    [Fact]
+    public void IsLatestEpisodeWatched_NullStoredLatest_ReturnsFalse() =>
+        Assert.False(QueueItemExtensions.IsLatestEpisodeWatched(latestSeason: null, latestEpisode: null, highWaterWatched: (12, 5)));
+
+    // user hasn't watched anything for this show → not caught up.
+    [Fact]
+    public void IsLatestEpisodeWatched_NoWatchedEpisodes_ReturnsFalse() =>
+        Assert.False(QueueItemExtensions.IsLatestEpisodeWatched(latestSeason: 12, latestEpisode: 5, highWaterWatched: null));
+
     [Fact]
     public void ParseAvailableOnProviderIds_ValidJsonList_ReturnsIds()
     {

--- a/HurrahTv.Shared/Models/QueueItemExtensions.cs
+++ b/HurrahTv.Shared/Models/QueueItemExtensions.cs
@@ -26,6 +26,21 @@ public static class QueueItemExtensions
     public static int? DaysSinceLatestEpisode(this QueueItem item, DateTime todayUtc) =>
         item.LatestEpisodeDate is { } d ? (int)(todayUtc.Date - d.Date).TotalDays : null;
 
+    // caught up if the user's newest-watched episode for this show is at or beyond the
+    // stored "latest" (lexicographic by season then episode). Robust to a stale stored
+    // S/E: watching a genuinely-newer episode (S,E2) counts as caught up even when the
+    // stored latest still lags at (S,E1) — which is exactly the daily-show case where
+    // TMDb's last_episode_to_air ingestion lags the live season data. Returns false when
+    // there's no stored latest or the user hasn't watched anything for the show, matching
+    // the prior exact-match behavior. pins #189.
+    public static bool IsLatestEpisodeWatched(
+        int? latestSeason, int? latestEpisode, (int Season, int Episode)? highWaterWatched)
+    {
+        if (latestSeason is not { } season || latestEpisode is not { } episode) return false;
+        if (highWaterWatched is not { } watched) return false;
+        return watched.CompareTo((season, episode)) >= 0;
+    }
+
     // streamable y/n for the Home watchlist filter — mirrors the API's IsWatchableOn
     // (QueueEndpoints) exactly: empty/unknown provider data is "don't hide" (#141), and a
     // match is plain service-id membership. NOT the same rule as the Queue page's


### PR DESCRIPTION
## What

Fixes two linked symptoms for daily shows (repro: *Late Night with Seth Meyers*), both rooted in `QueueItem.LatestEpisode*` lagging the truly-newest aired episode.

**1. Watched-but-still-in-Available-Now.** `IsLatestEpisodeWatched` was an exact match against the stale stored S/E, so watching the genuinely-newer episode never flipped it. Replaced with a high-water-mark reconcile in Shared (`QueueItemExtensions.IsLatestEpisodeWatched`): caught up if the newest watched `(season, episode)` is `>=` the stored latest. `Home.StampWatchedFlags` precomputes a per-show high-water dict once and uses it.

**2. Stale "X days ago".** TMDb's `last_episode_to_air` lags the live season data the Details episode browser reads. `GetEpisodeDatesAsync` now re-derives latest/next from the season's episodes (`PickFreshestFromSeason`) for actively-airing shows (latest aired within `SeasonScanActiveWindow`), so the Home badge matches the episode browser. `WatchlistFilters` is unchanged — it just gets a correct flag.

## Verification

Browser-verified in the running app as a logged-in user:
- Seth Meyers corrected **"5d ago" → "today"**, matching the episode browser's newest aired (S13E106, today).
- Marking that episode watched **removed the show from Available Now** before the 12h refresh; unmarking restored it.

## Tests
- 6 Shared regression/boundary tests for the high-water reconcile (pins #189).
- 2 Api tests for the season-scan override + dormant-show recency gate.
- `dotnet format --verify-no-changes` clean.

## Follow-up
- #190 (filed via /xsimplify) — promote a canonical TMDb date-only parse helper to Shared; the Client's bare `DateTime.TryParse` diverges from the Api convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #189