### PR TITLE
Shrink WASM bundle: wasm-tools relink + globalization shard + Release feature switches

### DIFF
--- a/.github/workflows/main_hurrahtv.yml
+++ b/.github/workflows/main_hurrahtv.yml
@@ -34,10 +34,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up .NET Core
-        id: dotnet
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
+
+      # capture the resolved SDK version explicitly — actions/setup-dotnet doesn't reliably
+      # expose it as a step output, so a key referencing that output could render empty and
+      # never invalidate. `dotnet --version` is the source of truth.
+      - name: Resolve SDK version for cache key
+        id: sdk
+        run: echo "version=$(dotnet --version)" >> "$GITHUB_OUTPUT"
 
       # cache the wasm-tools workload (~500 MB) so it isn't re-downloaded every deploy.
       # workloads install under $DOTNET_ROOT; key on the resolved SDK version so a .NET
@@ -49,7 +55,7 @@ jobs:
             ${{ env.DOTNET_ROOT }}/sdk-manifests
             ${{ env.DOTNET_ROOT }}/packs
             ${{ env.DOTNET_ROOT }}/metadata
-          key: ${{ runner.os }}-wasmtools-${{ steps.dotnet.outputs.dotnet-version }}
+          key: ${{ runner.os }}-wasmtools-${{ steps.sdk.outputs.version }}
 
       # required for the Client WASM publish to relink dotnet.native.wasm (#3).
       # without it, dotnet publish falls back to "without optimizations" and the

--- a/.github/workflows/main_hurrahtv.yml
+++ b/.github/workflows/main_hurrahtv.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           dotnet-version: '10.x'
 
+      # required for the Client WASM publish to relink dotnet.native.wasm (#3).
+      # without it, dotnet publish falls back to "without optimizations" and the
+      # client ships ~15% larger.
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/main_hurrahtv.yml
+++ b/.github/workflows/main_hurrahtv.yml
@@ -34,13 +34,26 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up .NET Core
+        id: dotnet
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
 
+      # cache the wasm-tools workload (~500 MB) so it isn't re-downloaded every deploy.
+      # workloads install under $DOTNET_ROOT; key on the resolved SDK version so a .NET
+      # bump invalidates the cache. on a miss the install step below repopulates these dirs.
+      - name: Cache wasm-tools workload
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ env.DOTNET_ROOT }}/sdk-manifests
+            ${{ env.DOTNET_ROOT }}/packs
+            ${{ env.DOTNET_ROOT }}/metadata
+          key: ${{ runner.os }}-wasmtools-${{ steps.dotnet.outputs.dotnet-version }}
+
       # required for the Client WASM publish to relink dotnet.native.wasm (#3).
       # without it, dotnet publish falls back to "without optimizations" and the
-      # client ships ~15% larger.
+      # client ships ~15% larger. fast no-op on a warm workload cache.
       - name: Install wasm-tools workload
         run: dotnet workload install wasm-tools
 

