### PR TITLE
#175 Phase 4: kill Home refetch-on-interaction + fix load CLS

### DIFF
--- a/HurrahTv.Client/Components/HomeHero.razor
+++ b/HurrahTv.Client/Components/HomeHero.razor
@@ -10,7 +10,9 @@
         <div class="aspect-[3/4] sm:aspect-[16/9] md:aspect-[21/9] relative bg-surface-100">
             @if (!string.IsNullOrEmpty(Item.BackdropUrl))
             {
-                <img src="@Item.BackdropUrl" alt="" draggable="false"
+                @* hero backdrop is the LCP element (#175); hint high priority so the browser fetches
+                   it ahead of lower-priority images the moment its URL is known after the AI pick lands. *@
+                <img src="@Item.BackdropUrl" alt="" draggable="false" fetchpriority="high"
                      class="absolute inset-0 w-full h-full object-cover no-callout" />
             }
 

--- a/HurrahTv.Client/Components/WatchlistRow.razor
+++ b/HurrahTv.Client/Components/WatchlistRow.razor
@@ -35,6 +35,8 @@
                 @foreach (QueueItem item in Items)
                 {
                     List<StreamingService> visible = item.VisibleServicesFor(_userServices);
+                    @* card dims (w-32 sm:w-32 md:w-36, aspect-[2/3], mt-1.5 label) are mirrored by
+                       Home.razor's watchlist load skeleton — keep in sync or CLS regresses (#175) *@
                     <div @key="item.Id" @ref="_cardRefs[item.Id]"
                          class="flex-shrink-0 w-32 sm:w-32 md:w-36 snap-start cursor-pointer group"
                          @onclick="() => GoToDetails(item)">

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -699,6 +699,12 @@ else
 
     private void OnMediaFilterChanged() => _ = InvokeAsync(() =>
     {
+        // MediaFilter is a global service whose InitializeAsync can fire OnChanged during startup,
+        // racing Home's own load. Skip until the queue is loaded — OnInitializedAsync owns first
+        // render and already reads the initialized media filter, so a pre-load run would only derive
+        // empty rows and kick a redundant LoadHero. Mirrors OnUserServicesChanged's _queueLoaded guard.
+        if (!_queueLoaded) return;
+
         // re-fetch a media-appropriate AI hero for the new filter (#147). The single client-held pick
         // may be the other media type; the server re-selects from the SAME cached reservoir (no paid
         // regen). Set _heroLoading BEFORE re-deriving so SelectHero (inside ReapplyDerivedState) keeps

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -149,21 +149,39 @@ else
         }
         @if (!_queueLoaded)
         {
-            <!-- skeleton: reserves vertical space matching a typical watchlist row so the
-                 page doesn't shift when the queue arrives. matches WatchlistRow card size. -->
+            <!-- skeleton mirrors the real watchlist section's structure so the swap doesn't grow the
+                 page and shove the rows below it down (#175 CLS): title + chip/sort control row, then
+                 two WatchlistRow-shaped placeholders (header bar + poster strip + label). Two rows is
+                 the common case (Available Now + Available Later); a sparse account collapses by at
+                 most one row, far less shift than the prior single bare poster row. matches the real
+                 header (Home.razor) and WatchlistRow card structure. -->
             <div class="mb-8">
-                <div class="flex items-center gap-2 mb-4">
-                    <span class="icon-[heroicons--rectangle-stack] w-5 h-5 text-accent"></span>
-                    <h2 class="text-lg md:text-xl font-bold text-white">@WatchlistTitle</h2>
+                <div class="mb-4">
+                    <div class="flex items-center gap-2 mb-1">
+                        <span class="icon-[heroicons--rectangle-stack] w-5 h-5 text-accent"></span>
+                        <h2 class="text-lg md:text-xl font-bold text-white">@WatchlistTitle</h2>
+                    </div>
+                    <div class="flex items-center justify-between mt-3 gap-2">
+                        <div class="h-7 w-28 md:w-44 bg-surface-100 rounded-lg animate-pulse"></div>
+                        <div class="h-7 w-36 bg-surface-100 rounded-lg animate-pulse"></div>
+                    </div>
                 </div>
-                <div class="flex gap-3 overflow-hidden">
-                    @for (int i = 0; i < 6; i++)
-                    {
-                        <div class="flex-shrink-0 w-32 sm:w-32 md:w-36">
-                            <div class="aspect-[2/3] bg-surface-100 rounded-lg animate-pulse"></div>
+
+                @for (int row = 0; row < 2; row++)
+                {
+                    <section class="mb-6 md:mb-8">
+                        <div class="h-5 w-40 bg-surface-100 rounded animate-pulse mb-3"></div>
+                        <div class="flex gap-3 overflow-hidden">
+                            @for (int i = 0; i < 6; i++)
+                            {
+                                <div class="flex-shrink-0 w-32 sm:w-32 md:w-36">
+                                    <div class="aspect-[2/3] bg-surface-100 rounded-lg animate-pulse"></div>
+                                    <div class="h-3 w-20 bg-surface-100 rounded animate-pulse mt-1.5"></div>
+                                </div>
+                            }
                         </div>
-                    }
-                </div>
+                    </section>
+                }
             </div>
         }
         else if (hasWatchlistContent)

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -307,7 +307,10 @@ else
     // the background fetch returns. While _heroLoading we show a skeleton rather than a
     // watchlist fallback, so the hero never flashes an already-in-list item.
     private CuratedHero? _heroPick;
-    private bool _heroLoading;
+    // default true so the hero skeleton reserves its full aspect-ratio height from the very first
+    // render of the watchlist view — otherwise the hero area renders at zero height until
+    // OnInitializedAsync sets the flag, then pops to full height and shoves the watchlist down (CLS, #175).
+    private bool _heroLoading = true;
     private int _heroRequestSeq; // latest-wins guard so overlapping fetches don't both apply
     private bool _disposed;      // LoadHero is fire-and-forget + slow; don't render after disposal
     // page-scoped CTS, cancelled in Dispose(), so navigating away mid-fetch aborts the
@@ -531,9 +534,12 @@ else
             case QueueStatus.Finished:    _settings.ShowFinished    = !current; break;
         }
 
+        // re-apply the filter from the in-memory queue for an instant response — the chip flags are
+        // read by ApplyWatchlistFilters inside ReapplyDerivedState, so no /api/queue refetch is needed
+        // (this used to call ReloadWatchlist, which round-tripped). Persist the setting afterward.
+        ReapplyDerivedState();
+        StateHasChanged();
         await Api.SetUserSettingsAsync(_settings);
-        // reload to re-apply filter (uses cached queue data from last load)
-        await ReloadWatchlist();
     }
 
     private void ApplyWatchlistFilters(List<QueueItem> allItems)
@@ -673,24 +679,21 @@ else
         catch { /* leave stale data in place on network failure */ }
     });
 
