### PR TITLE
#200: warm Npgsql connection pool to fix /api/queue connect-timeouts

### DIFF
--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -7,6 +7,7 @@ using HurrahTv.Api.Middleware;
 using HurrahTv.Api.Services;
 using HurrahTv.Api.Telemetry;
 using System.Threading.RateLimiting;
+using Npgsql;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -14,6 +15,24 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient<TmdbService>();
+
+// single pool-warmed NpgsqlDataSource shared by DbService (#200 — Sentry HURRAH-TV-3). Min Pool Size
+// keeps connections warm so the first post-idle request never pays a cold (cross-region) connect, and
+// KeepAlive stops Azure Postgres' gateway idle-timeout from silently dropping pooled connections.
+// Max Pool Size stays under the server's max_connections (50). Factory form so the DI container
+// disposes the data source on shutdown.
+string pgConnString = builder.Configuration.GetConnectionString("Default")
+    ?? throw new InvalidOperationException("ConnectionStrings:Default is required");
+NpgsqlConnectionStringBuilder pgCsb = new(pgConnString)
+{
+    MinPoolSize = 3,
+    MaxPoolSize = 40,
+    KeepAlive = 30,
+    ConnectionIdleLifetime = 300,
+    Timeout = 15,
+    CommandTimeout = 30,
+};
+builder.Services.AddSingleton<NpgsqlDataSource>(_ => new NpgsqlDataSourceBuilder(pgCsb.ConnectionString).Build());
 builder.Services.AddSingleton<DbService>();
 builder.Services.AddSingleton<SmsService>();
 builder.Services.AddScoped<AuthService>();

--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddSingleton<NpgsqlDataSource>(_ =>
     pool.MaxPoolSize = 20;
     pool.KeepAlive = 30;
     pool.ConnectionIdleLifetime = 300;
+    // connection Timeout (15s) and Dapper CommandTimeout (30s) deliberately left at Npgsql's defaults.
     return dataSourceBuilder.Build();
 });
 builder.Services.AddSingleton<DbService>();

--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -23,16 +23,16 @@ builder.Services.AddHttpClient<TmdbService>();
 // disposes the data source on shutdown.
 string pgConnString = builder.Configuration.GetConnectionString("Default")
     ?? throw new InvalidOperationException("ConnectionStrings:Default is required");
-NpgsqlConnectionStringBuilder pgCsb = new(pgConnString)
+builder.Services.AddSingleton<NpgsqlDataSource>(_ =>
 {
-    MinPoolSize = 3,
-    MaxPoolSize = 40,
-    KeepAlive = 30,
-    ConnectionIdleLifetime = 300,
-    Timeout = 15,
-    CommandTimeout = 30,
-};
-builder.Services.AddSingleton<NpgsqlDataSource>(_ => new NpgsqlDataSourceBuilder(pgCsb.ConnectionString).Build());
+    NpgsqlDataSourceBuilder dataSourceBuilder = new(pgConnString);
+    NpgsqlConnectionStringBuilder pool = dataSourceBuilder.ConnectionStringBuilder;
+    pool.MinPoolSize = 3;
+    pool.MaxPoolSize = 40;          // under the server's max_connections (50)
+    pool.KeepAlive = 30;
+    pool.ConnectionIdleLifetime = 300;
+    return dataSourceBuilder.Build();
+});
 builder.Services.AddSingleton<DbService>();
 builder.Services.AddSingleton<SmsService>();
 builder.Services.AddScoped<AuthService>();

