### PR TITLE
Align EpisodeBrowser/Details date semantics on a UTC baseline (#192)

### DIFF
--- a/.claude/skills/tidy/SKILL.md
+++ b/.claude/skills/tidy/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Post-merge cleanup — switch to the default branch, pull, and delete the merged feature branch (with a safety check that the PR actually merged)
+description: Post-merge cleanup — switch to the default branch, pull, and delete the merged feature branch (with a safety check that the PR actually merged). Run on the default branch itself, it commits and pushes any dirty work instead.
 argument-hint: "[branch] (defaults to the current branch)"
 user-invocable: true
 ---
@@ -27,9 +27,42 @@ DEFAULT="${DEFAULT:-main}"
 echo "target: $TARGET   default: $DEFAULT"
 ```
 
-- If `$TARGET` equals `$DEFAULT` → nothing to delete. Just run step 3 (sync) and stop.
-- If the working tree is dirty (`git status --porcelain` non-empty) → **stop and tell the user.**
+- If `$TARGET` equals `$DEFAULT` → nothing to delete. **Run step 3a (sync + commit + push) and stop.**
+- Otherwise (`$TARGET` is a feature branch) and the working tree is dirty
+  (`git status --porcelain` non-empty) → **stop and tell the user.**
   Don't switch branches over uncommitted work.
+
+### 3a. On the default branch: pull, commit & push
+
+Only when `$TARGET` equals `$DEFAULT`. This replaces step 3 — don't also run step 3.
+
+**First, pull any unpulled commits.** Always fetch and check whether the local default
+is behind the remote, even if the tree is dirty:
+
+```bash
+git fetch origin "$DEFAULT"
+git status --porcelain                                   # what's about to be committed (may be empty)
+git rev-list --left-right --count "origin/$DEFAULT...HEAD"   # "<behind>  <ahead>"
+```
+
+- **Clean tree** → `git pull --ff-only origin "$DEFAULT"` to absorb any unpulled commits.
+  Then if there's nothing to commit, report "nothing to commit, already synced" and stop.
+- **Dirty tree** → commit first (see below), then reconcile any unpulled commits with a
+  rebase so your commit lands cleanly on top:
+  ```bash
+  git add -A && git commit            # message per the rules below
+  git pull --rebase origin "$DEFAULT" # no-op if not behind; replays your commit if behind
+  git push origin "$DEFAULT"
+  ```
+
+Commit message rules:
+- Write a concise message summarizing the actual changes — read the diff first;
+  don't use a generic placeholder. End it with the standard `Co-Authored-By` trailer.
+
+Safety:
+- Never force-push the default branch. If the rebase hits a conflict, **stop** and surface it
+  — don't auto-resolve. If the push is still rejected after the rebase (remote moved again),
+  re-run the `pull --rebase` then retry the push once; if it still fails, stop and report.
 
 ### 2. Safety check — did the PR actually merge?
 
@@ -65,11 +98,13 @@ git remote prune origin          # drop the now-deleted origin/$TARGET ref (and 
 
 One line: what was pulled into the default branch (`git log --oneline -1`) and which branch was deleted.
 If `git remote prune` removed extra stale refs, mention them — it's a useful side-effect, not an error.
+When run on the default branch, instead report what was committed & pushed (or "nothing to commit" if the tree was clean).
 
 ## Guidelines
 
 - **The GitHub merge check (step 2) is the load-bearing safety.** It's what makes `-D` safe
   after a squash merge. Skipping it risks deleting genuinely unmerged work.
-- This skill never merges, pushes, or touches the remote branch beyond pruning the dead ref —
-  GitHub's "delete branch on merge" (or the squash-merge UI) already removed `origin/$TARGET`.
+- On a **feature branch**, this skill never merges or pushes — it only cleans up after a merge
+  the user already performed (GitHub's "delete branch on merge" already removed `origin/$TARGET`,
+  so it just prunes the dead ref). On the **default branch**, it commits & pushes dirty work (step 3a).
 - Branch/PR structure is the user's to own — this only cleans up *after* a merge the user already performed.

--- a/HurrahTv.Client/Components/EpisodeBrowser.razor
+++ b/HurrahTv.Client/Components/EpisodeBrowser.razor
@@ -69,12 +69,11 @@
                     {
                         <div class="border-t border-surface-200">
                             @{
-                                DateTime today = DateTime.Now.Date;
-                                List<EpisodeInfo> aired = [.. _seasonDetail.Episodes.Where(e => HasAired(e.AirDate, today))];
-                                EpisodeInfo? nextUp = _seasonDetail.Episodes
-                                    .Where(e => IsFuture(e.AirDate, today))
-                                    .OrderBy(e => e.EpisodeNumber)
-                                    .FirstOrDefault();
+                                // UTC "today" for cross-surface consistency with the Home page's
+                                // server-side classification (#192). SplitAiredUpcoming parses each
+                                // AirDate once.
+                                (IReadOnlyList<EpisodeInfo> aired, EpisodeInfo? nextUp) =
+                                    TmdbDateDisplay.SplitAiredUpcoming(_seasonDetail.Episodes, DateTime.UtcNow.Date);
                                 List<EpisodeInfo> visible = [.. aired];
                                 if (nextUp != null) visible.Add(nextUp);
                             }
@@ -97,7 +96,7 @@
                                         </div>
                                         @if (!string.IsNullOrEmpty(ep.AirDate))
                                         {
-                                            <div class="text-[10px] text-gray-600 ml-8">@FormatDate(ep.AirDate)</div>
+                                            <div class="text-[10px] text-gray-600 ml-8">@TmdbDateDisplay.FormatAbsolute(ep.AirDate)</div>
                                         }
                                     </div>
                                     @if (!upcoming)
@@ -198,26 +197,6 @@
             _seasonSentiments[seasonNumber] = new SeasonSentiment { TmdbId = TmdbId, SeasonNumber = seasonNumber, Sentiment = newSentiment.Value };
         else
             _seasonSentiments.Remove(seasonNumber);
-    }
-
-    private static bool HasAired(string? dateStr, DateTime today)
-    {
-        // null or unparseable = unknown = not aired (don't show sentiment buttons)
-        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return false;
-        return date.Date <= today;
-    }
-
-    private static bool IsFuture(string? dateStr, DateTime today)
-    {
-        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return false;
-        return date.Date > today;
-    }
-
-    private static string FormatDate(string? dateStr)
-    {
-        if (string.IsNullOrEmpty(dateStr) || dateStr == "0000-00-00") return "";
-        if (!TmdbDate.TryParse(dateStr, out DateTime date)) return "";
-        return date.ToString("MMM d, yyyy");
     }
 
     private async Task SetEpisodeSentiment(int seasonNumber, int episodeNumber, int sentiment)

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -229,12 +229,12 @@ else
                             {
                                 <span>&ldquo;@_details.NextEpisodeName&rdquo;</span>
                             }
-                            &mdash; @FormatAirDate(_details.NextEpisodeAirDate)
+                            &mdash; @TmdbDateDisplay.FormatRelative(_details.NextEpisodeAirDate, DateTime.UtcNow.Date)
                         </span>
                     </div>
                 </div>
             }
-            else if (_details.LastEpisodeAirDate != null && IsRecent(_details.LastEpisodeAirDate))
+            else if (_details.LastEpisodeAirDate != null && TmdbDateDisplay.IsRecent(_details.LastEpisodeAirDate, DateTime.UtcNow.Date))
             {
                 <div class="flex items-center gap-2 bg-accent/20 border border-accent/40 rounded-lg px-3 py-2 mb-3 md:mb-4">
                     <span class="icon-[heroicons--sparkles] w-5 h-5 text-accent-light"></span>
@@ -246,7 +246,7 @@ else
                             {
                                 <span>&ldquo;@_details.LastEpisodeName&rdquo;</span>
                             }
-                            &mdash; aired @FormatAirDate(_details.LastEpisodeAirDate)
+                            &mdash; aired @TmdbDateDisplay.FormatRelative(_details.LastEpisodeAirDate, DateTime.UtcNow.Date)
                         </span>
                     </div>
                 </div>
@@ -279,9 +279,9 @@ else
             }
             @if (_details.MediaType == "tv" && _details.LastEpisodeAirDate != null)
             {
-                <span>Last aired @FormatAirDate(_details.LastEpisodeAirDate)</span>
+                <span>Last aired @TmdbDateDisplay.FormatRelative(_details.LastEpisodeAirDate, DateTime.UtcNow.Date)</span>
             }
-            @if (_details.MediaType == "movie" && !string.IsNullOrEmpty(_details.ReleaseDate) && IsRecent(_details.ReleaseDate))
+            @if (_details.MediaType == "movie" && !string.IsNullOrEmpty(_details.ReleaseDate) && TmdbDateDisplay.IsRecent(_details.ReleaseDate, DateTime.UtcNow.Date))
             {
                 <span class="text-accent-light font-medium">New release</span>
             }
@@ -627,29 +627,4 @@ else
     private bool Navigated(int startTmdbId, string startMediaType) =>
         _disposed || TmdbId != startTmdbId || MediaType != startMediaType;
 
-    private static bool IsRecent(string? dateStr)
-    {
-        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return false;
-        return (DateTime.UtcNow - date).TotalDays <= 30;
-    }
-
-    private static string FormatAirDate(string? dateStr)
-    {
-        if (string.IsNullOrEmpty(dateStr) || !TmdbDate.TryParse(dateStr, out DateTime date)) return "";
-
-        int daysAgo = (int)(DateTime.UtcNow - date).TotalDays;
-        if (daysAgo < 0)
-        {
-            int daysUntil = -daysAgo;
-            if (daysUntil == 0) return "today";
-            if (daysUntil == 1) return "tomorrow";
-            if (daysUntil <= 7) return $"in {daysUntil} days";
-            return date.ToString("MMM d, yyyy");
-        }
-        if (daysAgo == 0) return "today";
-        if (daysAgo == 1) return "yesterday";
-        if (daysAgo <= 7) return $"{daysAgo} days ago";
-        if (daysAgo <= 30) return $"{daysAgo / 7} weeks ago";
-        return date.ToString("MMM d, yyyy");
-    }
 }

--- a/HurrahTv.Shared.Tests/TmdbDateDisplayTests.cs
+++ b/HurrahTv.Shared.Tests/TmdbDateDisplayTests.cs
@@ -1,0 +1,130 @@
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Shared.Tests;
+
+// TmdbDateDisplay owns aired/upcoming classification + relative phrasing for TMDb date-only
+// strings, using typed comparisons against an injected todayUtc. These pin the two reachable
+// signed-day-diff bugs from #192 (2a: future reads as recent; 2b: near-future labels as "today")
+// and the aired/upcoming split. todayUtc is fixed so the date fences don't drift across midnight.
+public class TmdbDateDisplayTests
+{
+    private static readonly DateTime Today = new(2026, 6, 11, 0, 0, 0, DateTimeKind.Utc);
+
+    private static string Raw(int dayOffset) => $"{Today.AddDays(dayOffset):yyyy-MM-dd}";
+
+    private static EpisodeInfo Ep(int number, string? airDate) =>
+        new() { EpisodeNumber = number, AirDate = airDate };
+
+    // --- IsRecent ---
+
+    [Fact]
+    public void IsRecent_PastWithinWindow_IsTrue()
+    {
+        Assert.True(TmdbDateDisplay.IsRecent(Raw(-5), Today));
+        Assert.True(TmdbDateDisplay.IsRecent(Raw(0), Today));   // today counts
+        Assert.True(TmdbDateDisplay.IsRecent(Raw(-30), Today)); // inclusive boundary
+    }
+
+    [Fact]
+    public void IsRecent_BeyondWindow_IsFalse() =>
+        Assert.False(TmdbDateDisplay.IsRecent(Raw(-31), Today));
+
+    [Fact]
+    public void IsRecent_FutureDate_IsFalse() // pins #192/2a
+    {
+        Assert.False(TmdbDateDisplay.IsRecent(Raw(1), Today));
+        Assert.False(TmdbDateDisplay.IsRecent(Raw(60), Today)); // unreleased movie ReleaseDate
+    }
+
+    [Fact]
+    public void IsRecent_NullOrUnparseable_IsFalse()
+    {
+        Assert.False(TmdbDateDisplay.IsRecent(null, Today));
+        Assert.False(TmdbDateDisplay.IsRecent("not-a-date", Today));
+    }
+
+    // --- FormatRelative ---
+
+    [Fact]
+    public void FormatRelative_NearFuture_IsTomorrow_NotToday() // pins #192/2b
+    {
+        Assert.Equal("tomorrow", TmdbDateDisplay.FormatRelative(Raw(1), Today));
+        Assert.Equal("today", TmdbDateDisplay.FormatRelative(Raw(0), Today));
+    }
+
+    [Fact]
+    public void FormatRelative_WithinWeek_UsesRelativePhrasing()
+    {
+        Assert.Equal("in 3 days", TmdbDateDisplay.FormatRelative(Raw(3), Today));
+        Assert.Equal("yesterday", TmdbDateDisplay.FormatRelative(Raw(-1), Today));
+        Assert.Equal("5 days ago", TmdbDateDisplay.FormatRelative(Raw(-5), Today));
+        Assert.Equal("2 weeks ago", TmdbDateDisplay.FormatRelative(Raw(-14), Today));
+    }
+
+    [Fact]
+    public void FormatRelative_OutsideWindow_FallsBackToAbsolute()
+    {
+        // compare against the helper's own culture-dependent format so the test is culture-stable
+        Assert.Equal(Today.AddDays(8).ToString("MMM d, yyyy"), TmdbDateDisplay.FormatRelative(Raw(8), Today));
+        Assert.Equal(Today.AddDays(-40).ToString("MMM d, yyyy"), TmdbDateDisplay.FormatRelative(Raw(-40), Today));
+    }
+
+    [Fact]
+    public void FormatRelative_Unparseable_IsEmpty() =>
+        Assert.Equal("", TmdbDateDisplay.FormatRelative("0000-00-00", Today));
+
+    // --- FormatAbsolute ---
+
+    [Fact]
+    public void FormatAbsolute_Valid_FormatsDate() =>
+        Assert.Equal(new DateTime(2026, 6, 11).ToString("MMM d, yyyy"), TmdbDateDisplay.FormatAbsolute("2026-06-11"));
+
+    [Fact]
+    public void FormatAbsolute_MissingOrSentinel_IsEmpty()
+    {
+        Assert.Equal("", TmdbDateDisplay.FormatAbsolute(null));
+        Assert.Equal("", TmdbDateDisplay.FormatAbsolute("0000-00-00"));
+    }
+
+    // --- SplitAiredUpcoming ---
+
+    [Fact]
+    public void SplitAiredUpcoming_PartitionsOnTodayInclusive_AndPicksLowestFutureEpisode()
+    {
+        List<EpisodeInfo> episodes =
+        [
+            Ep(1, Raw(-10)),
+            Ep(2, Raw(0)),   // today → aired
+            Ep(4, Raw(5)),   // future
+            Ep(3, Raw(2)),   // earlier future, lower episode number → NextUp
+        ];
+
+        (IReadOnlyList<EpisodeInfo> aired, EpisodeInfo? nextUp) = TmdbDateDisplay.SplitAiredUpcoming(episodes, Today);
+
+        Assert.Equal([1, 2], aired.Select(e => e.EpisodeNumber).OrderBy(n => n));
+        Assert.NotNull(nextUp);
+        Assert.Equal(3, nextUp!.EpisodeNumber);
+    }
+
+    [Fact]
+    public void SplitAiredUpcoming_DropsUnparseable_FromBoth()
+    {
+        List<EpisodeInfo> episodes = [Ep(1, Raw(-1)), Ep(2, null), Ep(3, "0000-00-00")];
+
+        (IReadOnlyList<EpisodeInfo> aired, EpisodeInfo? nextUp) = TmdbDateDisplay.SplitAiredUpcoming(episodes, Today);
+
+        Assert.Equal([1], aired.Select(e => e.EpisodeNumber));
+        Assert.Null(nextUp);
+    }
+
+    [Fact]
+    public void SplitAiredUpcoming_AllPast_HasNoNextUp()
+    {
+        List<EpisodeInfo> episodes = [Ep(1, Raw(-3)), Ep(2, Raw(-1))];
+
+        (IReadOnlyList<EpisodeInfo> aired, EpisodeInfo? nextUp) = TmdbDateDisplay.SplitAiredUpcoming(episodes, Today);
+
+        Assert.Equal(2, aired.Count);
+        Assert.Null(nextUp);
+    }
+}

--- a/HurrahTv.Shared.Tests/TmdbDateDisplayTests.cs
+++ b/HurrahTv.Shared.Tests/TmdbDateDisplayTests.cs
@@ -58,6 +58,7 @@ public class TmdbDateDisplayTests
         Assert.Equal("in 3 days", TmdbDateDisplay.FormatRelative(Raw(3), Today));
         Assert.Equal("yesterday", TmdbDateDisplay.FormatRelative(Raw(-1), Today));
         Assert.Equal("5 days ago", TmdbDateDisplay.FormatRelative(Raw(-5), Today));
+        Assert.Equal("1 week ago", TmdbDateDisplay.FormatRelative(Raw(-8), Today));   // singular, not "1 weeks ago"
         Assert.Equal("2 weeks ago", TmdbDateDisplay.FormatRelative(Raw(-14), Today));
     }
 

--- a/HurrahTv.Shared/Models/TmdbDateDisplay.cs
+++ b/HurrahTv.Shared/Models/TmdbDateDisplay.cs
@@ -1,0 +1,64 @@
+namespace HurrahTv.Shared.Models;
+
+// Display + aired/upcoming classification for TMDb date-only fields (air_date / first_air_date).
+// All comparisons are typed against todayUtc.Date — never a signed day-diff integer, whose sign
+// the `is <= N` / `(int)TotalDays` patterns hide (see Learnings/date-predicates-prefer-typed-comparisons.md).
+// todayUtc is injected (not DateTime.UtcNow inline) so the date fences are testable without
+// midnight-UTC drift, mirroring HurrahTv.Shared/Filters/WatchlistFilters.cs.
+//
+// Hurrah.tv standardizes client TMDb date display on a UTC "today" for cross-surface consistency
+// with the Home page's server-side classification (#192). Callers pass DateTime.UtcNow.Date.
+public static class TmdbDateDisplay
+{
+    // aired within the last `withinDays`, and not in the future. The `dayDelta <= 0` arm is what
+    // keeps an unreleased (future) date from reading as "recent" — the signed-int bug #192/2a.
+    public static bool IsRecent(string? raw, DateTime todayUtc, int withinDays = 30)
+    {
+        if (!TmdbDate.TryParse(raw, out DateTime date)) return false;
+        int dayDelta = (date.Date - todayUtc.Date).Days;
+        return dayDelta <= 0 && dayDelta >= -withinDays;
+    }
+
+    // relative phrasing ("today" / "tomorrow" / "in 3 days" / "yesterday" / "5 days ago" /
+    // "2 weeks ago"), falling back to an absolute date outside ±7d (future) / -30d (past).
+    // dayDelta is the exact calendar-day difference of two midnights — sign-correct, so a
+    // near-future date can't truncate to 0 and mislabel as "today" (the bug #192/2b).
+    public static string FormatRelative(string? raw, DateTime todayUtc)
+    {
+        if (!TmdbDate.TryParse(raw, out DateTime date)) return "";
+        int dayDelta = (date.Date - todayUtc.Date).Days;
+        return dayDelta switch
+        {
+            0 => "today",
+            1 => "tomorrow",
+            > 1 and <= 7 => $"in {dayDelta} days",
+            -1 => "yesterday",
+            < -1 and >= -7 => $"{-dayDelta} days ago",
+            < -7 and >= -30 => $"{-dayDelta / 7} weeks ago",
+            _ => date.ToString("MMM d, yyyy"),
+        };
+    }
+
+    // absolute "MMM d, yyyy", or "" when missing/unparseable (TryParse rejects "0000-00-00").
+    public static string FormatAbsolute(string? raw) =>
+        TmdbDate.TryParse(raw, out DateTime date) ? date.ToString("MMM d, yyyy") : "";
+
+    // single pass over a season's episodes (parses each AirDate once): everything aired on or
+    // before todayUtc goes to Aired; the earliest still-upcoming episode (lowest episode number)
+    // is NextUp. Episodes with a missing/unparseable AirDate are unknown — dropped from both.
+    public static (IReadOnlyList<EpisodeInfo> Aired, EpisodeInfo? NextUp) SplitAiredUpcoming(
+        IReadOnlyList<EpisodeInfo> episodes, DateTime todayUtc)
+    {
+        List<EpisodeInfo> aired = [];
+        EpisodeInfo? nextUp = null;
+        foreach (EpisodeInfo ep in episodes)
+        {
+            if (!TmdbDate.TryParse(ep.AirDate, out DateTime date)) continue;
+            if (date.Date <= todayUtc.Date)
+                aired.Add(ep);
+            else if (nextUp is null || ep.EpisodeNumber < nextUp.EpisodeNumber)
+                nextUp = ep;
+        }
+        return (aired, nextUp);
+    }
+}

--- a/HurrahTv.Shared/Models/TmdbDateDisplay.cs
+++ b/HurrahTv.Shared/Models/TmdbDateDisplay.cs
@@ -10,13 +10,14 @@ namespace HurrahTv.Shared.Models;
 // with the Home page's server-side classification (#192). Callers pass DateTime.UtcNow.Date.
 public static class TmdbDateDisplay
 {
-    // aired within the last `withinDays`, and not in the future. The `dayDelta <= 0` arm is what
-    // keeps an unreleased (future) date from reading as "recent" — the signed-int bug #192/2a.
+    // aired within the last `withinDays`, and not in the future. Typed date-window comparison
+    // (not a signed day-diff int) per Learnings/date-predicates-prefer-typed-comparisons.md: the
+    // `<= todayUtc.Date` bound is what keeps an unreleased (future) date from reading as "recent"
+    // — the bug #192/2a — and reads as a window by construction.
     public static bool IsRecent(string? raw, DateTime todayUtc, int withinDays = 30)
     {
         if (!TmdbDate.TryParse(raw, out DateTime date)) return false;
-        int dayDelta = (date.Date - todayUtc.Date).Days;
-        return dayDelta <= 0 && dayDelta >= -withinDays;
+        return date.Date <= todayUtc.Date && date.Date >= todayUtc.Date.AddDays(-withinDays);
     }
 
     // relative phrasing ("today" / "tomorrow" / "in 3 days" / "yesterday" / "5 days ago" /
@@ -34,7 +35,7 @@ public static class TmdbDateDisplay
             > 1 and <= 7 => $"in {dayDelta} days",
             -1 => "yesterday",
             < -1 and >= -7 => $"{-dayDelta} days ago",
-            < -7 and >= -30 => $"{-dayDelta / 7} weeks ago",
+            < -7 and >= -30 => $"{-dayDelta / 7} week{(-dayDelta / 7 == 1 ? "" : "s")} ago",
             _ => date.ToString("MMM d, yyyy"),
         };
     }

--- a/Learnings/blazor-wasm-datetime.md
+++ b/Learnings/blazor-wasm-datetime.md
@@ -1,5 +1,6 @@
 # DateTime.Now vs DateTime.UtcNow in Blazor WASM
 
+> **Superseded for client TMDb *display* dates by [[tmdb-client-date-display-uses-utc]] (#192):** Hurrah.tv now uses a UTC "today" when displaying TMDb dates, to stay consistent with the Home page's server-side UTC classification. The local-`DateTime.Now` guidance below still holds in general — it's the cross-surface display case that changed.
 > **Area:** WASM
 > **Date:** 2026-03-30
 

--- a/Learnings/tmdb-client-date-display-uses-utc.md
+++ b/Learnings/tmdb-client-date-display-uses-utc.md
@@ -1,0 +1,43 @@
+# Client TMDb Date Display Uses a UTC "Today" (Deliberate Reversal)
+
+> **Area:** WASM | Data | UI
+> **Date:** 2026-06-13
+> **Resolves:** mkerchenski/hurrah-tv#192
+
+## Context
+
+Two earlier learnings — [[blazor-wasm-datetime]] and [[wasm-datetime-source-matters]] — established that TMDb date-only strings (`"2026-06-11"`, `Kind=Unspecified`) should be compared against **`DateTime.Now.Date`** (the user's local calendar day) for *display*, so "aired yesterday" / "Today" badges match what day the user thinks it is. That was the right call for isolated badges.
+
+But the app grew a second surface that classifies the *same* TMDb dates: the Home page's "Available Now / Upcoming" rows, which are computed **server-side in UTC** (`WatchlistFilters`, `todayUtc`) so the result is cacheable and identical for every client. Meanwhile `EpisodeBrowser` (aired/upcoming episode split) used local `DateTime.Now.Date` and `Details` used `DateTime.UtcNow` — so the two client surfaces could disagree with each other *and* with Home about whether an episode had "aired."
+
+#190 had just made the parse deterministic (`TmdbDate.TryParse` → `Kind=Utc`); #192 was the comparison/display follow-up.
+
+## Learning
+
+**Hurrah.tv standardizes client-side TMDb date *display* on a UTC "today" (`DateTime.UtcNow.Date`), deliberately overriding the local-baseline rule from the two prior learnings.** The driver is **cross-surface consistency**: EpisodeBrowser, Details, and the Home rows now all answer "has this aired / is this upcoming?" against the same UTC calendar day the server uses. One self-consistent app beat each surface being individually "most local-accurate."
+
+This is centralized in **`HurrahTv.Shared/Models/TmdbDateDisplay.cs`** (`IsRecent` / `FormatRelative` / `FormatAbsolute` / `SplitAiredUpcoming`), which takes an injected `todayUtc` and uses **typed `DateTime` comparisons**, never a signed day-diff integer (the [[date-predicates-prefer-typed-comparisons]] anti-pattern — that's how `IsRecent` used to report future dates as "recent" and `FormatAirDate` truncated a near-future date to "today"). Callers pass `DateTime.UtcNow.Date`.
+
+**Rejected alternative:** keep local `DateTime.Now.Date` everywhere and instead flip Home/server to compare per-request in the caller's timezone. Rejected because server classification is shared + cached across clients and has no single "local" to use — UTC is the only stable baseline there, so the client was the cheaper thing to align.
+
+**Known tradeoff (accepted):** for a user west of UTC in the evening, once UTC rolls past local midnight, an episode whose `air_date` is the user's *local tomorrow* can briefly show as already aired (and vice-versa for users east of UTC in the morning). This is the exact off-by-one the prior learnings avoided — accepted here in exchange for whole-app consistency. The user base is primarily US; revisit if that changes.
+
+## Example
+
+```csharp
+// HurrahTv.Shared/Models/TmdbDateDisplay.cs — typed, UTC-baseline, injectable today
+public static string FormatRelative(string? raw, DateTime todayUtc)
+{
+    if (!TmdbDate.TryParse(raw, out DateTime date)) return "";
+    int dayDelta = (date.Date - todayUtc.Date).Days; // sign-correct: a future date can't truncate to 0
+    return dayDelta switch { 0 => "today", 1 => "tomorrow", /* … */ _ => date.ToString("MMM d, yyyy") };
+}
+
+// Call sites (EpisodeBrowser.razor, Details.razor):
+TmdbDateDisplay.FormatRelative(_details.NextEpisodeAirDate, DateTime.UtcNow.Date);
+```
+
+## How to spot it in review
+
+- A new client surface rendering TMDb air dates with `DateTime.Now` — for *this app* that now diverges from Home. Route it through `TmdbDateDisplay` with `DateTime.UtcNow.Date` instead.
+- Don't "fix" `TmdbDateDisplay` back to local on the strength of the two older learnings alone — this learning supersedes them for the cross-surface display case.

--- a/Learnings/wasm-datetime-source-matters.md
+++ b/Learnings/wasm-datetime-source-matters.md
@@ -1,5 +1,6 @@
 # WASM Date Math: The Right Answer Depends on Where the DateTime Came From
 
+> **Superseded for client TMDb *display* dates by [[tmdb-client-date-display-uses-utc]] (#192):** for displaying TMDb date-only fields, Hurrah.tv now standardizes on a UTC "today" (not the local baseline the provenance table below prescribes) so the client agrees with the Home page's server-side UTC classification. The provenance reasoning below still applies to DB/`TIMESTAMPTZ` dates and to understanding the tradeoff.
 > **Area:** WASM | Data
 > **Date:** 2026-04-16
 


### PR DESCRIPTION
## What
Follow-up to #190. #190 unified the TMDb date-only **parse** (`Kind=Utc`); this fixes the **comparison/display** side. Extracts a tested, pure helper and routes both client components through it on a UTC "today".

## Changes
- **New `HurrahTv.Shared/Models/TmdbDateDisplay.cs`** — `IsRecent` / `FormatRelative` / `FormatAbsolute` / `SplitAiredUpcoming`. Typed `DateTime` comparisons against an injected `todayUtc` (never a signed day-diff int — the `date-predicates-prefer-typed-comparisons` anti-pattern); parses each episode `AirDate` **once**.
- **`EpisodeBrowser.razor` / `Details.razor`** — thinned to call the helper; "today" is now `DateTime.UtcNow.Date` on both, for cross-surface consistency with the Home page's server-side UTC classification.
- **New `HurrahTv.Shared.Tests/TmdbDateDisplayTests.cs`** — 13 regression tests (injected `todayUtc`, no midnight drift).

## Bugs fixed (Copilot-surfaced on #193, now reachable-pinned)
- **2a** — `IsRecent` no longer reports **future** dates as recent (an unreleased movie no longer shows the "New release" badge).
- **2b** — `FormatRelative` labels a near-future date **"tomorrow"**, not "today" (the `(int)TotalDays` truncation is gone).
- **3** — episode `AirDate` parsed once per episode, not twice.

## Decision on record (UTC baseline)
Standardizing client TMDb **display** on UTC **reverses** the local-baseline guidance in `blazor-wasm-datetime.md` / `wasm-datetime-source-matters.md`. New learning `tmdb-client-date-display-uses-utc.md` documents the decision, the rejected local alternative, and the tradeoff (a US-west user in the evening can briefly see a local-tomorrow episode as aired once UTC rolls over); supersede pointers added atop both prior learnings.

## Verification
- Build clean ×3 (0 warnings); `dotnet format --verify-no-changes` (CI gate) clean.
- 120 tests green (13 new).
- Browser smoke-test: EpisodeBrowser aired/upcoming split + Details "Next episode / New episode / Last aired / New release" labels.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)