-    private void OnMediaFilterChanged() => _ = InvokeAsync(async () =>
+    private void OnMediaFilterChanged() => _ = InvokeAsync(() =>
     {
-        // re-fetch a media-appropriate AI hero for the new filter (#147). The single client-held
-        // pick may be the other media type; the server re-selects from the SAME cached reservoir
-        // (no paid regen). Recompute _hero with _heroLoading set BEFORE the async work so the slot
-        // reflects the new filter immediately — keeping the current pick only if it still matches,
-        // else showing the skeleton — instead of flashing the now-filtered-out pick during the
-        // in-flight refetch. The flag gates a derived value (_hero), so it must be set before that
-        // value is recomputed, not just before the async call (see #135 learning).
+        // re-fetch a media-appropriate AI hero for the new filter (#147). The single client-held pick
+        // may be the other media type; the server re-selects from the SAME cached reservoir (no paid
+        // regen). Set _heroLoading BEFORE re-deriving so SelectHero (inside ReapplyDerivedState) keeps
+        // the current pick only if it still matches the new filter, else renders the skeleton — the
+        // flag gates the derived _hero value, so it must be set before that value is recomputed (#135).
         _heroLoading = true;
-        _hero = SelectHero();
-        StateHasChanged();
-        // the hero fetch and the watchlist reload are independent (the server reads its own
-        // watchlist for the hero, not the client's), so kick the hero off concurrently rather
-        // than after the awaited reload — the new pick lands sooner.
+        // the hero fetch is independent (the server reads its own watchlist for the hero, not the
+        // client's), so kick it off — the new media-appropriate pick lands when it returns.
         _ = LoadHero();
-        try { await ReloadWatchlist(); }
-        catch { /* leave stale data in place on network failure */ }
+        // the media partition is a pure function of the in-memory queue + the new media filter
+        // (cf. OnUserServicesChanged), so re-derive locally instead of refetching /api/queue.
+        ReapplyDerivedState();
+        StateHasChanged();
     });
 
     // user changed services in Settings — refresh the cached list and re-run the partition

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -371,10 +371,10 @@ else
         _settings = await settingsTask;
         _watchlistSort = _settings.WatchlistSort;
 
-        // set BEFORE ProcessQueueResponse: it computes _hero via SelectHero, which must see
-        // _heroLoading=true to suppress the watchlist fallback and render the skeleton instead.
-        // Otherwise the hero flashes an in-list item until the AI pick lands.
-        _heroLoading = true;
+        // ProcessQueueResponse computes _hero via SelectHero, which must see _heroLoading=true to
+        // suppress the watchlist fallback and render the skeleton (else the hero flashes an in-list
+        // item until the AI pick lands). The field defaults true and nothing has cleared it yet on
+        // this first-load path, so no assignment is needed here.
         ProcessQueueResponse(await queueTask);
 
         // AI is the slowest call (Claude API) and not needed for first paint — let it finish in

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -626,6 +626,12 @@
   .w-32 {
     width: calc(var(--spacing) * 32);
   }
+  .w-36 {
+    width: calc(var(--spacing) * 36);
+  }
+  .w-40 {
+    width: calc(var(--spacing) * 40);
+  }
   .w-48 {
     width: calc(var(--spacing) * 48);
   }
@@ -2243,6 +2249,11 @@
   .md\:w-36 {
     @media (width >= 48rem) {
       width: calc(var(--spacing) * 36);
+    }
+  }
+  .md\:w-44 {
+    @media (width >= 48rem) {
+      width: calc(var(--spacing) * 44);
     }
   }
   .md\:grid-cols-2 {

--- a/HurrahTv.Client/wwwroot/index.html
+++ b/HurrahTv.Client/wwwroot/index.html
@@ -7,6 +7,11 @@
     <title>Hurrah.tv</title>
     <base href="/" />
 
+    <!-- warm the TMDb image CDN connection early so poster/backdrop fetches skip DNS+TLS setup
+         once the WASM app discovers them post-boot (#175). crossorigin because the images are
+         fetched anonymously from a different origin. -->
+    <link rel="preconnect" href="https://image.tmdb.org" crossorigin />
+
     <!-- site-wide meta + Open Graph + Twitter Card. Blazor WASM doesn't SSR, so iOS Safari
          / iMessage / Twitter link-preview bots only ever see what's in this static HTML.
          Per-show OG (using TMDb backdrop + title for /details/{type}/{id}) needs a


### PR DESCRIPTION
## What

Phase 4 of #175 (Home initial load). Building on #3 (WASM bundle, already shipped), this removes the remaining boot-independent waste the #175 baseline measurement surfaced.

**4b — stop refetching `/api/queue` on filter toggles**
`ToggleStatusFilter` and `OnMediaFilterChanged` re-partition from the in-memory queue (`ReapplyDerivedState()`) instead of round-tripping the server for what is a pure client-side derivation. `OnQuickActionChanged` keeps its post-mutation refetch (it follows a server write).

**4c — eliminate the load layout shift (CLS)**
- `_heroLoading` defaults `true` so the hero skeleton reserves its aspect-ratio height from the first render (no zero-height→full-height pop-in).
- The watchlist load skeleton was rebuilt to mirror the real section structure (chip/sort header + two `WatchlistRow`-shaped placeholder rows) instead of a single bare poster row, so the section no longer grows and shoves the discover rows down on load.
- Added `fetchpriority="high"` on the hero backdrop and a `preconnect` to the TMDb image CDN (cheap, low-impact hints).

## Verification

Measured authenticated Home on a real account via Chrome DevTools:

| Metric | Before (prod baseline) | After |
|---|---|---|
| `/api/queue` on chip/media toggle | 1 refetch each | **0** (chip fires only `PUT /api/settings`) |
| CLS | 0.154 | **0.00** (hero fix 0.154→0.11, skeleton match 0.11→0.00) |

LCP is boot-bound (~1s) and unchanged — the #3 bundle work already addressed the boot lever; the LCP element is the post-boot AI hero, so the discovery hints are minor by design. Build clean (0 warnings), CI formatter gate passes. `/xsimplify` pass applied (redundant flag drop + cross-file breadcrumb) and surfaced #208.

## Notes / follow-ups

- Deliberately left `OnQuickActionChanged`'s post-mutation refetch in place.
- Deferred: a double `GET /api/queue` seen on initial load on prod — not present in this code, likely a #201 observability artifact; needs checking against the `d4a2185` diff.
- CLS 0.00 was measured on a populated (~2-row) account; sparse/3-row accounts may have a small residual. Worth a prod re-measure post-deploy.
- #208 filed: extract a shared poster-strip skeleton component (DRY ContentRow/PosterGrid/Home).

Related: #210 (settings-write robustness, surfaced by review)

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)