### PR TITLE
Promote a canonical TMDb date-only parse helper to HurrahTv.Shared (#190)

### DIFF
--- a/HurrahTv.Api/Services/TmdbService.cs
+++ b/HurrahTv.Api/Services/TmdbService.cs
@@ -511,7 +511,7 @@ public class TmdbService
             // todayUtc.Date — an Unspecified-Kind value could drift a calendar day near
             // midnight UTC. pins the date-only convention in tmdb-air-date-is-date-only.
             if (lastEp.TryGetProperty("air_date", out JsonElement lastDate) && lastDate.ValueKind == JsonValueKind.String
-                && TryParseTmdbDate(lastDate.GetString(), out DateTime parsedLast))
+                && TmdbDate.TryParse(lastDate.GetString(), out DateTime parsedLast))
             {
                 lastAired = parsedLast;
             }
@@ -530,7 +530,7 @@ public class TmdbService
             // same date-only → midnight UTC convention as last_episode_to_air above; the filter
             // also compares NextEpisodeDate.Date against todayUtc.Date (#170 override).
             if (nextEp.TryGetProperty("air_date", out JsonElement nextDate) && nextDate.ValueKind == JsonValueKind.String
-                && TryParseTmdbDate(nextDate.GetString(), out DateTime parsedNext))
+                && TmdbDate.TryParse(nextDate.GetString(), out DateTime parsedNext))
             {
                 nextAir = parsedNext;
             }
@@ -639,14 +639,6 @@ public class TmdbService
         OriginalLanguage = r.OriginalLanguage ?? "",
     };
 
-    // TMDb date-only fields (air_date / first_air_date) carry no hour-of-day. Parse with
-    // AssumeUniversal|AdjustToUniversal so the value stores + round-trips as Kind=Utc — an
-    // Unspecified-Kind value can drift a calendar day against todayUtc.Date in the Home
-    // filters. See Learnings/tmdb-air-date-is-date-only.md.
-    private static bool TryParseTmdbDate(string? raw, out DateTime parsed) =>
-        DateTime.TryParse(raw, CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out parsed);
-
     // scans a season's episodes for the newest already-aired episode (later date wins, tie-break
     // on higher episode number) and the earliest still-upcoming one. Pure given a SeasonDetail +
     // today; the caller decides whether these beat the show-endpoint's last/next_episode_to_air.
