### PR TITLE
Queue removal from Details, targeted queue lookup, Upcoming today-routing (#195, #8, #182, #196)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Run through this top-to-bottom. Most steps link to deeper sections below. If any
 - [ ] Configure [signed commits](#signed-commits). Branch protection rejects unsigned commits — if you skip this, your first push will bounce.
 - [ ] Open `Hurrah.tv.code-workspace` in VS Code (File → Open Workspace from File). Install recommended extensions when prompted.
 - [ ] Run `Cmd/Ctrl+Shift+P → Tasks: Run Task → Watch All (API + Client)`. Open https://localhost:7267 in Chrome.
-- [ ] Sign in with your phone (OTP flow), add a show to your watchlist, confirm it renders. That proves the whole stack — client, API, Postgres, Twilio — is working.
+- [ ] Sign in with your phone (OTP flow), add a show to your watchlist, confirm it renders. That proves the stack — client, API, Postgres — is working. **In Development the OTP is logged to the API console, not SMS'd** — look for the `OTP (dev — not SMS'd)` log line and type that code in. No Twilio call happens locally, so you don't need working Twilio credentials to sign in (to actually exercise Twilio SMS you'd run against a non-Development environment).
 - [ ] Pick a [`good first issue`](https://github.com/mkerchenski/hurrah-tv/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), comment "I'd like to take this", open a [PR](#pull-request-workflow).
 
 ---

--- a/HurrahTv.Api.Tests/QueueEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/QueueEndpointsTests.cs
@@ -338,6 +338,11 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         // invalid media type → 400
         HttpResponseMessage bad = await client.GetAsync("/api/queue/1399/banana");
         Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+
+        // tmdbId <= 0 → 400 (the :int route matches 0/negatives; the handler rejects them like
+        // every other TmdbId endpoint)
+        HttpResponseMessage zeroId = await client.GetAsync($"/api/queue/0/{MediaTypes.Tv}");
+        Assert.Equal(HttpStatusCode.BadRequest, zeroId.StatusCode);
     }
 
     // the targeted lookup must be UserId-scoped like every other queue read — user A asking for a

--- a/HurrahTv.Api.Tests/QueueEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/QueueEndpointsTests.cs
@@ -310,6 +310,51 @@ public class QueueEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         Assert.Equal("/backdrop.jpg", ensured.BackdropPath); // but backdrop backfilled
     }
 
+    // pins #8 — the targeted GET /api/queue/{tmdbId}/{mediaType} the Details page uses instead
+    // of fetching the whole watchlist. Returns the item when queued, 404 when not, and 400 for an
+    // invalid media type.
+    [Fact]
+    public async Task GetQueueItem_ReturnsItem_WhenQueued_404_WhenNot()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "user-getitem");
+
+        QueueItem added = (await PostAsync(client, NewQueueItem(tmdbId: 1399, title: "Game of Thrones")))!;
+
+        // queued → 200 with the row
+        HttpResponseMessage hit = await client.GetAsync($"/api/queue/1399/{MediaTypes.Tv}");
+        Assert.Equal(HttpStatusCode.OK, hit.StatusCode);
+        QueueItem? fetched = await hit.Content.ReadFromJsonAsync<QueueItem>();
+        Assert.Equal(added.Id, fetched!.Id);
+        Assert.Equal(1399, fetched.TmdbId);
+
+        // not queued (wrong id) → 404
+        HttpResponseMessage missId = await client.GetAsync($"/api/queue/2/{MediaTypes.Tv}");
+        Assert.Equal(HttpStatusCode.NotFound, missId.StatusCode);
+
+        // right id, wrong media type → 404 (the dedup key includes MediaType)
+        HttpResponseMessage missType = await client.GetAsync($"/api/queue/1399/{MediaTypes.Movie}");
+        Assert.Equal(HttpStatusCode.NotFound, missType.StatusCode);
+
+        // invalid media type → 400
+        HttpResponseMessage bad = await client.GetAsync("/api/queue/1399/banana");
+        Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+    }
+
+    // the targeted lookup must be UserId-scoped like every other queue read — user A asking for a
+    // tmdbId only user B has queued gets a 404, never B's row.
+    [Fact]
+    public async Task GetQueueItem_IsUserScoped()
+    {
+        HttpClient userA = TestAuth.CreateClient(fx, "user-A");
+        HttpClient userB = TestAuth.CreateClient(fx, "user-B");
+
+        HttpResponseMessage bPost = await userB.PostAsJsonAsync("/api/queue", NewQueueItem(tmdbId: 1399, title: "B's show"));
+        Assert.Equal(HttpStatusCode.Created, bPost.StatusCode);
+
+        HttpResponseMessage aLookup = await userA.GetAsync($"/api/queue/1399/{MediaTypes.Tv}");
+        Assert.Equal(HttpStatusCode.NotFound, aLookup.StatusCode);
+    }
+
     private static async Task<QueueItem?> PostAsync(HttpClient client, QueueItem payload)
     {
         HttpResponseMessage resp = await client.PostAsJsonAsync("/api/queue", payload);

--- a/HurrahTv.Api/Endpoints/QueueEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/QueueEndpoints.cs
@@ -63,6 +63,19 @@ public static class QueueEndpoints
             }
         });
 
+        // targeted single-item lookup for the Details page (#8) — returns the queue item for this
+        // content or 404 when it isn't queued. The Details page used to GET the entire watchlist
+        // and FirstOrDefault() it; this is one row instead of all N.
+        group.MapGet("/{tmdbId:int}/{mediaType}", async (int tmdbId, string mediaType, ClaimsPrincipal user, DbService db, CancellationToken ct) =>
+        {
+            if (!MediaTypes.IsValid(mediaType))
+                return Results.BadRequest("Invalid media type");
+
+            string userId = user.GetUserId();
+            QueueItem? item = await db.GetQueueItemAsync(userId, tmdbId, mediaType, ct);
+            return item is not null ? Results.Ok(item) : Results.NotFound();
+        });
+
         group.MapPost("", async (QueueItem item, ClaimsPrincipal user, DbService db) =>
         {
             if (string.IsNullOrWhiteSpace(item.Title) || !MediaTypes.IsValid(item.MediaType) || item.TmdbId <= 0)

--- a/HurrahTv.Api/Endpoints/QueueEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/QueueEndpoints.cs
@@ -68,6 +68,11 @@ public static class QueueEndpoints
         // and FirstOrDefault() it; this is one row instead of all N.
         group.MapGet("/{tmdbId:int}/{mediaType}", async (int tmdbId, string mediaType, ClaimsPrincipal user, DbService db, CancellationToken ct) =>
         {
+            // reject structurally invalid input the same way every other TmdbId endpoint here does
+            // (POST "", /seen, /ensure) — the :int route constraint guarantees parseability, not
+            // positivity.
+            if (tmdbId <= 0)
+                return Results.BadRequest("Invalid tmdbId");
             if (!MediaTypes.IsValid(mediaType))
                 return Results.BadRequest("Invalid media type");
 

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -259,6 +259,18 @@ public class DbService(IConfiguration config)
         return [.. items];
     }
 
+    // single-row lookup for the Details page (#8) — avoids fetching the whole watchlist just to
+    // find one item. Scoped by UserId like every other queue read. (UserId, TmdbId, MediaType) is
+    // the dedup key (UNIQUE constraint from #155), so QueryFirstOrDefault returns at most one row.
+    public async Task<QueueItem?> GetQueueItemAsync(string userId, int tmdbId, string mediaType, CancellationToken cancellationToken = default)
+    {
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        CommandDefinition cmd = new(
+            "SELECT * FROM QueueItems WHERE UserId = @UserId AND TmdbId = @TmdbId AND MediaType = @MediaType",
+            new { UserId = userId, TmdbId = tmdbId, MediaType = mediaType }, cancellationToken: cancellationToken);
+        return await db.QueryFirstOrDefaultAsync<QueueItem>(cmd);
+    }
+
     public async Task<QueueItem?> AddToQueueAsync(QueueItem item, string userId)
     {
         using NpgsqlConnection db = await OpenAsync();

--- a/HurrahTv.Client/Components/QuickActions.razor
+++ b/HurrahTv.Client/Components/QuickActions.razor
@@ -258,7 +258,19 @@
 
     private void SetStatus(QueueStatus status)
     {
-        if (_queueId > 0 && status == _currentStatus) return;
+        // tapping the already-active status removes the item from the queue (#195) — mirrors the
+        // Details page so the toggle-off gesture is consistent everywhere. RunAction closes the
+        // sheet immediately; the broad failure-path NotifyChanged reloads if the delete fails.
+        if (_queueId > 0 && status == _currentStatus)
+        {
+            int removeId = _queueId;
+            RunAction($"status:{(int)status}", async () =>
+            {
+                await Api.RemoveFromQueueAsync(removeId);
+                QuickActionSvc.NotifyItemRemoved(removeId);
+            });
+            return;
+        }
 
         // queue surface: optimistic flip + single API call
         if (_queueId > 0)

--- a/HurrahTv.Client/Components/WatchlistRow.razor
+++ b/HurrahTv.Client/Components/WatchlistRow.razor
@@ -211,6 +211,12 @@
         // already filters them out (defensive guard against stale TMDb stamps).
         if (RowMode == "later")
         {
+            // a latest episode dated today was routed into Upcoming because "available today" for
+            // a streaming release isn't watchable-now (see WatchlistFilters, #196). Surface it as
+            // "today" rather than counting down to the *next* episode, whose date may be null/far off.
+            if (item.DaysSinceLatestEpisode(todayUtc) == 0)
+                return "today";
+
             return item.DaysUntilNextEpisode(todayUtc) switch
             {
                 null or <= 0 => "",

--- a/HurrahTv.Client/Components/WatchlistRow.razor
+++ b/HurrahTv.Client/Components/WatchlistRow.razor
@@ -214,7 +214,7 @@
             // a latest episode dated today was routed into Upcoming because "available today" for
             // a streaming release isn't watchable-now (see WatchlistFilters, #196). Surface it as
             // "today" rather than counting down to the *next* episode, whose date may be null/far off.
-            if (item.DaysSinceLatestEpisode(todayUtc) == 0)
+            if (item.IsDroppingToday(todayUtc))
                 return "today";
 
             return item.DaysUntilNextEpisode(todayUtc) switch

--- a/HurrahTv.Client/Pages/Details.razor
+++ b/HurrahTv.Client/Pages/Details.razor
@@ -453,10 +453,12 @@ else
             _details = details;
             _loading = false;
 
-            // check if this item is already in the queue
-            List<QueueItem> queue = await Api.GetQueueAsync(ct);
+            // check if this item is already in the queue — targeted single-row lookup (#8)
+            // instead of fetching the whole watchlist and FirstOrDefault-ing it. assign-on-success
+            // (mirrors the _details bind above) so a late response can't overwrite a newer title.
+            QueueItem? queueItem = await Api.GetQueueItemAsync(TmdbId, MediaType, ct);
             if (ct.IsCancellationRequested) return;
-            _queueItem = queue.FirstOrDefault(i => i.TmdbId == TmdbId && i.MediaType == MediaType);
+            _queueItem = queueItem;
         }
         catch (OperationCanceledException)
         {
@@ -533,8 +535,28 @@ else
             if (_queueItem != null)
             {
                 QueueItem existing = _queueItem;
+                // tapping the already-active status toggles it off — removes the item from the
+                // queue entirely (#195). Previously this was a no-op, leaving no way to take a
+                // show back out of every list from Details. Optimistically clear local state,
+                // then notify so Home/Queue splice the row out; restore on failure.
                 if (existing.Status == status)
+                {
+                    _queueItem = null;
+                    if (!_disposed) StateHasChanged();
+                    try
+                    {
+                        await Api.RemoveFromQueueAsync(existing.Id);
+                        if (Navigated(startTmdbId, startMediaType)) return;
+                        QuickActionSvc.NotifyItemRemoved(existing.Id);
+                    }
+                    catch
+                    {
+                        if (!Navigated(startTmdbId, startMediaType)) _queueItem = existing; // restore
+                        await Toast.ShowAsync("Couldn't update your list — try again");
+                    }
+                    if (!_disposed) StateHasChanged();
                     return;
+                }
                 QueueItem? updated = await Api.UpdateStatusAsync(existing.Id, status);
                 if (Navigated(startTmdbId, startMediaType)) return;
                 if (updated != null)

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -651,7 +651,7 @@ else
         // WatchlistFilters, #196). Sort it ahead of strictly-future episodes by keying it on today
         // rather than its NextEpisodeDate, which may be null (→ MaxValue, sorts last) or far off.
         DateTime UpcomingKey(QueueItem i) =>
-            i.LatestEpisodeDate?.Date == today ? today : (i.NextEpisodeDate?.Date ?? DateTime.MaxValue);
+            i.IsDroppingToday(today) ? today : (i.NextEpisodeDate?.Date ?? DateTime.MaxValue);
 
         return _watchlistSort switch
         {

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -323,6 +323,7 @@ else
     {
         QuickActionSvc.OnChanged += OnQuickActionChanged;
         QuickActionSvc.OnItemUpdated += OnItemUpdated;
+        QuickActionSvc.OnItemRemoved += OnItemRemoved;
         QuickActionSvc.OnEpisodeWatchedChanged += OnEpisodeWatchedChanged;
         MediaFilter.OnChanged += OnMediaFilterChanged;
         UserServicesCache.Changed += OnUserServicesChanged;
@@ -468,6 +469,19 @@ else
         {
             _allItems.Add(updated);
         }
+        StampWatchedFlags();
+        ReapplyDerivedState();
+        StateHasChanged();
+    });
+
+    // a queued item was removed from another surface (e.g. Details toggling its active status
+    // off). Splice it out of _allItems by Id, recompute derived rows, render — no /api/queue
+    // refetch needed. Mirrors OnItemUpdated. No-op if we never had the item locally.
+    private void OnItemRemoved(int queueItemId) => InvokeAsync(() =>
+    {
+        int idx = _allItems.FindIndex(i => i.Id == queueItemId);
+        if (idx < 0) return;
+        _allItems.RemoveAt(idx);
         StampWatchedFlags();
         ReapplyDerivedState();
         StateHasChanged();
@@ -630,12 +644,22 @@ else
         _           => [.. items.OrderByDescending(i => i.HasEpisodeThisMonth ? 1 : 0).ThenByDescending(i => i.LatestEpisodeDate ?? DateTime.MinValue).ThenBy(i => i.Position)]
     };
 
-    private List<QueueItem> SortUpcoming(IEnumerable<QueueItem> items) => _watchlistSort switch
+    private List<QueueItem> SortUpcoming(IEnumerable<QueueItem> items)
     {
-        "sentiment" => [.. items.OrderByDescending(i => SentimentSortKey(i.Sentiment)).ThenBy(i => i.NextEpisodeDate ?? DateTime.MaxValue)],
-        "queue"     => [.. items.OrderBy(i => QueueStatusOrdering.SortPriority(i.Status)).ThenBy(i => i.NextEpisodeDate ?? DateTime.MaxValue)],
-        _           => [.. items.OrderBy(i => i.NextEpisodeDate ?? DateTime.MaxValue)]
-    };
+        DateTime today = DateTime.UtcNow.Date;
+        // a latest episode dated today is routed into Upcoming as a "drops today" item (see
+        // WatchlistFilters, #196). Sort it ahead of strictly-future episodes by keying it on today
+        // rather than its NextEpisodeDate, which may be null (→ MaxValue, sorts last) or far off.
+        DateTime UpcomingKey(QueueItem i) =>
+            i.LatestEpisodeDate?.Date == today ? today : (i.NextEpisodeDate?.Date ?? DateTime.MaxValue);
+
+        return _watchlistSort switch
+        {
+            "sentiment" => [.. items.OrderByDescending(i => SentimentSortKey(i.Sentiment)).ThenBy(UpcomingKey)],
+            "queue"     => [.. items.OrderBy(i => QueueStatusOrdering.SortPriority(i.Status)).ThenBy(UpcomingKey)],
+            _           => [.. items.OrderBy(UpcomingKey)]
+        };
+    }
 
     private List<QueueItem> SortMovies(IEnumerable<QueueItem> items) => _watchlistSort switch
     {
@@ -769,6 +793,7 @@ else
         _cts.Dispose();
         QuickActionSvc.OnChanged -= OnQuickActionChanged;
         QuickActionSvc.OnItemUpdated -= OnItemUpdated;
+        QuickActionSvc.OnItemRemoved -= OnItemRemoved;
         QuickActionSvc.OnEpisodeWatchedChanged -= OnEpisodeWatchedChanged;
         MediaFilter.OnChanged -= OnMediaFilterChanged;
         UserServicesCache.Changed -= OnUserServicesChanged;

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -309,6 +309,7 @@ else
     {
         MediaFilter.OnChanged += OnMediaFilterChanged;
         UserServicesCache.Changed += OnServicesChanged;
+        QuickActionSvc.OnItemRemoved += OnItemRemoved;
         _loading = true;
         Task<IReadOnlyList<int>> servicesTask = UserServicesCache.GetAsync();
         Task<List<QueueItem>> queueTask = Api.GetQueueAsync();
@@ -572,6 +573,20 @@ else
         catch { }
     }
 
+    // a removal raised from another surface (Details' toggle-off, or the QuickActions sheet) —
+    // splice it out by Id so the row disappears without a refetch, mirroring Home's handler and
+    // Queue's own Remove() above. Fires only on a confirmed server delete (#195). No-op if this
+    // page never held the item.
+    private void OnItemRemoved(int queueItemId) => InvokeAsync(() =>
+    {
+        int idx = _items.FindIndex(i => i.Id == queueItemId);
+        if (idx < 0) return;
+        _items.RemoveAt(idx);
+        UpdateCounts();
+        RecomputeVisible();
+        StateHasChanged();
+    });
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         bool wantSortable = _activeTab == WantToWatchTab && !_loading && _visibleItems.Count > 0;
@@ -750,6 +765,7 @@ else
         _disposed = true;
         MediaFilter.OnChanged -= OnMediaFilterChanged;
         UserServicesCache.Changed -= OnServicesChanged;
+        QuickActionSvc.OnItemRemoved -= OnItemRemoved;
         await DisposeSortableAsync();
         _dotNetRef?.Dispose();
         _dotNetRef = null;

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -72,9 +72,14 @@ public class ApiClient(HttpClient http)
     public async Task<QueueItem?> GetQueueItemAsync(int tmdbId, string mediaType, CancellationToken cancellationToken = default)
     {
         HttpResponseMessage response = await _http.GetAsync($"api/queue/{tmdbId}/{mediaType}", cancellationToken);
-        return response.IsSuccessStatusCode
-            ? await response.Content.ReadFromJsonAsync<QueueItem>(cancellationToken)
-            : null;
+        // 404 is the expected "not queued" answer → null (Details shows the Add-to-queue UI).
+        // Any OTHER non-2xx (500, 401) is a genuine failure — throw so it surfaces like the
+        // GetDetailsAsync call right before it, rather than masquerading as "not queued" and
+        // wrongly showing Add-to-queue for an item that IS in the user's list.
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return null;
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<QueueItem>(cancellationToken);
     }
 
     // watched episodes
@@ -95,8 +100,16 @@ public class ApiClient(HttpClient http)
         return null;
     }
 
-    public async Task RemoveFromQueueAsync(int id, CancellationToken cancellationToken = default) =>
-        await _http.DeleteAsync($"api/queue/{id}", cancellationToken);
+    // EnsureSuccessStatusCode so a non-2xx delete THROWS — HttpClient.DeleteAsync only throws on
+    // transport failure, not on a 401/500 status. Callers (Details, QuickActions RunAction,
+    // Queue.Remove) drive optimistic-remove UI from a try/catch that assumes failure surfaces as an
+    // exception; without this a failed delete would silently clear local state and skip the
+    // reload/restore path, leaving the UI out of sync with the server.
+    public async Task RemoveFromQueueAsync(int id, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.DeleteAsync($"api/queue/{id}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
 
     public async Task<QueueItem?> UpdateStatusAsync(int id, QueueStatus status, CancellationToken cancellationToken = default)
     {

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -59,11 +59,22 @@ public class ApiClient(HttpClient http)
         return response ?? new QueueResponse([], []);
     }
 
-    // convenience for callers that only need items (Details page, Queue page)
+    // convenience for callers that only need items (Queue page)
     public async Task<List<QueueItem>> GetQueueAsync(CancellationToken cancellationToken = default)
     {
         QueueResponse response = await GetQueueResponseAsync(cancellationToken);
         return response.Items;
+    }
+
+    // targeted single-item lookup for the Details page (#8). Returns null when the item isn't
+    // queued (404) — the Details page reads that as "show the Add-to-queue UI". A cancelled token
+    // still throws (TaskCanceledException), which Details' load path catches as navigation abort.
+    public async Task<QueueItem?> GetQueueItemAsync(int tmdbId, string mediaType, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.GetAsync($"api/queue/{tmdbId}/{mediaType}", cancellationToken);
+        return response.IsSuccessStatusCode
+            ? await response.Content.ReadFromJsonAsync<QueueItem>(cancellationToken)
+            : null;
     }
 
     // watched episodes

--- a/HurrahTv.Client/Services/QuickActionService.cs
+++ b/HurrahTv.Client/Services/QuickActionService.cs
@@ -10,6 +10,9 @@ public class QuickActionService
     // targeted update — subscribers can splice the item into local state without a refetch
     public event Action<QueueItem>? OnItemUpdated;
 
+    // targeted removal — subscribers splice the item OUT of local state by Id without a refetch
+    public event Action<int>? OnItemRemoved;
+
     // episode-watched toggle. Tells subscribers to update their local watched-set in place.
     public event Action<int, int, int, bool>? OnEpisodeWatchedChanged;
 
@@ -20,6 +23,7 @@ public class QuickActionService
     public void ShowForSearchResult(SearchResult result) => OnShowForSearchResult?.Invoke(result);
     public void NotifyChanged() => OnChanged?.Invoke();
     public void NotifyItemUpdated(QueueItem item) => OnItemUpdated?.Invoke(item);
+    public void NotifyItemRemoved(int queueItemId) => OnItemRemoved?.Invoke(queueItemId);
     public void NotifyEpisodeWatchedChanged(int tmdbId, int season, int episode, bool watched) =>
         OnEpisodeWatchedChanged?.Invoke(tmdbId, season, episode, watched);
 }

--- a/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
+++ b/HurrahTv.Shared.Tests/QueueItemExtensionsTests.cs
@@ -69,6 +69,39 @@ public class QueueItemExtensionsTests
         Assert.Null(item.DaysSinceLatestEpisode(TodayUtc));
     }
 
+    // canonical "drops today" predicate (#196) — the single rule the partition, the badge, and
+    // the Upcoming sort all read. True only on the exact air day; yesterday, future, and null
+    // are all "not dropping today".
+    [Fact]
+    public void IsDroppingToday_LatestEpisodeToday_ReturnsTrue()
+    {
+        QueueItem item = new() { LatestEpisodeDate = TodayUtc };
+        Assert.True(item.IsDroppingToday(TodayUtc));
+    }
+
+    [Fact]
+    public void IsDroppingToday_LatestEpisodeYesterday_ReturnsFalse()
+    {
+        QueueItem item = new() { LatestEpisodeDate = TodayUtc.AddDays(-1) };
+        Assert.False(item.IsDroppingToday(TodayUtc));
+    }
+
+    // a future-stamped LatestEpisodeDate (the #86 leak shape) is not "today" — typed comparison
+    // can't be fooled by a wrong-sign day-diff.
+    [Fact]
+    public void IsDroppingToday_LatestEpisodeFuture_ReturnsFalse()
+    {
+        QueueItem item = new() { LatestEpisodeDate = TodayUtc.AddDays(1) };
+        Assert.False(item.IsDroppingToday(TodayUtc));
+    }
+
+    [Fact]
+    public void IsDroppingToday_NullLatestEpisode_ReturnsFalse()
+    {
+        QueueItem item = new() { LatestEpisodeDate = null };
+        Assert.False(item.IsDroppingToday(TodayUtc));
+    }
+
     // pins #189 — the daily-show bug. Stored latest lags at (S,E1); the user watched the
     // genuinely-newer (S,E2) via the live Details browser. High-water reconciliation must
     // treat the show as caught up so it drops out of Available Now, even though the stored

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -152,6 +152,59 @@ public class WatchlistFiltersTests
         Assert.DoesNotContain(item, result.AvailableNow);
     }
 
+    // pins #196 — "available today" for a streaming release usually means it drops sometime today
+    // and isn't watchable yet, so a latest episode dated today belongs in Upcoming (badged "today"),
+    // not Available Now. Membership is preserved: the item still shows, it just moves rows.
+    [Fact]
+    public void AvailableNow_Excludes_TvItem_Dropping_Today_RoutesToLater()
+    {
+        QueueItem item = TvItem(latestEpisode: Today);
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableNow);
+        Assert.Contains(item, result.AvailableLater);
+    }
+
+    // boundary partner to the drops-today test: yesterday definitely aired → stays in Available Now.
+    [Fact]
+    public void AvailableNow_Includes_TvItem_That_Aired_Yesterday()
+    {
+        QueueItem item = TvItem(latestEpisode: Today.AddDays(-1));
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableNow);
+        Assert.DoesNotContain(item, result.AvailableLater);
+    }
+
+    // the Watching bypass that keeps no-provider shows (Kimmel-class) visible must survive the
+    // now→later relocation — a Watching show dropping today must not vanish from both rows.
+    [Fact]
+    public void AvailableLater_Includes_Watching_TodayDropper_With_No_ProviderData()
+    {
+        QueueItem item = TvItem(status: QueueStatus.Watching, latestEpisode: Today);
+        item.AvailableOnJson = "[]";
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableNow);
+        Assert.Contains(item, result.AvailableLater);
+    }
+
+    // a today-dropper that ALSO has a next episode within the window must appear in Upcoming
+    // exactly once — the addedToLater guard prevents the double-add.
+    [Fact]
+    public void AvailableLater_TodayDropper_With_UpcomingEpisode_AppearsOnce()
+    {
+        QueueItem item = TvItem(latestEpisode: Today, nextEpisode: Today.AddDays(7));
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.DoesNotContain(item, result.AvailableNow);
+        Assert.Single(result.AvailableLater);
+    }
+
     [Fact]
     public void AvailableLater_Includes_NextEpisode_Within_Window()
     {

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -92,7 +92,7 @@ public static class WatchlistFilters
                     // than Available Now (#196). We keep the full Available Now gate above (incl. the
                     // Watching bypass) and only relocate WHICH row it renders in — so no item that
                     // showed before disappears, it just moves from "now" to "later".
-                    if (item.LatestEpisodeDate is { } latest && latest.Date == today)
+                    if (item.IsDroppingToday(today))
                     {
                         availableLater.Add(item);
                         addedToLater = true;

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -86,7 +86,7 @@ public static class WatchlistFilters
                     && (!item.IsLatestEpisodeWatched || overrideLatestWatched)
                     && HasAiredOrIsActivelyWatching(item, today))
                 {
-                    // A latest episode dated *today* is "available today" — for a streaming release
+                    // a latest episode dated *today* is "available today" — for a streaming release
                     // that usually means it drops at some point during the day and isn't watchable
                     // yet, so it belongs in the forward-looking Upcoming row (badged "today") rather
                     // than Available Now (#196). We keep the full Available Now gate above (incl. the

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -65,6 +65,8 @@ public static class WatchlistFilters
             // chip filter gates AvailableNow (the active watchlist) but not AvailableLater —
             // a new-season premiere on a Finished show should still surface when the Finished
             // chip is off, since "later" is forward-looking and independent of watch state.
+            bool addedToLater = false;
+
             if (isWatching || isStreamable)
             {
                 // for Watching, resurface a caught-up show (latest episode marked watched) ONLY
@@ -84,13 +86,30 @@ public static class WatchlistFilters
                     && (!item.IsLatestEpisodeWatched || overrideLatestWatched)
                     && HasAiredOrIsActivelyWatching(item, today))
                 {
-                    availableNow.Add(item);
+                    // A latest episode dated *today* is "available today" — for a streaming release
+                    // that usually means it drops at some point during the day and isn't watchable
+                    // yet, so it belongs in the forward-looking Upcoming row (badged "today") rather
+                    // than Available Now (#196). We keep the full Available Now gate above (incl. the
+                    // Watching bypass) and only relocate WHICH row it renders in — so no item that
+                    // showed before disappears, it just moves from "now" to "later".
+                    if (item.LatestEpisodeDate is { } latest && latest.Date == today)
+                    {
+                        availableLater.Add(item);
+                        addedToLater = true;
+                    }
+                    else
+                    {
+                        availableNow.Add(item);
+                    }
                 }
             }
 
-            // Available Later still requires streamability — "available on a user service soon"
-            // is a stronger claim than Available Now's "you've committed to this".
-            if (isStreamable && item.NextEpisodeDate is { } next && next.Date > today && next.Date <= windowEnd)
+            // Available Later also surfaces a strictly-future next episode within the window. It
+            // requires streamability — "available on a user service soon" is a stronger claim than
+            // Available Now's "you've committed to this". The addedToLater guard prevents adding an
+            // item twice when it both drops today (routed above) and has a next episode in-window.
+            if (!addedToLater && isStreamable
+                && item.NextEpisodeDate is { } next && next.Date > today && next.Date <= windowEnd)
             {
                 availableLater.Add(item);
             }

--- a/HurrahTv.Shared/Models/QueueItemExtensions.cs
+++ b/HurrahTv.Shared/Models/QueueItemExtensions.cs
@@ -26,6 +26,15 @@ public static class QueueItemExtensions
     public static int? DaysSinceLatestEpisode(this QueueItem item, DateTime todayUtc) =>
         item.LatestEpisodeDate is { } d ? (int)(todayUtc.Date - d.Date).TotalDays : null;
 
+    // "drops today": the latest episode is dated today. For a streaming release that means it
+    // lands at some point during the day and isn't watchable yet, so the watchlist treats it as
+    // forward-looking — Upcoming row, badged "today" — rather than already-available (#196).
+    // Canonical so the filter (WatchlistFilters), the badge (WatchlistRow), and the Upcoming sort
+    // (Home) all read the same rule. Typed date comparison, not a day-diff, per
+    // Learnings/date-predicates-prefer-typed-comparisons.md.
+    public static bool IsDroppingToday(this QueueItem item, DateTime todayUtc) =>
+        item.LatestEpisodeDate is { } latest && latest.Date == todayUtc.Date;
+
     // caught up if the user's newest-watched episode for this show is at or beyond the
     // stored "latest" (lexicographic by season then episode). Robust to a stale stored
     // S/E: watching a genuinely-newer episode (S,E2) counts as caught up even when the


### PR DESCRIPTION
Four batched fixes plus an /xsimplify refactor.

## #195 — Remove a show from the queue (Details + QuickActions)
Tapping the **already-active** list status now **removes** the item from the queue (previously a no-op, leaving no way to take a show back out). Same toggle-off gesture on the Details page and the QuickActions bottom sheet. New targeted `QuickActionService.OnItemRemoved` event so Home splices the row out in place (no refetch); optimistic clear with restore-on-failure. Queue page reflects it on its next load (non-reactive by design).

## #8 — Targeted queue-item lookup on Details
Details used to GET the entire watchlist and `FirstOrDefault()` it just to find one item. New `GET /api/queue/{tmdbId}/{mediaType}` (`DbService.GetQueueItemAsync`, UserId-scoped, 404/400) + `ApiClient.GetQueueItemAsync`, used by the Details load path — one indexed row instead of N.

## #182 — CONTRIBUTING dev-OTP docs
The smoke-test step now notes the OTP is logged to the API console (`OTP (dev — not SMS'd)`) in Development — no Twilio call, no Twilio creds needed to sign in locally.

## #196 — available-today → Upcoming, not Available Now
A TV item whose latest episode is dated **today** now renders in **Available Later / Upcoming** badged "today", not Available Now — a streaming drop isn''t watchable until it lands. Membership-preserving relocation (keeps the Watching bypass for no-provider shows), with a double-add guard and today-first Upcoming sort.

## /xsimplify
Extracted the canonical `QueueItemExtensions.IsDroppingToday(todayUtc)` predicate (the "drops today" rule had been spelled three ways across the filter, badge, and sort) and routed all three sites through it — matching the `HasNewEpisode` / `CanMarkLatestEpisodeWatched` family.

## Tests
- `WatchlistFiltersTests`: today→Upcoming routing, no-double-add, yesterday boundary
- `QueueItemExtensionsTests`: `IsDroppingToday` today/yesterday/future/null
- `QueueEndpointsTests`: targeted lookup happy/404/400 + user-scoping

Full suite green (Shared 128, Client 39, Api 36); `dotnet format` clean.

Closes #195
Closes #8
Closes #182
Closes #196