### PR TITLE
#5: shared ErrorBoundary for ApiClient failures + graceful event-handler error surfacing

### DIFF
--- a/HurrahTv.Client/Components/AppErrorBoundary.razor
+++ b/HurrahTv.Client/Components/AppErrorBoundary.razor
@@ -1,0 +1,46 @@
+@inject NavigationManager Nav
+@implements IDisposable
+
+@* Shared error boundary (#5). Catches unhandled exceptions from its child's lifecycle/render —
+   in practice the GetFromJsonAsync-based ApiClient calls that THROW on 5xx/network, which every
+   page runs in OnInitializedAsync/OnParametersSetAsync. Wrapped around @Body in MainLayout, one
+   instance covers every page (and every future one) with a consistent "something went wrong +
+   retry" panel. Expected per-action failures still surface via ToastService, as before. *@
+<ErrorBoundary @ref="_boundary">
+    <ChildContent>
+        @ChildContent
+    </ChildContent>
+    <ErrorContent>
+        <div class="flex flex-col items-center justify-center text-center py-16 px-4">
+            <span class="icon-[heroicons--exclamation-triangle] w-12 h-12 text-accent mb-4"></span>
+            <h2 class="text-white text-lg font-semibold mb-1">Something went wrong</h2>
+            <p class="text-gray-400 text-sm mb-6 max-w-sm">
+                We couldn't load this page. Check your connection and try again.
+            </p>
+            <button class="bg-accent hover:bg-accent-light text-white font-semibold px-6 py-2.5 rounded-lg transition-colors"
+                    @onclick="Retry">
+                Try again
+            </button>
+        </div>
+    </ErrorContent>
+</ErrorBoundary>
+
+@code {
+    [Parameter, EditorRequired] public RenderFragment? ChildContent { get; set; }
+
+    private ErrorBoundary? _boundary;
+
+    // reset the boundary on navigation — without this, once a page throws the error panel "sticks"
+    // and the next route renders behind it. LocationChanged fires only on real navigations (not on
+    // every re-render), so we never clear a just-caught error before the user can see it.
+    protected override void OnInitialized() => Nav.LocationChanged += OnLocationChanged;
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+        => _boundary?.Recover();
+
+    // manual retry — Recover() re-renders ChildContent, which re-runs the page's load lifecycle
+    // (re-fetch). If the API is still down it simply catches again.
+    private void Retry() => _boundary?.Recover();
+
+    public void Dispose() => Nav.LocationChanged -= OnLocationChanged;
+}

--- a/HurrahTv.Client/Components/AppErrorBoundary.razor
+++ b/HurrahTv.Client/Components/AppErrorBoundary.razor
@@ -1,11 +1,11 @@
 @inject NavigationManager Nav
 @implements IDisposable
 
-@* Shared error boundary (#5). Catches unhandled exceptions from its child's lifecycle/render —
+@* shared error boundary (#5). catches unhandled exceptions from its child's lifecycle/render —
    in practice the GetFromJsonAsync-based ApiClient calls that THROW on 5xx/network, which every
-   page runs in OnInitializedAsync/OnParametersSetAsync. Wrapped around @Body in MainLayout, one
+   page runs in OnInitializedAsync/OnParametersSetAsync. wrapped around @Body in MainLayout, one
    instance covers every page (and every future one) with a consistent "something went wrong +
-   retry" panel. Expected per-action failures still surface via ToastService, as before. *@
+   retry" panel. expected per-action failures still surface via ToastService, as before. *@
 <ErrorBoundary @ref="_boundary">
     <ChildContent>
         @ChildContent
@@ -26,7 +26,7 @@
 </ErrorBoundary>
 
 @code {
-    [Parameter, EditorRequired] public RenderFragment? ChildContent { get; set; }
+    [Parameter, EditorRequired] public RenderFragment ChildContent { get; set; } = default!;
 
     private ErrorBoundary? _boundary;
 

--- a/HurrahTv.Client/Layout/MainLayout.razor
+++ b/HurrahTv.Client/Layout/MainLayout.razor
@@ -93,7 +93,9 @@
     <!-- main content -->
     <main class="flex-1 px-4 pt-4 pb-20 md:px-6 md:py-6 md:pb-6 max-w-7xl mx-auto w-full">
         <InstallBanner />
-        @Body
+        <AppErrorBoundary>
+            @Body
+        </AppErrorBoundary>
     </main>
 
     <!-- footer (desktop only) -->

--- a/HurrahTv.Client/Pages/AdminUsers.razor
+++ b/HurrahTv.Client/Pages/AdminUsers.razor
@@ -171,6 +171,12 @@
             }
             _response = await Api.GetAdminUsersAsync();
         }
+        catch
+        {
+            // a thrown transport failure (API unreachable) — surface it via the same _error banner
+            // the HTTP-error branch above uses, rather than letting the exception escape silently.
+            _error = $"Couldn't {verb} admin — check your connection and try again.";
+        }
         finally
         {
             _busyId = null;
@@ -232,6 +238,10 @@
             }
             _response = await Api.GetAdminUsersAsync();
         }
+        catch
+        {
+            _error = "Couldn't delete — check your connection and try again.";
+        }
         finally
         {
             _busyId = null;
@@ -253,6 +263,10 @@
             }
             _editingNameId = null;
             _response = await Api.GetAdminUsersAsync();
+        }
+        catch
+        {
+            _error = "Couldn't save name — check your connection and try again.";
         }
         finally
         {

--- a/HurrahTv.Client/Pages/Queue.razor
+++ b/HurrahTv.Client/Pages/Queue.razor
@@ -7,6 +7,7 @@
 @inject QuickActionService QuickActionSvc
 @inject NavigationManager Nav
 @inject SortableService SortableSvc
+@inject ToastService Toast
 
 <PageTitle>My List - Hurrah.tv</PageTitle>
 
@@ -550,15 +551,20 @@ else
                 int idx = _items.IndexOf(item);
                 if (idx >= 0) _items[idx] = updated;
                 QuickActionSvc.NotifyItemUpdated(updated);
+                UpdateCounts();
+                RecomputeVisible();
             }
             else
             {
-                item.Status = status; // optimistic fallback
+                // server rejected it (non-2xx → null). Don't flip the row to the new status — that
+                // would show a change the server didn't make. Tell the user instead.
+                await Toast.ShowAsync("Couldn't update — try again");
             }