@@ -660,7 +652,7 @@ public class TmdbService
 
         foreach (EpisodeInfo ep in season.Episodes)
         {
-            if (!TryParseTmdbDate(ep.AirDate, out DateTime epDate)) continue;
+            if (!TmdbDate.TryParse(ep.AirDate, out DateTime epDate)) continue;
 
             if (epDate.Date <= today)
             {

--- a/HurrahTv.Client/Components/EpisodeBrowser.razor
+++ b/HurrahTv.Client/Components/EpisodeBrowser.razor
@@ -203,20 +203,20 @@
     private static bool HasAired(string? dateStr, DateTime today)
     {
         // null or unparseable = unknown = not aired (don't show sentiment buttons)
-        if (string.IsNullOrEmpty(dateStr) || !DateTime.TryParse(dateStr, out DateTime date)) return false;
+        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return false;
         return date.Date <= today;
     }
 
     private static bool IsFuture(string? dateStr, DateTime today)
     {
-        if (string.IsNullOrEmpty(dateStr) || !DateTime.TryParse(dateStr, out DateTime date)) return false;
+        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return false;
         return date.Date > today;
     }
 
     private static string FormatDate(string? dateStr)
     {
         if (string.IsNullOrEmpty(dateStr) || dateStr == "0000-00-00") return "";
-        if (!DateTime.TryParse(dateStr, out DateTime date)) return "";
+        if (!TmdbDate.TryParse(dateStr, out DateTime date)) return "";
         return date.ToString("MMM d, yyyy");
     }
 

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -629,13 +629,13 @@ else
 
     private static bool IsRecent(string? dateStr)
     {
-        if (string.IsNullOrEmpty(dateStr) || !DateTime.TryParse(dateStr, out DateTime date)) return false;
+        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return false;
         return (DateTime.UtcNow - date).TotalDays <= 30;
     }
 
     private static string FormatAirDate(string? dateStr)
     {
-        if (string.IsNullOrEmpty(dateStr) || !DateTime.TryParse(dateStr, out DateTime date)) return "";
+        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return "";
 
         int daysAgo = (int)(DateTime.UtcNow - date).TotalDays;
         if (daysAgo < 0)

--- a/HurrahTv.Shared.Tests/TmdbDateTests.cs
+++ b/HurrahTv.Shared.Tests/TmdbDateTests.cs
@@ -1,0 +1,38 @@
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Shared.Tests;
+
+// TMDb air_date / first_air_date are date-only wire strings. The canonical parse must yield
+// Kind=Utc so Api and Client agree on the convention — a bare DateTime.TryParse yields
+// Kind=Unspecified, the calendar-day drift this helper exists to prevent. Pins #190.
+public class TmdbDateTests
+{
+    [Fact]
+    public void TryParse_DateOnly_YieldsUtcKind()
+    {
+        Assert.True(TmdbDate.TryParse("2026-06-11", out DateTime parsed));
+        Assert.Equal(DateTimeKind.Utc, parsed.Kind);
+        Assert.Equal(new DateTime(2026, 6, 11, 0, 0, 0, DateTimeKind.Utc), parsed);
+    }
+
+    [Fact]
+    public void TryParse_NullOrEmpty_ReturnsFalse()
+    {
+        Assert.False(TmdbDate.TryParse(null, out _));
+        Assert.False(TmdbDate.TryParse("", out _));
+    }
+
+    [Fact]
+    public void TryParse_Garbage_ReturnsFalse() =>
+        Assert.False(TmdbDate.TryParse("not-a-date", out _));
+
+    [Fact]
+    public void TryParse_OffsetTimestamp_NormalizesToUtc()
+    {
+        // a value with an offset must adjust to UTC, not stay local — keeps the convention
+        // consistent if TMDb ever sends a full timestamp on these fields.
+        Assert.True(TmdbDate.TryParse("2026-06-11T20:00:00-04:00", out DateTime parsed));
+        Assert.Equal(DateTimeKind.Utc, parsed.Kind);
+        Assert.Equal(new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc), parsed);
+    }
+}

--- a/HurrahTv.Shared/Models/TmdbDate.cs
+++ b/HurrahTv.Shared/Models/TmdbDate.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+
+namespace HurrahTv.Shared.Models;
+
+// Canonical parse for TMDb date-only fields (air_date / first_air_date), shared by Api and Client
+// so both sides of the wire agree on the convention. These fields carry no hour-of-day; parse with
+// AssumeUniversal|AdjustToUniversal so the value is Kind=Utc — an Unspecified-Kind value can drift
+// a calendar day against a UTC "today". See Learnings/tmdb-air-date-is-date-only.md.
+public static class TmdbDate
+{
+    public static bool TryParse(string? raw, out DateTime parsed) =>
+        DateTime.TryParse(raw, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out parsed);
+}


### PR DESCRIPTION
## What
Extracts the TMDb date-only parse (`AssumeUniversal | AdjustToUniversal` → `Kind=Utc`) into a single canonical helper in `HurrahTv.Shared/Models/TmdbDate.cs`, and routes both sides of the wire through it.

## Why
TMDb `air_date` / `first_air_date` are date-only wire strings, so the date-only → `Kind=Utc` convention is a contract both Api and Client must agree on (`Learnings/tmdb-air-date-is-date-only.md`). The Api already parsed correctly via `TmdbService.TryParseTmdbDate`, but the Client re-parsed the same strings with a **bare** `DateTime.TryParse` yielding `Kind=Unspecified` — exactly the drift the learning warns about.

## Changes
- **New** `HurrahTv.Shared/Models/TmdbDate.TryParse` — the single canonical helper
- `HurrahTv.Api/Services/TmdbService.cs` — drops the private `TryParseTmdbDate`; its 3 parse sites call the shared helper
- `HurrahTv.Client/Components/EpisodeBrowser.razor` — `HasAired` / `IsFuture` / `FormatDate` replace bare `DateTime.TryParse`
- `HurrahTv.Client/Pages/Details.razor` — `IsRecent` / `FormatAirDate` replace bare `DateTime.TryParse`
- **New** `HurrahTv.Shared.Tests/TmdbDateTests.cs` — 4 regression tests pinning Kind=Utc, null/empty, garbage, and offset-timestamp normalization

## Verification
- Build clean across all three projects (0 warnings)
- `dotnet format --verify-no-changes` (CI gate) passes
- 107 Shared tests green (incl. the 4 new)
- Browser smoke-test: EpisodeBrowser aired/upcoming split + Details air-date labels render correctly

## Notes
For date-only strings the parsed `.Date` is numerically identical to before — this makes the **convention** consistent (Kind=Utc on both sides). Follow-up #192 tracks the remaining comparison-side drift (EpisodeBrowser's local "today", Details' signed day-diff).

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)