### PR TITLE
#63: Microsoft Clarity analytics (prod-gated) + dedupe pre-boot host gating

### DIFF
--- a/.github/workflows/main_hurrahtv.yml
+++ b/.github/workflows/main_hurrahtv.yml
@@ -100,8 +100,16 @@ jobs:
           # case, and as the step's last command that would fail the build under `set -e`.
           if grep -q '__SENTRY_LOADER_KEY__' wwwroot/index.html; then echo "SENTRY_LOADER_KEY placeholder not substituted"; exit 1; fi
           if grep -q '__BUILD_VERSION__' wwwroot/index.html; then echo "BUILD_VERSION placeholder not substituted"; exit 1; fi
+          # Clarity (#63): inject the public project tracking ID. A repo VARIABLE (not a secret —
+          # it's a public ID, and a secret would be masked to *** and break the guard grep below).
+          # Unset resolves to empty, so the client gate ('__' prefix / empty id) keeps Clarity a
+          # no-op — merge-safe, same shape as the Sentry key above. Same placeholder-gone guard:
+          # assert the literal placeholder is replaced (by id OR empty), not still present.
+          sed -i "s|__CLARITY_PROJECT_ID__|${CLARITY_PROJECT_ID}|" wwwroot/index.html
+          if grep -q '__CLARITY_PROJECT_ID__' wwwroot/index.html; then echo "CLARITY_PROJECT_ID placeholder not substituted"; exit 1; fi
         env:
           SENTRY_LOADER_KEY: ${{ secrets.SENTRY_LOADER_KEY }}