-            UpdateCounts();
-            RecomputeVisible();
         }
-        catch { }
+        catch
+        {
+            await Toast.ShowAsync("Couldn't update — try again");
+        }
     }
 
     private async Task Remove(QueueItem item)
@@ -570,7 +576,12 @@ else
             UpdateCounts();
             RecomputeVisible();
         }
-        catch { }
+        catch
+        {
+            // RemoveFromQueueAsync throws on non-2xx, so a failed delete lands here — surface it
+            // and leave the row in place rather than silently swallowing the failure.
+            await Toast.ShowAsync("Couldn't remove — try again");
+        }
     }
 
     // a removal raised from another surface (Details' toggle-off, or the QuickActions sheet) —

--- a/HurrahTv.Client/Pages/Search.razor
+++ b/HurrahTv.Client/Pages/Search.razor
@@ -100,6 +100,19 @@
             });
         }
         catch (TaskCanceledException) { }
+        catch
+        {
+            // a non-cancellation failure (5xx/network) from the typed-search path. The shared
+            // AppErrorBoundary can't catch this — it's a detached event-handler task — so surface
+            // it inline instead of leaving the spinner stuck (#5).
+            await InvokeAsync(() =>
+            {
+                _loading = false;
+                _results = [];
+                _emptyMessage = "Search failed — check your connection and try again";
+                StateHasChanged();
+            });
+        }
     }
 
     private void OnMediaFilterChanged() => InvokeAsync(StateHasChanged);

--- a/HurrahTv.Client/Pages/Search.razor
+++ b/HurrahTv.Client/Pages/Search.razor
@@ -99,12 +99,18 @@
                 StateHasChanged();
             });
         }
-        catch (TaskCanceledException) { }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            // superseded by a newer keystroke (the debounce token was cancelled) — ignore. An
+            // HttpClient TIMEOUT also surfaces as TaskCanceledException but with the token NOT
+            // cancelled, so it falls through to the failure catch below instead of hanging the
+            // spinner (see Learnings/oce-rethrow-needs-token-filter.md).
+        }
         catch
         {
-            // a non-cancellation failure (5xx/network) from the typed-search path. The shared
-            // AppErrorBoundary can't catch this — it's a detached event-handler task — so surface
-            // it inline instead of leaving the spinner stuck (#5).
+            // a non-cancellation failure (5xx/network/timeout) from the typed-search path. The
+            // shared AppErrorBoundary can't catch this — it's a detached event-handler task — so
+            // surface it inline instead of leaving the spinner stuck (#5).
             await InvokeAsync(() =>
             {
                 _loading = false;


### PR DESCRIPTION
Implements #5 — a shared error-handling pattern for ApiClient failures.

## Design decision (the issue asked to choose first)
**Global `ErrorBoundary` + existing Toast**, not per-page boundaries or an ApiClient-wide error-event rewire. Rationale: every page loads its primary data via a `GetFromJsonAsync`-based call that *throws* on 5xx/network, inside `OnInitializedAsync`/`OnParametersSetAsync` — so one boundary around `@Body` covers all pages (and future ones) for the hard-failure case.

## Changes
- **`AppErrorBoundary.razor`** (new) — wraps Blazor''s `<ErrorBoundary>` with a dark-theme "Something went wrong / Try again" panel. Recovers on `NavigationManager.LocationChanged` so a tripped panel doesn''t stick across navigation; the retry button calls `Recover()` to re-render `@Body` (re-runs the page''s load).
- **`MainLayout.razor`** — wraps `@Body`; nav chrome stays outside the boundary, so the user keeps navigation during an error.
- **`Search.razor`** — the debounced keystroke search is a detached event-handler task the boundary structurally can''t catch, so it now catches non-cancellation failures inline ("Search failed — check your connection and try again") instead of leaving the spinner stuck.
- **`Queue.razor`** — `SelectStatus`/`Remove` had empty `catch {}` that swallowed failures; now Toast on failure, and `SelectStatus` no longer flips the row to a status the server didn''t accept.
- **`AdminUsers.razor`** — `ToggleAdmin`/`DeleteUser`/`SaveName` had `try/finally` with no `catch`, so thrown transport failures escaped silently; now routed to the existing `_error` banner (HTTP-error responses were already handled there).

## Verification
Browser-verified end-to-end (kill the API, navigate, retry): boundary panel + nav intact on Queue load failure; retry re-catches cleanly while down; boundary resets on navigation; Search shows the inline failure; recovery works once the API is back. Queue/Admin event-handler catches mirror the established Details (`Toast`) / AdminUsers (`_error`) patterns. Build clean, `dotnet format` clean, full suite green (Shared 128, Client 39, Api 36).

Closes #5