--- a/HurrahTv.Client/HurrahTv.Client.csproj
+++ b/HurrahTv.Client/HurrahTv.Client.csproj
@@ -7,6 +7,23 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- no i18n: ship the minimal ICU shard instead of the full globalization data (#3) -->
+    <BlazorWebAssemblyLoadAllGlobalizationData>false</BlazorWebAssemblyLoadAllGlobalizationData>
+  </PropertyGroup>
+
+  <!-- #3 size pass (Release/publish only — keeps dev hot reload + debugging intact). These
+       feature switches let the IL trimmer + wasm-tools relinker strip native + managed code the
+       app doesn't use. AOT was measured and dropped: it added ~2.4 MB to the download for no
+       measurable boot win (539-576 ms vs 518-623 ms non-AOT — within noise) on a render-bound
+       startup. NOT set: InvariantGlobalization / InvariantTimezone (would break culture-aware +
+       episode air-date formatting), JsonSerializerIsReflectionEnabledByDefault (app uses
+       reflection-based System.Text.Json). -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebuggerSupport>false</DebuggerSupport>
+    <MetadataUpdaterSupport>false</MetadataUpdaterSupport>
+    <EventSourceSupport>false</EventSourceSupport>
+    <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HurrahTv.Client/HurrahTv.Client.csproj
+++ b/HurrahTv.Client/HurrahTv.Client.csproj
@@ -7,7 +7,10 @@
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- no i18n: ship the minimal ICU shard instead of the full globalization data (#3) -->
+    <!-- ship only the ICU shard matching the runtime culture (typically EFIGS), not the full
+         globalization data (#3). browser culture is still honored within the shard — this is NOT
+         InvariantGlobalization. intentionally unconditional (not Release-only) so dev runs the same
+         ICU behavior as prod and any culture bug surfaces early. -->
     <BlazorWebAssemblyLoadAllGlobalizationData>false</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
 
@@ -17,13 +20,14 @@
        measurable boot win (539-576 ms vs 518-623 ms non-AOT — within noise) on a render-bound
        startup. NOT set: InvariantGlobalization / InvariantTimezone (would break culture-aware +
        episode air-date formatting), JsonSerializerIsReflectionEnabledByDefault (app uses
-       reflection-based System.Text.Json). -->
+       reflection-based System.Text.Json), and UseSystemResourceKeys — keeping readable BCL
+       exception messages is worth more than the few KB while this first trim pass is unproven
+       (a trim-stripped path otherwise throws an opaque numeric key). -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebuggerSupport>false</DebuggerSupport>
     <MetadataUpdaterSupport>false</MetadataUpdaterSupport>
     <EventSourceSupport>false</EventSourceSupport>
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
-    <UseSystemResourceKeys>true</UseSystemResourceKeys>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HurrahTv.Client/HurrahTv.Client.csproj
+++ b/HurrahTv.Client/HurrahTv.Client.csproj
@@ -14,9 +14,10 @@
     <BlazorWebAssemblyLoadAllGlobalizationData>false</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
 
-  <!-- #3 size pass (Release/publish only — keeps dev hot reload + debugging intact). These
-       feature switches let the IL trimmer + wasm-tools relinker strip native + managed code the
-       app doesn't use. AOT was measured and dropped: it added ~2.4 MB to the download for no
+  <!-- #3 size pass — Release configuration only, so dev (Debug) keeps hot reload + full
+       debugging. The switches take effect when publish trims/relinks; a plain `dotnet build -c
+       Release` leaves them inert. They let the IL trimmer + wasm-tools relinker strip native +
+       managed code the app doesn't use. AOT was measured and dropped: it added ~2.4 MB to the download for no
        measurable boot win (539-576 ms vs 518-623 ms non-AOT — within noise) on a render-bound
        startup. NOT set: InvariantGlobalization / InvariantTimezone (would break culture-aware +
        episode air-date formatting), JsonSerializerIsReflectionEnabledByDefault (app uses


### PR DESCRIPTION
## What
Reduces the WASM client download by enabling the `wasm-tools` workload (relinking) plus a globalization shard and Release-only feature switches, and adds the matching CI workload install step.

**EFIGS-user download: ~2.90 MB → ~2.46 MB brotli** (~15%), build clean, 203 tests green.

### Changes
- `HurrahTv.Client.csproj`
  - `BlazorWebAssemblyLoadAllGlobalizationData=false` — ship one ICU shard, not the full set (culture/date formatting preserved; **did not** set `InvariantGlobalization`/`InvariantTimezone`, which would break TMDb/episode date formatting)
  - Release-only `PropertyGroup`: `DebuggerSupport`/`MetadataUpdaterSupport`/`EventSourceSupport`/`HttpActivityPropagationSupport` off — lets the trimmer/relinker strip more (`UseSystemResourceKeys` was dropped per review: readable BCL exception messages beat the few KB during a first trim pass); dev hot-reload + debugging untouched
- `.github/workflows/main_hurrahtv.yml` — `dotnet workload install wasm-tools` before the Client publish, so staging/prod relink too (**toolchain change**: without it, the deployed bundle is ~15% larger)

## Why
Part of the v1 Public Launch perf work. Measured this session against Release publishes + Chrome DevTools.

## Decisions (with evidence)
- **AOT dropped.** `RunAOTCompilation` added **+2.4 MB** download (2.49 → 4.89 MB) for **no measurable boot win** — 539–576 ms (AOT) vs 518–623 ms (non-AOT) on a Release landing, ranges overlapping. Startup is render-bound, not managed-compute-bound.
- **JWT custom-decoder swap dropped.** Its only benefit was ~36 KB of download; not worth replacing the battle-tested `System.IdentityModel` library, especially once AOT (and thus download-size primacy) was off the table.

## Verification
- `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` — clean
- `dotnet test HurrahTv.slnx` — 203 passed, 0 failed
- Release publish succeeds with relinking; Release build boots cleanly
- ⚠️ The feature switches only apply to the *Release* (trimmed) build, which the Debug test run doesn't exercise. They're logic-neutral (diagnostics-only) and trimming was already on, so risk is low — **recommend a quick authenticated smoke-test on staging after deploy** (auth + dates + queue render).

## Related
- The **#175** "slow Home load" investigation concluded the alarming 1.48 s was mostly the dev server's untrimmed BCL (Release landing boots ~550 ms). The real production symptom — sporadic 10–15 s loads — is tracked separately in **#200** (perf-analysis plan). #175 is left open pending that work; not closed here.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