--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -28,7 +28,11 @@ builder.Services.AddSingleton<NpgsqlDataSource>(_ =>
     NpgsqlDataSourceBuilder dataSourceBuilder = new(pgConnString);
     NpgsqlConnectionStringBuilder pool = dataSourceBuilder.ConnectionStringBuilder;
     pool.MinPoolSize = 3;
-    pool.MaxPoolSize = 40;          // under the server's max_connections (50)
+    // staging + prod slots SHARE one Postgres (max_connections=50), and staging runs
+    // continuously (auto-deploys on every main push) alongside prod — both are also briefly
+    // live during a swap. So the cap is shared across two pools: keep MaxPoolSize low enough
+    // that 2 slots plus Azure's own connections stay under 50 (20 + 20 + overhead < 50).
+    pool.MaxPoolSize = 20;
     pool.KeepAlive = 30;
     pool.ConnectionIdleLifetime = 300;
     return dataSourceBuilder.Build();

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -4,10 +4,13 @@ using HurrahTv.Shared.Models;
 
 namespace HurrahTv.Api.Services;
 
-public class DbService(IConfiguration config)
+public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
 {
-    private readonly string _connectionString = config.GetConnectionString("Default")
-            ?? throw new InvalidOperationException("ConnectionStrings:Default is required");
+    // rent from a single shared, pool-warmed NpgsqlDataSource (configured in Program.cs) rather
+    // than `new NpgsqlConnection(connString)` per call — a Min-Pool-Size=0 pool drained to zero
+    // when idle, so the first post-idle request paid a full cross-region cold connect and could
+    // exceed the 15s connection timeout, stalling Home's /api/queue (#200, Sentry HURRAH-TV-3).
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     public async Task InitializeAsync()
     {
@@ -1136,11 +1139,7 @@ public class DbService(IConfiguration config)
     // OpenAsync runs to completion before the subsequent Dapper command throws OCE,
     // wasting a pooled connection on a request the caller has given up on. pins #127.
     private async Task<NpgsqlConnection> OpenAsync(CancellationToken cancellationToken = default)
-    {
-        NpgsqlConnection conn = new(_connectionString);
-        await conn.OpenAsync(cancellationToken);
-        return conn;
-    }
+        => await _dataSource.OpenConnectionAsync(cancellationToken);
 
     // single-row lookup by the natural key (UserId, TmdbId, MediaType). Shared by the add
     // and upsert paths and their ON CONFLICT re-reads so the query lives in one place.

--- a/Plans/perf-analysis-and-observability.md
+++ b/Plans/perf-analysis-and-observability.md
@@ -72,7 +72,7 @@ The timeout is in **opening a physical connection**, not running a query. The ev
 **`GET /api/queue`** — the call Home awaits on first paint (`Home.razor:378`) — so it presents as a slow page load.
 The ~15 s symptom == Npgsql's **default connection `Timeout` of 15 s**.
 
-**Mechanism:** `OpenAsync` (DbService.cs:1138-1143) does `new NpgsqlConnection(_connectionString)` per call (pools by
+**Mechanism:** `DbService.OpenAsync` did `new NpgsqlConnection(_connectionString)` per call (pools by
 connection string — all 46 call sites dispose via `using`, **no leak**). But the connection string sets **no pool
 params**, so **Minimum Pool Size = 0**: the pool drains to zero when idle, and the first post-idle request must build
 a fresh connection (TCP + SSL + auth to Azure Postgres). When establishing it is slow — **4-A found the DB is in a
@@ -102,7 +102,7 @@ Dapper `CommandTimeout` left at Npgsql's defaults of 15 s / 30 s — not set exp
 staging + prod slots share one Postgres (`max_connections=50`): two pools of 20 + Azure overhead stay under the cap.
 Verified local: build clean (0 warn), `dotnet format --verify-no-changes` exit 0, all 215 tests pass (48 Api.Tests
 exercise `DbService` through the new data source against real Postgres). Remaining: PR → deploy → monitoring window.
-1. **Register a single `NpgsqlDataSource` in DI** — `Program.cs` near `AddSingleton<DbService>()` (line 17), built
+1. **Register a single `NpgsqlDataSource` in DI** — `Program.cs` near `AddSingleton<DbService>()`, built
    from `ConnectionStrings:Default` via `NpgsqlDataSourceBuilder` (pool params in code; host/user/pass stay in the
    Azure app-setting connection string). Register as singleton.
 2. **Refactor `DbService`** — inject `NpgsqlDataSource` (replace the raw `_connectionString` field); change

--- a/Plans/perf-analysis-and-observability.md
+++ b/Plans/perf-analysis-and-observability.md
@@ -97,7 +97,9 @@ Per `Learnings/verify-plan-premise-against-live-data.md`, locked the cause befor
 
 ### Phase 4-B — Fix: a warm, centrally-configured pool (main change) ✅ CODE DONE 2026-06-24
 **Shipped in code** (`Program.cs` data-source registration; `DbService.cs` ctor + `OpenAsync` rent from it).
-Pool params: `MinPoolSize=3, MaxPoolSize=40, KeepAlive=30, ConnectionIdleLifetime=300, Timeout=15, CommandTimeout=30`.
+Pool params: `MinPoolSize=3, MaxPoolSize=20, KeepAlive=30, ConnectionIdleLifetime=300` (connection `Timeout` and
+Dapper `CommandTimeout` left at Npgsql's defaults of 15 s / 30 s — not set explicitly). `MaxPoolSize=20` because
+staging + prod slots share one Postgres (`max_connections=50`): two pools of 20 + Azure overhead stay under the cap.
 Verified local: build clean (0 warn), `dotnet format --verify-no-changes` exit 0, all 215 tests pass (48 Api.Tests
 exercise `DbService` through the new data source against real Postgres). Remaining: PR → deploy → monitoring window.
 1. **Register a single `NpgsqlDataSource` in DI** — `Program.cs` near `AddSingleton<DbService>()` (line 17), built
@@ -108,7 +110,8 @@ exercise `DbService` through the new data source against real Postgres). Remaini
    unchanged; preserves the #127 cancellation behavior.
 3. **Pool-warmth + resilience params:** `Minimum Pool Size` = 2–5 (the direct fix — no cold connect after idle);
    `Keepalive` ~30 s + `Connection Idle Lifetime` ~300 s (survive Azure gateway idle timeout); deliberate connection
-   `Timeout` + Dapper `Command Timeout` (fail fast vs hang); `Maximum Pool Size` **< 50** (server `max_connections`).
+   `Timeout` + Dapper `Command Timeout` (fail fast vs hang); `Maximum Pool Size` sized so **both shared slots fit
+   under `max_connections=50`** — staging + prod each hold their own pool, so ~20/slot, not <50/slot.
 4. **Infra follow-ons surfaced by 4-A (decision = owner, ties to #16) — NOT a PG tier bump (compute is idle):**
    - **Co-locate App Service + Postgres in one region** — currently East US vs East US 2; cross-region connect tax
      on every cold connection. Bigger move (recreate PG in East US, or move the app to East US 2).

--- a/Plans/perf-analysis-and-observability.md
+++ b/Plans/perf-analysis-and-observability.md
@@ -1,10 +1,11 @@
 # Performance Analysis & Observability for Go-Live — Implementation Plan
 
-> **Status:** Draft
-> **Phase:** capture-first (v1 Public Launch milestone)
+> **Status:** Active — capture phases (1–3) shipped; **Phase 4 (DB connect-timeout fix) ready** (data-attributed 2026-06-24)
+> **Phase:** fix-the-dominant-cause (v1 Public Launch milestone)
 > **Tracking issue:** mkerchenski/hurrah-tv#200
 > **Sub-issues:** #201 (client RUM beacon — created via /xplan 2026-06-15)
-> **Related:** #24 (App Insights/Sentry), #63 (Clarity), #16 (Azure settings umbrella), #175 (Home load), #3 (bundle)
+> **Related:** #24 (Sentry — shipped), #206 (App Insights — shipped), #63 (Clarity — shipped), #16 (Azure settings umbrella), #175 (Home load), #3 (bundle)
+> **Capture-phase outcome:** Sentry caught the first attributed cause — `Npgsql` connection-acquisition timeouts on `/api/queue` (HURRAH-TV-3). See Phase 4.
 
 ## Context
 
@@ -30,7 +31,7 @@ The site sporadically takes **10–15 s to load**, other times it's fast (#200).
 
 ---
 
-## Phase 1 — App Insights (server) — the linchpin
+## Phase 1 — App Insights (server) — the linchpin  ✅ SHIPPED (#206)
 
 Greenfield; highest value for the cold-start + dependency hypotheses. This is the Azure-native half of **#24**.
 
@@ -40,7 +41,7 @@ Greenfield; highest value for the cold-start + dependency hypotheses. This is th
 - **Verify:** drive a few requests against staging; confirm requests, dependencies (Postgres + TMDb), and a cold-start (restart slot → first request) appear in the AI resource.
 - **Tests:** none (infra wiring); gate is "telemetry visible in AI."
 
-## Phase 2 — Server-Timing header + `/api/telemetry` beacon + client RUM
+## Phase 2 — Server-Timing header + `/api/telemetry` beacon + client RUM  ✅ SHIPPED (#201)
 
 Capture the **client-side** phase breakdown for slow loads and tie it to server cost.
 
@@ -49,7 +50,7 @@ Capture the **client-side** phase breakdown for slow loads and tie it to server 
 - **Verify:** throttle the network in Chrome DevTools to force a slow load; confirm a sample lands in AI with a phase breakdown; confirm normal-fast loads are not beaconed.
 - **Tests:** if the threshold/sampling decision is pure logic, extract to `HurrahTv.Shared` and unit-test it; the JS/wiring is browser-verified.
 
-## Phase 3 — Microsoft Clarity (#63)
+## Phase 3 — Microsoft Clarity (#63)  ✅ SHIPPED (#63, verified live 2026-06-24)
 
 Qualitative: literally watch a slow load happen.
 
@@ -57,14 +58,80 @@ Qualitative: literally watch a slow load happen.
 - **Verify:** a session shows up in the Clarity dashboard within an hour; OTP/phone masked.
 - **Tests:** none.
 
-## Phase 4 — Fix the dominant cause (data-driven)
+## Phase 4 — Fix the dominant cause: Npgsql connection-acquisition timeouts (data-attributed 2026-06-24)
 
-Only after Phases 1–3 produce attributed samples. Candidates, ranked by current suspicion:
+The capture phases delivered the first hard evidence. **Sentry HURRAH-TV-3** (prod, 10 events 2026-06-20 → 06-23):
+`Npgsql.NpgsqlException: The operation has timed out` (inner `System.TimeoutException`). Stack:
 
-- **Cold start:** move `DbService.InitializeAsync` DDL off the request hot path — run-once guard / `IHostedService` startup task so the first user request doesn't wait on `CREATE TABLE IF NOT EXISTS` (mind `Learnings/shared-db-slot-swaps-need-backward-compatible-migrations.md` — keep migrations expand/contract for slot swaps).
-- **Post-deploy warm-up:** CI hits `/health` (or a warm-up path) after deploy/swap so the first real user isn't cold. Ties into #16.
-- **Cache headers:** audit `_framework/*` server cache headers (fingerprinted assets → `immutable`) so first-load + SW population is optimal; confirm the SW `no-cache`-before-`?v=`-immutable ordering still holds.
-- **Re-verify** each fix against AI/RUM over a monitoring window; #200's acceptance criteria is "sporadic slow loads no longer reproduce."
+```
+DbService.OpenAsync (DbService.cs:1141)
+  → NpgsqlConnection.OpenAsync → PoolingDataSource.Get → OpenNewConnector → ConnectAsync → (timeout)
+```
+
+The timeout is in **opening a physical connection**, not running a query. The event's transaction is
+**`GET /api/queue`** — the call Home awaits on first paint (`Home.razor:378`) — so it presents as a slow page load.
+The ~15 s symptom == Npgsql's **default connection `Timeout` of 15 s**.
+
+**Mechanism:** `OpenAsync` (DbService.cs:1138-1143) does `new NpgsqlConnection(_connectionString)` per call (pools by
+connection string — all 46 call sites dispose via `using`, **no leak**). But the connection string sets **no pool
+params**, so **Minimum Pool Size = 0**: the pool drains to zero when idle, and the first post-idle request must build
+a fresh connection (TCP + SSL + auth to Azure Postgres). When establishing it is slow — **4-A found the DB is in a
+different Azure region (East US vs East US 2)** so each cold connect pays cross-region multi-RTT TLS, **amplified by
+App Service memory-pressure GC stalls** (S1 at ~88–98%) — that handshake exceeds the 15 s timeout and the user eats a
+10–15 s `/api/queue` wait. (4-A ruled out Postgres compute: CPU credits full, 0 failed connections.)
+
+### Phase 4-A — Confirm attribution (read-only) ✅ DONE 2026-06-24
+Per `Learnings/verify-plan-premise-against-live-data.md`, locked the cause before changing anything.
+
+**Results (Azure CLI + Sentry, 06-23 metrics):**
+- **Confirmed connect-time, not query-time** — Sentry stack times out in `OpenAsync → OpenNewConnector → ConnectAsync`.
+- **Postgres compute RULED OUT (no tier bump):** `hurrahtv-pg` = `Standard_B1ms` Burstable, but `cpu_credits_remaining`
+  flat at 292 (full) all day, `cpu_percent` 8–25%, `connections_failed` = **0**, `active_connections` peak 31 of
+  `max_connections` 50. The Burstable-throttle hypothesis is dead.
+- **Found — cross-region App↔DB:** App Service is in **East US**, Postgres in **East US 2**. Every connection
+  establishment pays cross-region multi-RTT TLS latency; cold connects (Min Pool Size 0) are most exposed.
+- **Found — App Service memory pressure:** plan `ASP-hurrahweb-8ec4` (S1, 1.75 GB, 1 worker) ran **mean 87.5% /
+  peak 98% memory** on 06-23 (CPU mean 14%). Sustained pressure → GC/thread stalls can extend an in-flight connect
+  past 15 s — explains the intermittency (cold connect × stall coincidence). Matches the event's 88% memory tag.
+- **Attributed cause:** cold pool × cross-region connect × App-Service resource stalls — *not* PG compute.
+
+### Phase 4-B — Fix: a warm, centrally-configured pool (main change) ✅ CODE DONE 2026-06-24
+**Shipped in code** (`Program.cs` data-source registration; `DbService.cs` ctor + `OpenAsync` rent from it).
+Pool params: `MinPoolSize=3, MaxPoolSize=40, KeepAlive=30, ConnectionIdleLifetime=300, Timeout=15, CommandTimeout=30`.
+Verified local: build clean (0 warn), `dotnet format --verify-no-changes` exit 0, all 215 tests pass (48 Api.Tests
+exercise `DbService` through the new data source against real Postgres). Remaining: PR → deploy → monitoring window.
+1. **Register a single `NpgsqlDataSource` in DI** — `Program.cs` near `AddSingleton<DbService>()` (line 17), built
+   from `ConnectionStrings:Default` via `NpgsqlDataSourceBuilder` (pool params in code; host/user/pass stay in the
+   Azure app-setting connection string). Register as singleton.
+2. **Refactor `DbService`** — inject `NpgsqlDataSource` (replace the raw `_connectionString` field); change
+   `OpenAsync` to `await _dataSource.OpenConnectionAsync(cancellationToken)`. Call sites keep `using` + passed CT
+   unchanged; preserves the #127 cancellation behavior.
+3. **Pool-warmth + resilience params:** `Minimum Pool Size` = 2–5 (the direct fix — no cold connect after idle);
+   `Keepalive` ~30 s + `Connection Idle Lifetime` ~300 s (survive Azure gateway idle timeout); deliberate connection
+   `Timeout` + Dapper `Command Timeout` (fail fast vs hang); `Maximum Pool Size` **< 50** (server `max_connections`).
+4. **Infra follow-ons surfaced by 4-A (decision = owner, ties to #16) — NOT a PG tier bump (compute is idle):**
+   - **Co-locate App Service + Postgres in one region** — currently East US vs East US 2; cross-region connect tax
+     on every cold connection. Bigger move (recreate PG in East US, or move the app to East US 2).
+   - **Right-size App Service memory** — S1 is saturated (mean 87.5%/peak 98%); a bump (S2/P-series) or a memory
+     investigation removes the GC-stall amplifier. Independently improves load reliability.
+
+**Tests:** none new (DI/infra wiring, no new `HurrahTv.Shared` logic per CLAUDE.md). Gate: `HurrahTv.Api.Tests`
+(real-Postgres `WebApplicationFactory`) stays green — they exercise `DbService` through the new data source.
+
+### Phase 4-C — Complementary cold-start mitigations (optional, only if residual)
+- **Post-deploy warm-up ping:** CI hits `/health` after deploy/swap so the first user isn't cold (also primes
+  Min-Pool-Size connections). Ties into #16.
+- **Move `DbService.InitializeAsync` DDL off the request hot path** (run-once guard / `IHostedService`); keep
+  migrations expand/contract per `Learnings/shared-db-slot-swaps-need-backward-compatible-migrations.md`.
+
+### Out of scope / follow-on
+- **WASM boot failures** (Sentry HURRAH-TV-4/5/6) — separate smaller client thread; note on #200, don't fold in.
+- Home client-side load levers (#175/#3) live in `Plans/home-load-and-wasm-bundle-perf.md` — don't mix.
+
+**Verify:** local — run API with `Minimum Pool Size` set, confirm warm idle connections persist (`pg_stat_activity`);
+`dotnet test HurrahTv.slnx`; `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` before
+push. **Prod (real AC):** App Insights connect-time stays low + **no new HURRAH-TV-3 events** over a monitoring
+window → "sporadic slow loads no longer reproduce." PR: `Fixes HURRAH-TV-3` + `Closes #200` once the window is clean.
 
 ---
 


### PR DESCRIPTION
## What
Warm the Npgsql connection pool to fix the sporadic 10–15 s initial loads (#200).

`DbService` now rents connections from a single shared, pool-warmed `NpgsqlDataSource` (registered in `Program.cs`) instead of `new NpgsqlConnection(connString)` per call.

Pool params: `MinPoolSize=3`, `KeepAlive=30`, `ConnectionIdleLifetime=300`, `MaxPoolSize=20`. `MaxPoolSize` is 20 (not higher) because staging + prod App Service slots share one Postgres (`max_connections=50`) and both run concurrently — two pools of 20 + Azure overhead stay under the cap. Connection `Timeout`/`CommandTimeout` left at Npgsql defaults (15 s / 30 s).

## Why
Sentry **HURRAH-TV-3** showed Npgsql timing out while *opening a connection* (`OpenAsync → PoolingDataSource → ConnectAsync`) on `GET /api/queue` — Home's first-paint call — producing the ~15 s stalls (≈ Npgsql's default connection `Timeout`).

Phase 4-A attribution (Azure metrics) ruled out Postgres compute (CPU credits full, 0 failed connections). The real cause: the pool's `Minimum Pool Size` defaulted to **0**, so it drained to zero when idle and the first post-idle request paid a full cold connect — **cross-region** (App Service East US ↔ Postgres East US 2), amplified by App Service S1 memory pressure (~88–98%). Keeping a few connections warm removes the cold connect.

## Verification
- Build clean (0 warnings), `dotnet format --verify-no-changes` passes (exact CI command).
- All 215 tests pass; the 48 `Api.Tests` exercise `DbService` through the new data source against real Postgres.

## Tracking
- Refs #200 — **intentionally left open**: this is deploy-then-verify. Merge only deploys to staging; after the prod swap I'll watch HURRAH-TV-3 + the RUM beacon over a monitoring window, then close #200 and resolve HURRAH-TV-3.
- Related infra follow-ups surfaced by 4-A: #220 (App Service memory), #221 (region co-location).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