+          CLARITY_PROJECT_ID: ${{ vars.CLARITY_PROJECT_ID }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v5

--- a/HurrahTv.Client/Layout/MainLayout.razor
+++ b/HurrahTv.Client/Layout/MainLayout.razor
@@ -102,6 +102,7 @@
     <footer class="hidden md:block text-center text-gray-600 text-xs py-4 border-t border-surface-200">
         Data provided by <a href="https://www.themoviedb.org" target="_blank" class="text-gray-400 hover:text-white">TMDb</a>
         &middot; Watch provider data by <a href="https://www.justwatch.com" target="_blank" class="text-gray-400 hover:text-white">JustWatch</a>
+        &middot; Anonymized session analytics by <a href="https://privacy.microsoft.com/privacystatement" target="_blank" class="text-gray-400 hover:text-white">Microsoft Clarity</a>
     </footer>
 
     <!-- mobile bottom tab bar -->

--- a/HurrahTv.Client/Layout/MainLayout.razor
+++ b/HurrahTv.Client/Layout/MainLayout.razor
@@ -100,9 +100,9 @@
 
     <!-- footer (desktop only) -->
     <footer class="hidden md:block text-center text-gray-600 text-xs py-4 border-t border-surface-200">
-        Data provided by <a href="https://www.themoviedb.org" target="_blank" class="text-gray-400 hover:text-white">TMDb</a>
-        &middot; Watch provider data by <a href="https://www.justwatch.com" target="_blank" class="text-gray-400 hover:text-white">JustWatch</a>
-        &middot; Anonymized session analytics by <a href="https://privacy.microsoft.com/privacystatement" target="_blank" class="text-gray-400 hover:text-white">Microsoft Clarity</a>
+        Data provided by <a href="https://www.themoviedb.org" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-white">TMDb</a>
+        &middot; Watch provider data by <a href="https://www.justwatch.com" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-white">JustWatch</a>
+        &middot; Anonymized session analytics by <a href="https://privacy.microsoft.com/privacystatement" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-white">Microsoft Clarity</a>
     </footer>
 
     <!-- mobile bottom tab bar -->

--- a/HurrahTv.Client/Pages/AdminUserDetail.razor
+++ b/HurrahTv.Client/Pages/AdminUserDetail.razor
@@ -5,7 +5,9 @@
 
 <PageTitle>Admin · User - Hurrah.tv</PageTitle>
 
-<div class="max-w-5xl mx-auto">
+@* data-clarity-mask: this view shows a user's phone + profile — keep PII out of Clarity session
+   recordings (#63). Cascades to children, so it stays masked regardless of the remote mask mode. *@
+<div class="max-w-5xl mx-auto" data-clarity-mask="true">
     <div class="flex items-center gap-2 mb-4 md:mb-6 flex-wrap">
         <a href="/admin" class="text-gray-400 hover:text-white">Admin</a>
         <span class="text-gray-600">/</span>

--- a/HurrahTv.Client/Pages/AdminUsers.razor
+++ b/HurrahTv.Client/Pages/AdminUsers.razor
@@ -5,7 +5,10 @@
 
 <PageTitle>Admin · Users - Hurrah.tv</PageTitle>
 
-<div class="max-w-6xl mx-auto">
+@* data-clarity-mask: this view lists every user's phone number — keep all PII out of Clarity
+   session recordings (#63). The attribute cascades to children, so new admin fields are masked
+   by default rather than relying on Clarity's remote masking mode. *@
+<div class="max-w-6xl mx-auto" data-clarity-mask="true">
     <div class="flex items-center gap-3 mb-4 md:mb-6">
         <a href="/admin" class="text-gray-400 hover:text-white transition-colors">
             <span class="icon-[heroicons--chevron-left] w-5 h-5 inline-block align-text-bottom"></span>

--- a/HurrahTv.Client/Pages/Landing.razor
+++ b/HurrahTv.Client/Pages/Landing.razor
@@ -43,7 +43,9 @@
                 <p class="text-gray-500 text-sm mb-6">Enter your phone number to sign in or create an account.</p>
 
                 <div class="relative">
+                    @* data-clarity-mask: PII — never record the phone number in Clarity session replays (#63) *@
                     <input type="tel" @bind="_phoneNumber" @bind:event="oninput" @onkeydown="HandlePhoneKeyDown"
+                           data-clarity-mask="true"
                            placeholder="+1 (555) 123-4567"
                            class="w-full bg-surface-100 border border-surface-200 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent text-center text-lg tracking-wider" />
                 </div>
@@ -56,9 +58,12 @@
             else
             {
                 <h2 class="text-lg font-semibold mb-1">Enter your code</h2>
-                <p class="text-gray-500 text-sm mb-6">We sent a 6-digit code to <span class="text-white">@_phoneNumber</span></p>
+                @* mask the echoed phone number too: it's plain text, so a Relaxed masking mode would expose it (#63) *@
+                <p class="text-gray-500 text-sm mb-6">We sent a 6-digit code to <span class="text-white" data-clarity-mask="true">@_phoneNumber</span></p>
 
+                @* data-clarity-mask: the OTP is a short-lived auth secret — keep it out of replays (#63) *@
                 <input type="text" @bind="_code" @bind:event="oninput" @onkeydown="HandleCodeKeyDown"
+                       data-clarity-mask="true"
                        placeholder="000000" maxlength="6" inputmode="numeric"
                        class="w-full bg-surface-100 border border-surface-200 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent text-center text-2xl tracking-[0.5em] font-mono" />
 

--- a/HurrahTv.Client/wwwroot/index.html
+++ b/HurrahTv.Client/wwwroot/index.html
@@ -49,6 +49,18 @@
         });
         window.addEventListener('appinstalled', () => { window.__hurrahInstallPrompt = null; });
     </script>
+    <!-- host/env detection, computed once for the pre-boot scripts that gate on it: Sentry +
+         Clarity below and the service-worker registration at the end of <body>. Defined here,
+         before any consumer in document order, so each reads one decision instead of re-inlining
+         the localhost regex / staging check. Plain object on window because these are classic
+         inline scripts that run before the WASM runtime boots. -->
+    <script>
+        window.__hurrahHostEnv = (function () {
+            var isLocal = /^(localhost|127\.0\.0\.1)$/.test(location.hostname);
+            var isStaging = location.hostname.indexOf('staging') >= 0;
+            return { isLocal: isLocal, isStaging: isStaging, isProd: !isLocal && !isStaging };
+        })();
+    </script>
     <!-- RUM beacon (issue #201): classic early script so it still reports when a slow WASM
          boot is the problem. Self-gates to prod + slow/sampled loads; never throws into the page. -->
     <script defer src="js/rum.js"></script>
@@ -66,9 +78,9 @@
         (function () {
             var key = '__SENTRY_LOADER_KEY__';
             if (key.indexOf('__') === 0 || key === '') return;     // placeholder not replaced / no key
-            if (/^(localhost|127\.0\.0\.1)$/.test(location.hostname)) return;     // never on local dev
+            if (window.__hurrahHostEnv.isLocal) return;            // never on local dev
             // lowercase to match the API's normalized Sentry environment (one filter across surfaces)
-            var env = location.hostname.indexOf('staging') >= 0 ? 'staging' : 'production';
+            var env = window.__hurrahHostEnv.isStaging ? 'staging' : 'production';
             var release = '__BUILD_VERSION__';
             if (release.indexOf('__') === 0) release = undefined;   // unstamped (dev) — let Sentry omit it
             // strip the query string + fragment off a URL. Defense-in-depth mirroring the server's
@@ -113,6 +125,29 @@
             (document.head || document.documentElement).appendChild(s);
         })();
     </script>
+    <!-- Microsoft Clarity product analytics (#63): session recordings + heatmaps to inform UX.
+         Production-ONLY — unlike error monitoring (Sentry, staging+prod) this mirrors rum.js's
+         prod-only stance: staging sessions are just us testing and would pollute the recordings
+         and heatmaps. The project ID is injected at build time by CI from the GitHub `CLARITY_PROJECT_ID`
+         variable (same mechanism as the Sentry loader key above) — WASM is static + this script runs
+         pre-boot, so runtime appsettings can't reach it; build-time substitution is the client-config
+         mechanism. The ID is a PUBLIC tracking ID, not a secret. An unset variable resolves to empty
+         and the gate below no-ops, so this is merge-safe. Clarity masks all input-box text in every
+         mode; phone/OTP fields and the displayed phone number also carry explicit data-clarity-mask
+         (defense-in-depth, robust if the masking mode is ever relaxed). Loaded async via the standard
+         tag, gated behind the host check so it never sits on the #200 WASM-boot critical path. -->
+    <script>
+        (function () {
+            var id = '__CLARITY_PROJECT_ID__';
+            if (id.indexOf('__') === 0 || id === '') return;     // placeholder not replaced / unset
+            if (!window.__hurrahHostEnv.isProd) return;          // prod-only: skip localhost + staging (UX volume; mirror rum.js)
+            (function (c, l, a, r, i, t, y) {
+                c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
+                t = l.createElement(r); t.async = 1; t.src = 'https://www.clarity.ms/tag/' + i;
+                y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+            })(window, document, 'clarity', 'script', id);
+        })();
+    </script>
 </head>
 
 <body class="bg-surface text-gray-100 min-h-screen">
@@ -136,7 +171,7 @@
     <!-- PWA service worker (issue #15). Skipped on localhost so dotnet watch hot-reload
          isn't intercepted by a cache; test the SW against a published build via the Api. -->
     <script>
-        if ('serviceWorker' in navigator && !/^(localhost|127\.0\.0\.1)$/.test(location.hostname)) {
+        if ('serviceWorker' in navigator && !window.__hurrahHostEnv.isLocal) {
             navigator.serviceWorker.register('/service-worker.js').catch(() => { });
         }
     </script>

--- a/Plans/63-microsoft-clarity-analytics.md
+++ b/Plans/63-microsoft-clarity-analytics.md
@@ -1,0 +1,59 @@
+# Microsoft Clarity Product Analytics - Implementation Plan
+
+> **Status:** Active
+> **Tracking issue:** #63
+
+Wire up [Microsoft Clarity](https://clarity.microsoft.com/) for session recordings, heatmaps,
+and click/scroll telemetry to inform UX work — free, lightweight, and gated like the rest of our
+observability stack (App Insights #206, Sentry #24). Part of mirroring hurrah.dev's standard
+analytics stack (Clarity + GA4 + GSC); GA4 + Search Console are tracked on #11.
+
+## Design decisions
+
+- **Production-only gate.** Unlike error monitoring (Sentry runs on staging + prod so we catch
+  errors pre-prod), Clarity is gated to **production only** — it mirrors `rum.js`'s prod-only
+  stance. Staging sessions are just us testing and would pollute recordings and heatmaps. The
+  client script skips `localhost`/`127.0.0.1` and any hostname containing `staging`.
+- **Build-time CI substitution (same tier as the Sentry *client* loader key).** WASM `index.html`
+  is static and this script runs *pre-boot*, so runtime `appsettings.json` can't reach it (it'd load
+  too late, and Client config is downloaded to the browser anyway — equally public). The repo's
+  client-config mechanism is therefore build-time substitution: CI replaces `__CLARITY_PROJECT_ID__`
+  in `index.html` from the GitHub **variable** `CLARITY_PROJECT_ID`. (Contrast: the *API* Sentry DSN
+  correctly lives in Azure app settings — that's server config; this is a public client tag.)
+  Project ID: `x90c2vtxpj`.
+- **Repo variable, not secret.** The Clarity ID is a *public* tracking ID, so it's a GitHub Actions
+  **variable** (`vars.`), not a secret — a secret would be masked to `***` in logs and defeat the
+  placeholder-gone guard. An unset variable resolves to empty and the client gate keeps Clarity a
+  no-op, so the change is merge-safe before the variable is set.
+- **Off the boot critical path (#200).** Loaded async via Clarity's standard tag, behind the host
+  gate, so it never blocks the WASM boot on dev/staging.
+
+## Privacy / PII
+
+- Clarity masks **all input-box text in every masking mode** (can't be unmasked) — so the phone
+  and OTP `<input>` fields are protected by default.
+- Belt-and-suspenders: explicit `data-clarity-mask="true"` on the phone input, the OTP input, and
+  the **echoed phone-number span** on the verify step. The span is the load-bearing one — it's
+  plain text, so a future switch to Relaxed masking mode would expose it without the attribute.
+- Footer disclosure added: "Anonymized session analytics by Microsoft Clarity" linking to the
+  Microsoft privacy statement.
+
+## Phase 1 — Client + CI wiring  ✅
+
+- [x] Clarity loader script in `HurrahTv.Client/wwwroot/index.html` (prod-gated, `__CLARITY_PROJECT_ID__` placeholder)
+- [x] CI substitution + placeholder-gone guard in `main_hurrahtv.yml` (sourced from `vars.CLARITY_PROJECT_ID`)
+- [x] `data-clarity-mask` on phone input, OTP input, and echoed phone span in `Landing.razor`
+- [x] Footer session-recording disclosure in `MainLayout.razor`
+- Tests: none — all Razor/HTML/CI wiring, no `HurrahTv.Shared` logic. Verify in browser per CLAUDE.md.
+
+## Phase 2 — Provision + verify (operational, kept on #63)
+
+- [ ] Add GitHub Actions repo **variable** `CLARITY_PROJECT_ID` = `x90c2vtxpj`
+- [ ] Deploy to prod; confirm first session shows up in the Clarity dashboard within ~1 hour
+- [ ] Spot-check a recording: phone + OTP entry are masked (`•`), not legible
+
+## Known gap / follow-up candidate
+
+- The footer is **desktop-only** (`hidden md:block`) — mobile users never see the disclosure.
+  A proper privacy page (or an always-visible disclosure) would close this. Most users are mobile,
+  so this is worth a separate issue rather than expanding scope here.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The home page renders Netflix-style horizontal content rows, each powered by a d
 | Watch providers | JustWatch (via TMDb) |
 | Auth | Phone OTP via Twilio |
 | Hosting | Azure App Service + Azure PostgreSQL |
-| Observability | Application Insights (server + RUM) · Sentry (exception monitoring) |
+| Observability | Application Insights (server + RUM) · Sentry (exception monitoring) · Microsoft Clarity (product analytics, prod-only) |
 
 ## AI Curation
 


### PR DESCRIPTION
## What
Wires up **Microsoft Clarity** (session recordings + heatmaps) on production, gated and configured exactly like the existing observability stack (App Insights #206, Sentry #24).

## How
- **Loader** (`index.html`): standard Clarity tag, **production-only** — skips `localhost` *and* `staging` (mirroring `rum.js`'s prod-only stance; staging sessions would just pollute recordings). Loaded async, off the #200 WASM-boot critical path.
- **Config**: the public tracking ID is injected at build time by CI from the GitHub **variable** `CLARITY_PROJECT_ID` into a `__CLARITY_PROJECT_ID__` placeholder — same merge-safe build-time mechanism as the Sentry loader key (an unset variable resolves to empty and the client gate no-ops). A variable (not a secret) because the ID is public and a masked `***` would break the placeholder-gone guard.
- **Privacy**: explicit `data-clarity-mask` on the phone input, OTP input, and the **echoed phone-number span** in `Landing.razor`. Clarity masks input text in all modes by default; the span is plain text, so a Relaxed mode would otherwise expose it. Footer gains a session-recording disclosure linking to Microsoft's privacy statement.
- **Refactor (from /xsimplify)**: extracted a single early `window.__hurrahHostEnv` helper and routed all three pre-boot consumers (Sentry, Clarity, service-worker registration) through it, instead of re-inlining the localhost regex / staging check three times.

## Verified
- Build clean; `dotnet format --verify-no-changes` passes (CI gate).
- Ran locally: `window.__hurrahHostEnv` = `{isLocal:true, isStaging:false, isProd:false}`, Sentry + Clarity both correctly no-op on localhost, zero console errors.
- Repo variable `CLARITY_PROJECT_ID` already set.

## Remaining (operational — kept open on #63, not auto-closed)
- [ ] Deploy to prod; confirm first session lands in the Clarity dashboard within ~1 hr
- [ ] Spot-check a recording: phone + OTP entry render masked (`•`), not legible

Part of #63 (left open for the post-deploy verify ACs above).

Plan: `Plans/63-microsoft-clarity-analytics.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)