### PR TITLE
phase:now batch — Available Later (#214), SEO robots/sitemap (#11), Feedback/Changelog/Alerts (#19)

### DIFF
--- a/.claude/skills/deploy/skill.md
+++ b/.claude/skills/deploy/skill.md
@@ -51,16 +51,31 @@ Single App Service serves both the Blazor WASM client (static files) and the .NE
 
 **`/deploy now`**
 1. Check staging health first. If unhealthy, warn and stop.
-2. Use AskUserQuestion to confirm: "This will swap staging to production at hurrah.tv. Proceed?"
-3. If confirmed, trigger the swap:
+2. **Stamp the changelog (mirrors Hurrah's `/version release`).** A prod swap is the moment changes
+   become user-visible — and #19 surfaces the changelog to users (the `/changelog` page + the
+   new-feature alert banner), so cut a dated release here.
+   - Read `CHANGELOG.md`. If the `## [Unreleased]` section has real entries (any `### Category` with
+     `- ` items), show the user the draft and confirm.
+   - On confirm: replace the `## [Unreleased]` header with `## [<today>]` (use `date +%Y-%m-%d`) and
+     insert a fresh empty `## [Unreleased]` above it. Commit to `main` (concise message, e.g.
+     `Changelog: cut [Unreleased] → [<today>]`, with the standard `Co-Authored-By` trailer) and push.
+   - **Timing matters — the changelog is an embedded resource in the API build** (`/api/changelog`
+     reads it from the assembly). The stamp must reach the build *before* it's promoted, so this push
+     triggers a fresh staging deploy: **wait for `main_hurrahtv.yml` to finish**
+     (`gh run list --workflow main_hurrahtv.yml -R mkerchenski/hurrah-tv --limit 1`, poll to
+     completion) so the swapped build carries the dated changelog and the banner fires for users.
+   - If `[Unreleased]` is empty (a deploy with no user-visible changes), note that and skip straight to
+     the swap — don't stamp an empty release.
+3. Use AskUserQuestion to confirm: "This will swap staging to production at hurrah.tv. Proceed?"
+4. If confirmed, trigger the swap:
    ```bash
    gh workflow run swap.yml -R mkerchenski/hurrah-tv
    ```
-4. Monitor the run:
+5. Monitor the run:
    ```bash
    gh run list --workflow swap.yml -R mkerchenski/hurrah-tv --limit 1
    ```
-5. Report result.
+6. Report result (including the stamped changelog version, if one was cut).
 
 ## Error Handling
 - If staging health check fails, show the error and suggest checking the GitHub Actions logs

--- a/.claude/skills/xreview/skill.md
+++ b/.claude/skills/xreview/skill.md
@@ -167,6 +167,7 @@ If no issues score 50+:
 Reviewed N files. All 4 hurrah-tv agents + system review passed.
 dotnet format: [clean / fixed N files]
 README check: [up to date / flagged for update]
+Changelog: [entry present / added [Unreleased] line / n/a — internal-only change]
 ```
 
 If issues exist, sort by score descending:
@@ -191,6 +192,12 @@ Verify `README.md` accurately reflects the current state:
 - Architecture diagram/table matches current project layout
 
 If out of date, flag as an issue (count toward the score-50+ list) and offer to update.
+
+#### 7b. Changelog entry check (#19)
+
+Hurrah.tv surfaces `CHANGELOG.md` to users (the `/changelog` page + the new-feature alert banner), so a **user-visible** change should land a `[Unreleased]` entry *as it ships*. This is the **authoring** half of the changelog flow; the dated-release **stamp** happens later in `/deploy` (mirrors Hurrah: PR authors write entries, `/version release` stamps them).
+
+After the README check, judge whether the reviewed diff is **user-visible** — a new or changed feature, page, or behavior a user would notice. Skip refactors, tests, infra, docs-only, and dependency bumps (`CHANGELOG.md`'s own "Skip entries for:" list is the rule). If it **is** user-visible AND the diff did **not** touch `CHANGELOG.md` (no new `- ` line under `## [Unreleased]`), flag it as a score-50+ finding ("user-visible change missing a `CHANGELOG.md` [Unreleased] entry") and **offer to add one** — a `- ` bullet under the right `### Category` (Added / Changed / Fixed / Removed / Security), phrased from the user's perspective per `CHANGELOG.md`'s guidance. If the diff is internal-only, say so and skip — never manufacture an entry.
 
 #### 7a. Linked-issue comment (optional, opt-in only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Types of changes: **Added**, **Changed**, **Fixed**, **Removed**, **Security**.
 ### Added
 - Contributor onboarding: `CONTRIBUTING.md`, `Hurrah.tv.code-workspace`, issue + PR templates, label taxonomy, `/review` skill now files unaddressed findings as issues
 - 24 GitHub issues migrated from the former Trello board (bugs, enhancements, future items)
+- **Send Feedback** — report bugs or request features in-app (Settings → Help us improve)
+- **What's Changed** page plus a new-feature banner that highlights updates you haven't seen yet
 
 ### Changed
 - Line endings normalized across contributors via `.gitattributes` (LF in repo, native on checkout)

--- a/HurrahTv.Api.Tests/ChangelogEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/ChangelogEndpointsTests.cs
@@ -1,0 +1,21 @@
+using System.Net.Http.Json;
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Api.Tests;
+
+// #19 Phase 4 — proves the embedded CHANGELOG.md resource resolves (LogicalName "CHANGELOG.md") and
+// /api/changelog parses + serves it anonymously end-to-end. A parser unit test alone wouldn't catch
+// a wrong embed name (the stream would be null and the endpoint would silently return []).
+[Collection("postgres")]
+public class ChangelogEndpointsTests(PostgresFixture fx)
+{
+    [Fact]
+    public async Task GetChangelog_Anonymous_ReturnsParsedEntries()
+    {
+        HttpClient client = fx.Factory.CreateClient(); // no auth header — endpoint is anonymous
+        List<ChangelogEntry>? entries = await client.GetFromJsonAsync<List<ChangelogEntry>>("/api/changelog");
+
+        Assert.NotNull(entries);
+        Assert.NotEmpty(entries!); // the real CHANGELOG.md has at least an [Unreleased] section
+    }
+}

--- a/HurrahTv.Api.Tests/FeedbackEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/FeedbackEndpointsTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Http.Json;
+using HurrahTv.Api.Services;
+using HurrahTv.Shared.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HurrahTv.Api.Tests;
+
+// #19 Phase 2 — feedback submit (auth + honeypot + validation) and admin read. Each test uses a
+// distinct user id, so the per-user rate limit (5/5min) never trips across the suite.
+[Collection("postgres")]
+public class FeedbackEndpointsTests(PostgresFixture fx) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fx.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DbService Db => fx.Factory.Services.GetRequiredService<DbService>();
+
+    [Fact]
+    public async Task DbRoundTrip_Submit_Then_GetFeedback_ReturnsIt()
+    {
+        await Db.SubmitFeedbackAsync("fb-user", "bug", "it broke", "me@example.com");
+
+        List<FeedbackItem> all = await Db.GetFeedbackAsync();
+        FeedbackItem? item = all.FirstOrDefault(f => f.UserId == "fb-user");
+        Assert.NotNull(item);
+        Assert.Equal("bug", item!.Category);
+        Assert.Equal("it broke", item.Message);
+        Assert.Equal("me@example.com", item.ContactEmail);
+        Assert.Null(item.Phone); // no Users row → LEFT JOIN yields null, query still returns the row
+    }
+
+    [Fact]
+    public async Task Post_ValidFeedback_StoresIt()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "http-fb-user");
+        HttpResponseMessage res = await client.PostAsJsonAsync("/api/feedback",
+            new FeedbackSubmission { Category = "feature", Message = "add a dark mode toggle" });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+
+        List<FeedbackItem> all = await Db.GetFeedbackAsync();
+        Assert.Contains(all, f => f.UserId == "http-fb-user" && f.Message == "add a dark mode toggle" && f.Category == "feature");
+    }
+
+    [Fact]
+    public async Task Post_HoneypotFilled_DroppedSilently()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "bot-user");
+        HttpResponseMessage res = await client.PostAsJsonAsync("/api/feedback",
+            new FeedbackSubmission { Category = "general", Message = "spam", Website = "http://spam.example" });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode); // 200 so the bot can't tell it was filtered
+
+        List<FeedbackItem> all = await Db.GetFeedbackAsync();
+        Assert.DoesNotContain(all, f => f.UserId == "bot-user"); // ...but nothing was stored
+    }
+
+    [Fact]
+    public async Task Post_EmptyMessage_BadRequest()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "empty-user");
+        HttpResponseMessage res = await client.PostAsJsonAsync("/api/feedback",
+            new FeedbackSubmission { Category = "bug", Message = "   " });
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UnknownCategory_FallsBackToGeneral()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "cat-user");
+        await client.PostAsJsonAsync("/api/feedback",
+            new FeedbackSubmission { Category = "totally-made-up", Message = "hello" });
+
+        List<FeedbackItem> all = await Db.GetFeedbackAsync();
+        FeedbackItem? item = all.FirstOrDefault(f => f.UserId == "cat-user");
+        Assert.NotNull(item);
+        Assert.Equal("general", item!.Category); // never reject real feedback over a bad label
+    }
+
+    [Fact]
+    public async Task AdminFeedback_RejectsNonAdmin()
+    {
+        HttpClient client = TestAuth.CreateClient(fx, "non-admin-user");
+        HttpResponseMessage res = await client.GetAsync("/api/admin/feedback");
+        Assert.Equal(HttpStatusCode.Forbidden, res.StatusCode);
+    }
+}

--- a/HurrahTv.Api.Tests/FeedbackEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/FeedbackEndpointsTests.cs
@@ -83,4 +83,18 @@ public class FeedbackEndpointsTests(PostgresFixture fx) : IAsyncLifetime
         HttpResponseMessage res = await client.GetAsync("/api/admin/feedback");
         Assert.Equal(HttpStatusCode.Forbidden, res.StatusCode);
     }
+
+    // #225 (xreview): deleting a user must also remove their feedback — the Feedback table was
+    // added in #19 but the DeleteUserAsync cascade didn't include it, orphaning rows in the admin view.
+    [Fact]
+    public async Task DeleteUser_AlsoRemovesTheirFeedback_PinsIssue225()
+    {
+        string userId = await Db.GetOrCreateUserAsync("+15555550199");
+        await Db.SubmitFeedbackAsync(userId, "bug", "should be deleted with the user", null);
+        Assert.Contains(await Db.GetFeedbackAsync(), f => f.UserId == userId);
+
+        Assert.True(await Db.DeleteUserAsync(userId));
+
+        Assert.DoesNotContain(await Db.GetFeedbackAsync(), f => f.UserId == userId);
+    }
 }

--- a/HurrahTv.Api.Tests/SeoEndpointsTests.cs
+++ b/HurrahTv.Api.Tests/SeoEndpointsTests.cs
@@ -1,0 +1,43 @@
+using HurrahTv.Api.Endpoints;
+
+namespace HurrahTv.Api.Tests;
+
+// pins #11 — the prod/staging robots gate. Getting this wrong means search engines index staging
+// (duplicate content + leaked unreleased features), the exact mistake the issue calls out.
+// Pure helpers, so no WebApplicationFactory / Postgres needed.
+public class SeoEndpointsTests
+{
+    [Theory]
+    [InlineData("hurrah.tv")]
+    [InlineData("www.hurrah.tv")]
+    [InlineData("HURRAH.TV")] // host comparison is case-insensitive
+    public void Robots_ProductionHost_AllowsAndReferencesSitemap(string host)
+    {
+        string robots = SeoEndpoints.BuildRobotsTxt(host);
+        Assert.Contains("Allow: /", robots);
+        Assert.Contains("Sitemap: https://hurrah.tv/sitemap.xml", robots);
+        Assert.DoesNotContain("Disallow: /", robots);
+    }
+
+    [Theory]
+    [InlineData("staging.hurrah.tv")]
+    [InlineData("hurrahtv-api-staging.azurewebsites.net")]
+    [InlineData("hurrahtv-api.azurewebsites.net")] // raw prod slot hostname stays unindexed — only the custom domain is
+    [InlineData("localhost")]
+    public void Robots_NonProductionHost_BlocksAll(string host)
+    {
+        string robots = SeoEndpoints.BuildRobotsTxt(host);
+        Assert.Contains("Disallow: /", robots);
+        Assert.DoesNotContain("Allow: /", robots);
+        Assert.DoesNotContain("Sitemap:", robots);
+    }
+
+    [Fact]
+    public void Sitemap_ListsCanonicalHomepage_AndIsWellFormed()
+    {
+        string xml = SeoEndpoints.BuildSitemapXml();
+        Assert.StartsWith("<?xml", xml);
+        Assert.Contains("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">", xml);
+        Assert.Contains("<loc>https://hurrah.tv/</loc>", xml);
+    }
+}

--- a/HurrahTv.Api.Tests/UserSettingsChangelogVersionTests.cs
+++ b/HurrahTv.Api.Tests/UserSettingsChangelogVersionTests.cs
@@ -1,0 +1,49 @@
+using HurrahTv.Api.Services;
+using HurrahTv.Shared.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HurrahTv.Api.Tests;
+
+// #19 Phase 1 — the new LastSeenChangelogVersion column must round-trip through
+// Get/SaveUserSettingsAsync (it drives the new-feature alert banner's "have I seen this?" check),
+// and widening the SELECT/INSERT must not regress the existing settings columns.
+[Collection("postgres")]
+public class UserSettingsChangelogVersionTests(PostgresFixture fx) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fx.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task LastSeenChangelogVersion_RoundTrips()
+    {
+        DbService db = fx.Factory.Services.GetRequiredService<DbService>();
+
+        UserSettings fresh = await db.GetUserSettingsAsync("changelog-user");
+        Assert.Null(fresh.LastSeenChangelogVersion); // never seen → null
+
+        fresh.LastSeenChangelogVersion = "2026-06-25";
+        await db.SaveUserSettingsAsync("changelog-user", fresh);
+
+        UserSettings reloaded = await db.GetUserSettingsAsync("changelog-user");
+        Assert.Equal("2026-06-25", reloaded.LastSeenChangelogVersion);
+    }
+
+    [Fact]
+    public async Task Widening_DoesNotRegress_ExistingSettings()
+    {
+        DbService db = fx.Factory.Services.GetRequiredService<DbService>();
+
+        UserSettings settings = new()
+        {
+            EnglishOnly = true,
+            WatchlistSort = "sentiment",
+            LastSeenChangelogVersion = null
+        };
+        await db.SaveUserSettingsAsync("changelog-user-2", settings);
+
+        UserSettings reloaded = await db.GetUserSettingsAsync("changelog-user-2");
+        Assert.Null(reloaded.LastSeenChangelogVersion);
+        Assert.True(reloaded.EnglishOnly);
+        Assert.Equal("sentiment", reloaded.WatchlistSort);
+    }
+}

--- a/HurrahTv.Api/Endpoints/ChangelogEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/ChangelogEndpoints.cs
@@ -1,0 +1,31 @@
+using HurrahTv.Shared.Changelog;
+using HurrahTv.Shared.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace HurrahTv.Api.Endpoints;
+
+// serves the parsed CHANGELOG.md (#19). Anonymous (no PII) and memory-cached — the content is
+// embedded in the assembly, so it only changes on deploy.
+public static class ChangelogEndpoints
+{
+    private const string CacheKey = "changelog:entries";
+
+    public static void MapChangelogEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/changelog", (IMemoryCache cache) =>
+        {
+            IReadOnlyList<ChangelogEntry> entries =
+                cache.GetOrCreate(CacheKey, _ => ChangelogParser.Parse(ReadEmbeddedChangelog()))!;
+            return Results.Ok(entries);
+        }).AllowAnonymous();
+    }
+
+    private static string ReadEmbeddedChangelog()
+    {
+        using Stream? stream = typeof(ChangelogEndpoints).Assembly.GetManifestResourceStream("CHANGELOG.md");
+        if (stream is null)
+            return "";
+        using StreamReader reader = new(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/HurrahTv.Api/Endpoints/FeedbackEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/FeedbackEndpoints.cs
@@ -1,0 +1,54 @@
+using System.Security.Claims;
+using HurrahTv.Api.Services;
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Api.Endpoints;
+
+// in-app feedback (#19): an authenticated, rate-limited, honeypot-guarded submit endpoint that
+// stores to the Feedback table, plus an admin-only list read. GetUserId() (HurrahTv.Api) is in
+// scope via the parent namespace.
+public static class FeedbackEndpoints
+{
+    public const string RateLimitPolicy = "feedback";
+
+    private static readonly HashSet<string> AllowedCategories =
+        new(StringComparer.OrdinalIgnoreCase) { "bug", "feature", "general" };
+
+    private const int MaxMessageLength = 4000;
+    private const int MaxEmailLength = 255;
+
+    public static void MapFeedbackEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/feedback", async (FeedbackSubmission submission, ClaimsPrincipal user, DbService db) =>
+        {
+            // honeypot: real users never fill the hidden Website field. If it's set, accept-and-drop —
+            // return 200 so a bot can't tell a filtered submission from a stored one.
+            if (!string.IsNullOrWhiteSpace(submission.Website))
+                return Results.Ok();
+
+            string message = (submission.Message ?? "").Trim();
+            if (message.Length == 0)
+                return Results.BadRequest("Message is required");
+            if (message.Length > MaxMessageLength)
+                message = message[..MaxMessageLength];
+
+            // unknown/empty category falls back to "general" rather than 400 — never reject real feedback over a label
+            string category = AllowedCategories.Contains(submission.Category ?? "")
+                ? submission.Category!.ToLowerInvariant()
+                : "general";
+
+            string? email = string.IsNullOrWhiteSpace(submission.ContactEmail) ? null : submission.ContactEmail.Trim();
+            if (email is { Length: > MaxEmailLength })
+                email = email[..MaxEmailLength];
+
+            await db.SubmitFeedbackAsync(user.GetUserId(), category, message, email);
+            return Results.Ok();
+        })
+        .RequireAuthorization()
+        .RequireRateLimiting(RateLimitPolicy);
+
+        app.MapGet("/api/admin/feedback", async (DbService db) =>
+            Results.Ok(await db.GetFeedbackAsync()))
+        .RequireAuthorization("Admin");
+    }
+}

--- a/HurrahTv.Api/Endpoints/FeedbackEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/FeedbackEndpoints.cs
@@ -11,9 +11,6 @@ public static class FeedbackEndpoints
 {
     public const string RateLimitPolicy = "feedback";
 
-    private static readonly HashSet<string> AllowedCategories =
-        new(StringComparer.OrdinalIgnoreCase) { "bug", "feature", "general" };
-
     private const int MaxMessageLength = 4000;
     private const int MaxEmailLength = 255;
 
@@ -32,10 +29,10 @@ public static class FeedbackEndpoints
             if (message.Length > MaxMessageLength)
                 message = message[..MaxMessageLength];
 
-            // unknown/empty category falls back to "general" rather than 400 — never reject real feedback over a label
-            string category = AllowedCategories.Contains(submission.Category ?? "")
+            // unknown/empty category falls back to General rather than 400 — never reject real feedback over a label
+            string category = FeedbackCategories.All.Contains(submission.Category ?? "", StringComparer.OrdinalIgnoreCase)
                 ? submission.Category!.ToLowerInvariant()
-                : "general";
+                : FeedbackCategories.General;
 
             string? email = string.IsNullOrWhiteSpace(submission.ContactEmail) ? null : submission.ContactEmail.Trim();
             if (email is { Length: > MaxEmailLength })

--- a/HurrahTv.Api/Endpoints/SeoEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/SeoEndpoints.cs
@@ -1,0 +1,45 @@
+namespace HurrahTv.Api.Endpoints;
+
+// robots.txt + sitemap.xml for #11. The single deployment is served from both the production
+// custom domain (hurrah.tv) and the staging slot (staging.hurrah.tv / *.azurewebsites.net), so a
+// static file can't differ per environment — robots.txt is generated per-request from the Host.
+// Only hurrah.tv is indexable; staging and the raw slot hostnames must return Disallow so search
+// engines don't index staging (duplicate content + leaked unreleased features) — the gate is the
+// load-bearing correctness here.
+public static class SeoEndpoints
+{
+    private const string ProductionHost = "hurrah.tv";
+    private const string CanonicalBaseUrl = "https://hurrah.tv";
+
+    public static void MapSeoEndpoints(this WebApplication app)
+    {
+        app.MapGet("/robots.txt", (HttpContext ctx) =>
+            Results.Text(BuildRobotsTxt(ctx.Request.Host.Host), "text/plain")).AllowAnonymous();
+
+        app.MapGet("/sitemap.xml", () =>
+            Results.Text(BuildSitemapXml(), "application/xml")).AllowAnonymous();
+    }
+
+    // only the canonical custom domain is indexable — NOT www, the staging subdomain, the raw
+    // *.azurewebsites.net slot hostnames, or localhost. (We don't bind www, but guard it anyway.)
+    public static bool IsProductionHost(string host) =>
+        string.Equals(host, ProductionHost, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(host, "www." + ProductionHost, StringComparison.OrdinalIgnoreCase);
+
+    public static string BuildRobotsTxt(string host) =>
+        IsProductionHost(host)
+            ? $"User-agent: *\nAllow: /\nSitemap: {CanonicalBaseUrl}/sitemap.xml\n"
+            : "User-agent: *\nDisallow: /\n";
+
+    // the app is auth-gated (Home and every watchlist route are [Authorize]), so the only publicly
+    // indexable surface is the canonical landing page. Listing auth-gated SPA routes would just feed
+    // crawlers the WASM shell, not real content — so the sitemap is deliberately the homepage only.
+    public static string BuildSitemapXml() =>
+        $"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>{CanonicalBaseUrl}/</loc></url>
+        </urlset>
+
+        """;
+}

--- a/HurrahTv.Api/Endpoints/SeoEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/SeoEndpoints.cs
@@ -1,9 +1,9 @@
 namespace HurrahTv.Api.Endpoints;
 
-// robots.txt + sitemap.xml for #11. The single deployment is served from both the production
+// robots.txt + sitemap.xml for #11. the single deployment is served from both the production
 // custom domain (hurrah.tv) and the staging slot (staging.hurrah.tv / *.azurewebsites.net), so a
 // static file can't differ per environment — robots.txt is generated per-request from the Host.
-// Only hurrah.tv is indexable; staging and the raw slot hostnames must return Disallow so search
+// only hurrah.tv is indexable; staging and the raw slot hostnames must return Disallow so search
 // engines don't index staging (duplicate content + leaked unreleased features) — the gate is the
 // load-bearing correctness here.
 public static class SeoEndpoints

--- a/HurrahTv.Api/Endpoints/SeoEndpoints.cs
+++ b/HurrahTv.Api/Endpoints/SeoEndpoints.cs
@@ -8,9 +8,6 @@ namespace HurrahTv.Api.Endpoints;
 // load-bearing correctness here.
 public static class SeoEndpoints
 {
-    private const string ProductionHost = "hurrah.tv";
-    private const string CanonicalBaseUrl = "https://hurrah.tv";
-
     public static void MapSeoEndpoints(this WebApplication app)
     {
         app.MapGet("/robots.txt", (HttpContext ctx) =>
@@ -20,15 +17,11 @@ public static class SeoEndpoints
             Results.Text(BuildSitemapXml(), "application/xml")).AllowAnonymous();
     }
 
-    // only the canonical custom domain is indexable — NOT www, the staging subdomain, the raw
-    // *.azurewebsites.net slot hostnames, or localhost. (We don't bind www, but guard it anyway.)
-    public static bool IsProductionHost(string host) =>
-        string.Equals(host, ProductionHost, StringComparison.OrdinalIgnoreCase)
-        || string.Equals(host, "www." + ProductionHost, StringComparison.OrdinalIgnoreCase);
-
+    // only the canonical custom domain (PublicSite.IsProductionHost) is indexable — staging, the raw
+    // *.azurewebsites.net slot hostnames, and localhost get Disallow.
     public static string BuildRobotsTxt(string host) =>
-        IsProductionHost(host)
-            ? $"User-agent: *\nAllow: /\nSitemap: {CanonicalBaseUrl}/sitemap.xml\n"
+        PublicSite.IsProductionHost(host)
+            ? $"User-agent: *\nAllow: /\nSitemap: {PublicSite.Origin}/sitemap.xml\n"
             : "User-agent: *\nDisallow: /\n";
 
     // the app is auth-gated (Home and every watchlist route are [Authorize]), so the only publicly
@@ -38,7 +31,7 @@ public static class SeoEndpoints
         $"""
         <?xml version="1.0" encoding="UTF-8"?>
         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-          <url><loc>{CanonicalBaseUrl}/</loc></url>
+          <url><loc>{PublicSite.Origin}/</loc></url>
         </urlset>
 
         """;

--- a/HurrahTv.Api/HurrahTv.Api.csproj
+++ b/HurrahTv.Api/HurrahTv.Api.csproj
@@ -24,4 +24,10 @@
     <ProjectReference Include="..\HurrahTv.Shared\HurrahTv.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- embed the repo-root CHANGELOG.md so /api/changelog (#19) serves it with no content-root
+         path dependency that could break across deploy layouts. LogicalName pins the manifest name. -->
+    <EmbeddedResource Include="..\CHANGELOG.md" LogicalName="CHANGELOG.md" />
+  </ItemGroup>
+
 </Project>

--- a/HurrahTv.Api/Middleware/OgPreviewMiddleware.cs
+++ b/HurrahTv.Api/Middleware/OgPreviewMiddleware.cs
@@ -19,7 +19,7 @@ public sealed class OgPreviewMiddleware(RequestDelegate next)
     // canonical production origin — used in og:url even when the request hit
     // staging.hurrah.tv, so a shared link from a staging session still resolves
     // to the prod card on the next crawl
-    private const string PublicBaseUrl = "https://hurrah.tv";
+    private const string PublicBaseUrl = PublicSite.Origin;
 
     private static readonly string[] BotUaMarkers =
     [

--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -154,6 +154,20 @@ builder.Services.AddRateLimiter(options =>
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0
             }));
+
+    // per-user limit on feedback submissions (#19) — the endpoint is authenticated, so partition on
+    // the user's sub claim (fall back to client IP for the brief pre-auth window so the factory can't
+    // throw on a missing claim, unlike GetUserId()).
+    options.AddPolicy(FeedbackEndpoints.RateLimitPolicy, httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.User.FindFirst("sub")?.Value
+                ?? TelemetryEndpoints.ResolveClientIp(httpContext),
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 5,
+                Window = TimeSpan.FromMinutes(5),
+                QueueLimit = 0
+            }));
 });
 
 WebApplication app = builder.Build();
@@ -243,6 +257,7 @@ app.MapAdminEndpoints();
 app.MapProfileEndpoints();
 app.MapTelemetryEndpoints();
 app.MapSeoEndpoints();
+app.MapFeedbackEndpoints();
 
 // health check + version (buildVersion computed above, near the App Insights registration)
 app.MapGet("/api/health", () => Results.Ok(new { status = "ok", time = DateTime.UtcNow })).AllowAnonymous();

--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -242,6 +242,7 @@ app.MapCurationEndpoints();
 app.MapAdminEndpoints();
 app.MapProfileEndpoints();
 app.MapTelemetryEndpoints();
+app.MapSeoEndpoints();
 
 // health check + version (buildVersion computed above, near the App Insights registration)
 app.MapGet("/api/health", () => Results.Ok(new { status = "ok", time = DateTime.UtcNow })).AllowAnonymous();

--- a/HurrahTv.Api/Program.cs
+++ b/HurrahTv.Api/Program.cs
@@ -258,6 +258,7 @@ app.MapProfileEndpoints();
 app.MapTelemetryEndpoints();
 app.MapSeoEndpoints();
 app.MapFeedbackEndpoints();
+app.MapChangelogEndpoints();
 
 // health check + version (buildVersion computed above, near the App Insights registration)
 app.MapGet("/api/health", () => Results.Ok(new { status = "ok", time = DateTime.UtcNow })).AllowAnonymous();

--- a/HurrahTv.Api/PublicSite.cs
+++ b/HurrahTv.Api/PublicSite.cs
@@ -1,0 +1,15 @@
+namespace HurrahTv.Api;
+
+// the canonical public production origin, shared by the SEO endpoints (robots/sitemap indexing
+// gate, #11) and the OG-preview middleware (og:url, #98) so the host can't drift between them.
+public static class PublicSite
+{
+    public const string Host = "hurrah.tv";
+    public const string Origin = "https://" + Host;
+
+    // only the canonical custom domain is "production" — NOT www, the staging subdomain, the raw
+    // *.azurewebsites.net slot hostnames, or localhost. (We don't bind www, but guard it anyway.)
+    public static bool IsProductionHost(string host) =>
+        string.Equals(host, Host, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(host, "www." + Host, StringComparison.OrdinalIgnoreCase);
+}

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -172,6 +172,17 @@ public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
                 PRIMARY KEY (UserId, TmdbId, Season, Episode)
             );
 
+            -- in-app user feedback (#19) — read in the admin view
+            CREATE TABLE IF NOT EXISTS Feedback (
+                Id           INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                UserId       VARCHAR(50)  NOT NULL,
+                Category     VARCHAR(30)  NOT NULL,
+                Message      TEXT         NOT NULL,
+                ContactEmail VARCHAR(255) NULL,
+                CreatedAt    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+            );
+            CREATE INDEX IF NOT EXISTS IX_Feedback_CreatedAt ON Feedback(CreatedAt DESC);
+
             -- specific episode numbers for latest aired and next upcoming
             ALTER TABLE QueueItems ADD COLUMN IF NOT EXISTS LatestEpisodeSeason INT NULL;
             ALTER TABLE QueueItems ADD COLUMN IF NOT EXISTS LatestEpisodeNumber INT NULL;
@@ -187,6 +198,9 @@ public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
             ALTER TABLE UserSettings ADD COLUMN IF NOT EXISTS ShowFinished    BOOL NOT NULL DEFAULT TRUE;
             ALTER TABLE UserSettings ADD COLUMN IF NOT EXISTS WatchlistSort   VARCHAR(20) NOT NULL DEFAULT 'date';
             ALTER TABLE UserSettings ADD COLUMN IF NOT EXISTS MediaType       VARCHAR(10) NOT NULL DEFAULT 'all';
+
+            -- last changelog version the user has seen — drives the new-feature alert banner (#19)
+            ALTER TABLE UserSettings ADD COLUMN IF NOT EXISTS LastSeenChangelogVersion VARCHAR(50) NULL;
 
             -- admin role on users (managed in-app once seeded)
             ALTER TABLE Users ADD COLUMN IF NOT EXISTS IsAdmin BOOLEAN NOT NULL DEFAULT FALSE;
@@ -826,7 +840,7 @@ public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
     {
         using NpgsqlConnection db = await OpenAsync(cancellationToken);
         CommandDefinition cmd = new(
-            "SELECT EnglishOnly, ShowWatching, ShowWantToWatch, ShowFinished, WatchlistSort, MediaType FROM UserSettings WHERE UserId = @UserId",
+            "SELECT EnglishOnly, ShowWatching, ShowWantToWatch, ShowFinished, WatchlistSort, MediaType, LastSeenChangelogVersion FROM UserSettings WHERE UserId = @UserId",
             new { UserId = userId }, cancellationToken: cancellationToken);
         UserSettings? settings = await db.QuerySingleOrDefaultAsync<UserSettings>(cmd);
         return settings ?? new UserSettings();
@@ -836,15 +850,16 @@ public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
     {
         using NpgsqlConnection db = await OpenAsync();
         await db.ExecuteAsync("""
-            INSERT INTO UserSettings (UserId, EnglishOnly, ShowWatching, ShowWantToWatch, ShowFinished, WatchlistSort, MediaType)
-            VALUES (@UserId, @EnglishOnly, @ShowWatching, @ShowWantToWatch, @ShowFinished, @WatchlistSort, @MediaType)
+            INSERT INTO UserSettings (UserId, EnglishOnly, ShowWatching, ShowWantToWatch, ShowFinished, WatchlistSort, MediaType, LastSeenChangelogVersion)
+            VALUES (@UserId, @EnglishOnly, @ShowWatching, @ShowWantToWatch, @ShowFinished, @WatchlistSort, @MediaType, @LastSeenChangelogVersion)
             ON CONFLICT (UserId) DO UPDATE SET
-                EnglishOnly     = @EnglishOnly,
-                ShowWatching    = @ShowWatching,
-                ShowWantToWatch = @ShowWantToWatch,
-                ShowFinished    = @ShowFinished,
-                WatchlistSort   = @WatchlistSort,
-                MediaType       = @MediaType
+                EnglishOnly              = @EnglishOnly,
+                ShowWatching             = @ShowWatching,
+                ShowWantToWatch          = @ShowWantToWatch,
+                ShowFinished             = @ShowFinished,
+                WatchlistSort            = @WatchlistSort,
+                MediaType                = @MediaType,
+                LastSeenChangelogVersion = @LastSeenChangelogVersion
             """, new
         {
             UserId = userId,
@@ -853,7 +868,8 @@ public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
             settings.ShowWantToWatch,
             settings.ShowFinished,
             settings.WatchlistSort,
-            settings.MediaType
+            settings.MediaType,
+            settings.LastSeenChangelogVersion
         });
     }
 

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -873,6 +873,31 @@ public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
         });
     }
 
+    // feedback (#19)
+    public async Task SubmitFeedbackAsync(string userId, string category, string message, string? contactEmail)
+    {
+        using NpgsqlConnection db = await OpenAsync();
+        await db.ExecuteAsync("""
+            INSERT INTO Feedback (UserId, Category, Message, ContactEmail)
+            VALUES (@UserId, @Category, @Message, @ContactEmail)
+            """, new { UserId = userId, Category = category, Message = message, ContactEmail = contactEmail });
+    }
+
+    public async Task<List<FeedbackItem>> GetFeedbackAsync(CancellationToken cancellationToken = default)
+    {
+        using NpgsqlConnection db = await OpenAsync(cancellationToken);
+        // LEFT JOIN so feedback still lists if the user row was since removed; Phone helps an admin
+        // see who submitted without surfacing it anywhere else.
+        CommandDefinition cmd = new("""
+            SELECT F.Id, F.UserId, U.PhoneNumber AS Phone, F.Category, F.Message, F.ContactEmail, F.CreatedAt
+            FROM Feedback F
+            LEFT JOIN Users U ON U.Id = F.UserId
+            ORDER BY F.CreatedAt DESC
+            """, cancellationToken: cancellationToken);
+        IEnumerable<FeedbackItem> rows = await db.QueryAsync<FeedbackItem>(cmd);
+        return [.. rows];
+    }
+
     // watched episodes
     public async Task MarkEpisodeWatchedAsync(string userId, int tmdbId, int season, int episode)
     {

--- a/HurrahTv.Api/Services/DbService.cs
+++ b/HurrahTv.Api/Services/DbService.cs
@@ -966,6 +966,7 @@ public class DbService(NpgsqlDataSource dataSource, IConfiguration config)
         await db.ExecuteAsync("DELETE FROM WatchedEpisodes   WHERE UserId = @UserId", byUser, tx);
         await db.ExecuteAsync("DELETE FROM AIUsage           WHERE UserId = @UserId", byUser, tx);
         await db.ExecuteAsync("DELETE FROM CurationCache     WHERE UserId = @UserId", byUser, tx);
+        await db.ExecuteAsync("DELETE FROM Feedback          WHERE UserId = @UserId", byUser, tx);
         await db.ExecuteAsync("DELETE FROM OtpCodes          WHERE PhoneNumber = @Phone", new { Phone = phone }, tx);
         await db.ExecuteAsync("DELETE FROM Users             WHERE Id = @UserId", byUser, tx);
 

--- a/HurrahTv.Client/Components/NewFeatureAlertBanner.razor
+++ b/HurrahTv.Client/Components/NewFeatureAlertBanner.razor
@@ -29,11 +29,15 @@
             AuthenticationState state = await AuthProvider.GetAuthenticationStateAsync();
             if (state.User.Identity?.IsAuthenticated != true) return; // only for signed-in users
 
-            List<ChangelogEntry> entries = await Api.GetChangelogAsync();
-            _latest = ChangelogParser.LatestShippedVersion(entries);
+            // independent calls — run concurrently (this runs once, on MainLayout init)
+            Task<List<ChangelogEntry>> changelogTask = Api.GetChangelogAsync();
+            Task<UserSettings> settingsTask = Api.GetUserSettingsAsync();
+            await Task.WhenAll(changelogTask, settingsTask);
+
+            _latest = ChangelogParser.LatestShippedVersion(changelogTask.Result);
             if (_latest is null) return; // nothing shipped yet → never show
 
-            _settings = await Api.GetUserSettingsAsync();
+            _settings = settingsTask.Result;
             if (!string.Equals(_settings.LastSeenChangelogVersion, _latest, StringComparison.Ordinal))
                 _show = true;
         }

--- a/HurrahTv.Client/Components/NewFeatureAlertBanner.razor
+++ b/HurrahTv.Client/Components/NewFeatureAlertBanner.razor
@@ -1,0 +1,53 @@
+@inject ApiClient Api
+@inject Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider AuthProvider
+@using HurrahTv.Shared.Changelog
+
+@* Self-gating (#19): the banner decides its own visibility from the user's last-seen changelog
+   version vs the latest shipped one — no caller flag. Shows once until dismissed; dismissal
+   persists server-side in UserSettings so it follows the user across devices. *@
+@if (_show)
+{
+    <div class="fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 z-[65] bg-surface-100 border border-surface-200 shadow-lg rounded-full pl-4 pr-2 py-2 flex items-center gap-2 text-sm fade-in safe-area-bottom">
+        <span class="icon-[heroicons--sparkles] w-4 h-4 text-accent"></span>
+        <span class="text-white">New features</span>
+        <a href="/changelog" @onclick="MarkSeen" class="text-accent font-medium hover:underline">See what's changed</a>
+        <button @onclick="MarkSeen" aria-label="Dismiss" class="text-gray-500 hover:text-white ml-1">
+            <span class="icon-[heroicons--x-mark] w-4 h-4"></span>
+        </button>
+    </div>
+}
+
+@code {
+    private bool _show;
+    private UserSettings? _settings;
+    private string? _latest;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            AuthenticationState state = await AuthProvider.GetAuthenticationStateAsync();
+            if (state.User.Identity?.IsAuthenticated != true) return; // only for signed-in users
+
+            List<ChangelogEntry> entries = await Api.GetChangelogAsync();
+            _latest = ChangelogParser.LatestShippedVersion(entries);
+            if (_latest is null) return; // nothing shipped yet → never show
+
+            _settings = await Api.GetUserSettingsAsync();
+            if (!string.Equals(_settings.LastSeenChangelogVersion, _latest, StringComparison.Ordinal))
+                _show = true;
+        }
+        catch
+        {
+            // best-effort chrome — never let a failed fetch break the layout
+        }
+    }
+
+    private async Task MarkSeen()
+    {
+        _show = false;
+        if (_settings is null || _latest is null) return;
+        _settings.LastSeenChangelogVersion = _latest;
+        try { await Api.SetUserSettingsAsync(_settings); } catch { }
+    }
+}

--- a/HurrahTv.Client/Layout/MainLayout.razor
+++ b/HurrahTv.Client/Layout/MainLayout.razor
@@ -130,6 +130,7 @@
 
 <QuickActions />
 <UpdateBanner />
+<NewFeatureAlertBanner />
 <ToastHost />
 
 @code {

--- a/HurrahTv.Client/Pages/Admin.razor
+++ b/HurrahTv.Client/Pages/Admin.razor
@@ -43,6 +43,13 @@
                 </div>
                 <p class="text-sm text-gray-400">Signup funnel + completion rates.</p>
             </a>
+            <a href="/admin/feedback" class="block bg-surface-50 hover:bg-surface-100 rounded-xl p-4 md:p-6 transition-colors">
+                <div class="flex items-center gap-3 mb-2">
+                    <span class="icon-[heroicons--chat-bubble-left-right] w-5 h-5 text-accent"></span>
+                    <h2 class="text-lg font-semibold">Feedback</h2>
+                </div>
+                <p class="text-sm text-gray-400">User-submitted bugs, feature requests, and notes.</p>
+            </a>
         </div>
     }
 </div>

--- a/HurrahTv.Client/Pages/AdminFeedback.razor
+++ b/HurrahTv.Client/Pages/AdminFeedback.razor
@@ -1,0 +1,72 @@
+@page "/admin/feedback"
+@attribute [Authorize(Policy = "Admin")]
+@inject ApiClient Api
+
+<PageTitle>Admin · Feedback - Hurrah.tv</PageTitle>
+
+@* data-clarity-mask: feedback rows carry phone numbers + contact emails — keep all PII out of
+   Clarity session recordings (#63), mirroring AdminUsers. *@
+<div class="max-w-5xl mx-auto" data-clarity-mask="true">
+    <div class="flex items-center gap-3 mb-4 md:mb-6">
+        <a href="/admin" class="text-gray-400 hover:text-white transition-colors">
+            <span class="icon-[heroicons--chevron-left] w-5 h-5 inline-block align-text-bottom"></span>
+            Admin
+        </a>
+        <span class="text-gray-600">/</span>
+        <h1 class="text-xl md:text-2xl font-bold">Feedback</h1>
+    </div>
+
+    @if (_loading)
+    {
+        <div class="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin"></div>
+    }
+    else if (_items is null)
+    {
+        <div class="text-red-400">Could not load feedback.</div>
+    }
+    else if (_items.Count == 0)
+    {
+        <div class="bg-surface-50 rounded-xl p-6 text-gray-400 text-sm">No feedback yet.</div>
+    }
+    else
+    {
+        <div class="space-y-3">
+            @foreach (FeedbackItem f in _items)
+            {
+                <div class="bg-surface-50 rounded-xl p-4">
+                    <div class="flex items-center gap-2 mb-2 text-xs">
+                        <span class="@CategoryClass(f.Category) px-2 py-0.5 rounded uppercase font-medium">@f.Category</span>
+                        <span class="text-gray-500">@f.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</span>
+                        @if (!string.IsNullOrWhiteSpace(f.Phone))
+                        {
+                            <span class="text-gray-400">@PhoneHelpers.Format(f.Phone)</span>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(f.ContactEmail))
+                        {
+                            <a href="@($"mailto:{f.ContactEmail}")" class="text-accent hover:underline">@f.ContactEmail</a>
+                        }
+                    </div>
+                    <p class="text-sm text-white whitespace-pre-wrap break-words">@f.Message</p>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private bool _loading = true;
+    private List<FeedbackItem>? _items;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _items = await Api.GetAdminFeedbackAsync();
+        _loading = false;
+    }
+
+    private static string CategoryClass(string category) => category.ToLowerInvariant() switch
+    {
+        "bug" => "bg-red-500/20 text-red-300",
+        "feature" => "bg-accent/20 text-accent",
+        _ => "bg-surface-200 text-gray-300"
+    };
+}

--- a/HurrahTv.Client/Pages/Changelog.razor
+++ b/HurrahTv.Client/Pages/Changelog.razor
@@ -1,0 +1,52 @@
+@page "/changelog"
+@attribute [Authorize]
+@inject ApiClient Api
+
+<PageTitle>What's Changed - Hurrah.tv</PageTitle>
+
+<div class="max-w-2xl mx-auto">
+    <h1 class="text-xl md:text-2xl font-bold mb-4 md:mb-6">What's Changed</h1>
+
+    @if (_loading)
+    {
+        <div class="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin"></div>
+    }
+    else if (_entries.Count == 0)
+    {
+        <div class="bg-surface-50 rounded-xl p-6 text-gray-400 text-sm">Nothing here yet — check back soon.</div>
+    }
+    else
+    {
+        @foreach (ChangelogEntry entry in _entries)
+        {
+            <section class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4">
+                <h2 class="text-lg font-semibold mb-3">@DisplayVersion(entry.Version)</h2>
+                @foreach (ChangelogSection section in entry.Sections)
+                {
+                    <h3 class="text-xs uppercase tracking-wide text-gray-400 mt-3 mb-1">@section.Category</h3>
+                    <ul class="list-disc list-inside text-sm text-gray-200 space-y-1">
+                        @foreach (string item in section.Items)
+                        {
+                            <li>@item</li>
+                        }
+                    </ul>
+                }
+            </section>
+        }
+    }
+</div>
+
+@code {
+    private bool _loading = true;
+    private List<ChangelogEntry> _entries = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _entries = await Api.GetChangelogAsync();
+        _loading = false;
+    }
+
+    // "[Unreleased]" is dev-facing; show users something friendlier. Dated versions render as-is.
+    private static string DisplayVersion(string version) =>
+        version.Equals("Unreleased", StringComparison.OrdinalIgnoreCase) ? "Coming soon" : version;
+}

--- a/HurrahTv.Client/Pages/Feedback.razor
+++ b/HurrahTv.Client/Pages/Feedback.razor
@@ -59,7 +59,7 @@
 </div>
 
 @code {
-    private string _category = "general";
+    private string _category = FeedbackCategories.General;
     private string _message = "";
     private string _email = "";
     private string _website = ""; // honeypot — must stay empty

--- a/HurrahTv.Client/Pages/Feedback.razor
+++ b/HurrahTv.Client/Pages/Feedback.razor
@@ -1,0 +1,99 @@
+@page "/feedback"
+@attribute [Authorize]
+@inject ApiClient Api
+
+<PageTitle>Send Feedback - Hurrah.tv</PageTitle>
+
+<div class="max-w-2xl mx-auto">
+    <h1 class="text-xl md:text-2xl font-bold mb-4 md:mb-6">Send Feedback</h1>
+
+    @if (_sent)
+    {
+        <div class="bg-surface-50 rounded-xl p-6 text-center fade-in">
+            <span class="icon-[heroicons--check-circle] w-10 h-10 text-accent mx-auto block mb-3"></span>
+            <h2 class="text-lg font-semibold mb-1">Thanks — we got it</h2>
+            <p class="text-gray-400 text-sm mb-4">Your feedback helps make Hurrah.tv better.</p>
+            <button class="text-accent hover:underline text-sm" @onclick="Reset">Send more</button>
+        </div>
+    }
+    else
+    {
+        <div class="bg-surface-50 rounded-xl p-4 md:p-6">
+            <p class="text-gray-400 text-sm mb-4">Found a bug, want a feature, or just have a thought? Tell us.</p>
+
+            <label class="block text-sm font-medium mb-1">Type</label>
+            <select @bind="_category"
+                    class="w-full bg-surface-100 border border-surface-200 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent mb-4">
+                <option value="general">General</option>
+                <option value="bug">Bug</option>
+                <option value="feature">Feature request</option>
+            </select>
+
+            <label class="block text-sm font-medium mb-1">Message</label>
+            <textarea @bind="_message" @bind:event="oninput" rows="5" maxlength="4000"
+                      placeholder="What's on your mind?"
+                      class="w-full bg-surface-100 border border-surface-200 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent mb-1"></textarea>
+            <p class="text-xs text-gray-500 mb-4">@(_message?.Length ?? 0)/4000</p>
+
+            <label class="block text-sm font-medium mb-1">Email <span class="text-gray-500 font-normal">(optional, if you want a reply)</span></label>
+            <input type="email" @bind="_email" maxlength="255" placeholder="you@example.com"
+                   class="w-full bg-surface-100 border border-surface-200 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent mb-4" />
+
+            @* honeypot: positioned off-screen and hidden from assistive tech, so real users never fill
+               it. A non-empty value means a bot — the server silently drops it (FeedbackEndpoints). *@
+            <input type="text" @bind="_website" tabindex="-1" autocomplete="off" aria-hidden="true"
+                   class="absolute left-[-9999px] w-px h-px opacity-0" />
+
+            @if (_error)
+            {
+                <div class="text-red-400 text-sm mb-3">Couldn't send — check your connection and try again.</div>
+            }
+
+            <button class="bg-accent hover:bg-accent-light text-white font-semibold px-5 py-2 rounded-lg transition-colors disabled:opacity-40"
+                    disabled="@(_sending || string.IsNullOrWhiteSpace(_message))" @onclick="Submit">
+                @(_sending ? "Sending…" : "Send feedback")
+            </button>
+        </div>
+    }
+</div>
+
+@code {
+    private string _category = "general";
+    private string _message = "";
+    private string _email = "";
+    private string _website = ""; // honeypot — must stay empty
+    private bool _sending;
+    private bool _sent;
+    private bool _error;
+
+    private async Task Submit()
+    {
+        if (string.IsNullOrWhiteSpace(_message)) return;
+        _sending = true;
+        _error = false;
+        try
+        {
+            bool ok = await Api.SubmitFeedbackAsync(new FeedbackSubmission
+            {
+                Category = _category,
+                Message = _message,
+                ContactEmail = string.IsNullOrWhiteSpace(_email) ? null : _email,
+                Website = _website
+            });
+            if (ok) _sent = true;
+            else _error = true;
+        }
+        catch { _error = true; }
+        finally { _sending = false; }
+    }
+
+    private void Reset()
+    {
+        _category = "general";
+        _message = "";
+        _email = "";
+        _website = "";
+        _sent = false;
+        _error = false;
+    }
+}

--- a/HurrahTv.Client/Pages/Feedback.razor
+++ b/HurrahTv.Client/Pages/Feedback.razor
@@ -24,9 +24,10 @@
             <label class="block text-sm font-medium mb-1">Type</label>
             <select @bind="_category"
                     class="w-full bg-surface-100 border border-surface-200 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent mb-4">
-                <option value="general">General</option>
-                <option value="bug">Bug</option>
-                <option value="feature">Feature request</option>
+                @foreach (string cat in FeedbackCategories.All)
+                {
+                    <option value="@cat">@CategoryLabel(cat)</option>
+                }
             </select>
 
             <label class="block text-sm font-medium mb-1">Message</label>
@@ -89,11 +90,19 @@
 
     private void Reset()
     {
-        _category = "general";
+        _category = FeedbackCategories.General;
         _message = "";
         _email = "";
         _website = "";
         _sent = false;
         _error = false;
     }
+
+    // display labels for the shared category values (kept client-side — the wire form is the value)
+    private static string CategoryLabel(string category) => category switch
+    {
+        FeedbackCategories.Bug => "Bug",
+        FeedbackCategories.Feature => "Feature request",
+        _ => "General"
+    };
 }

--- a/HurrahTv.Client/Pages/Home.razor
+++ b/HurrahTv.Client/Pages/Home.razor
@@ -562,8 +562,9 @@ else
 
     private void ApplyWatchlistFilters(List<QueueItem> allItems)
     {
-        // Available Now (streamable today) and Available Later (streamable in next 14 days)
-        // are derived by a pure partition in HurrahTv.Shared — see WatchlistFilters.
+        // Available Now (streamable today) and Available Later (any upcoming episode in the
+        // window, any service — #214) are derived by a pure partition in HurrahTv.Shared — see
+        // WatchlistFilters.
         WatchlistFilters.Partition partition = WatchlistFilters.Apply(
             allItems,
             DateTime.UtcNow,

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -181,9 +181,11 @@
 
     private void OnEnglishOnlyChanged()
     {
-        // only EnglishOnly is editable here, but the settings PUT upserts the whole row —
-        // carry the other fields (home filters, sort, media type) from the loaded settings so
-        // toggling this doesn't reset them to defaults server-side.
+        // only EnglishOnly is editable here, but the settings PUT upserts the WHOLE row — carry
+        // every other field (home filters, sort, media type, last-seen changelog version) from the
+        // loaded settings so toggling this doesn't reset them server-side. Omitting
+        // LastSeenChangelogVersion here would null it and re-pop the new-feature banner
+        // (Learnings/partial-dto-put-full-row-upsert.md).
         _settings.EnglishOnly = _englishOnly;
         UserSettings snapshot = new()
         {
@@ -193,6 +195,7 @@
             ShowFinished = _settings.ShowFinished,
             WatchlistSort = _settings.WatchlistSort,
             MediaType = _settings.MediaType,
+            LastSeenChangelogVersion = _settings.LastSeenChangelogVersion,
         };
         _settingsSaver.Schedule(async () =>
         {

--- a/HurrahTv.Client/Pages/Settings.razor
+++ b/HurrahTv.Client/Pages/Settings.razor
@@ -90,6 +90,23 @@
         </button>
     </div>
 
+    <div class="bg-surface-50 rounded-xl p-4 md:p-6 mb-4 md:mb-6">
+        <h2 class="text-lg font-semibold mb-2">Help us improve</h2>
+        <p class="text-gray-400 text-sm mb-4">Tell us what's working and what's not — or see what's new.</p>
+        <div class="flex flex-wrap gap-3">
+            <a href="/feedback"
+               class="bg-accent hover:bg-accent-light text-white font-semibold px-4 py-2 rounded-lg transition-colors flex items-center gap-2">
+                <span class="icon-[heroicons--chat-bubble-left-right] w-4 h-4"></span>
+                Send feedback
+            </a>
+            <a href="/changelog"
+               class="border border-surface-200 text-gray-300 hover:text-white font-semibold px-4 py-2 rounded-lg transition-colors flex items-center gap-2">
+                <span class="icon-[heroicons--sparkles] w-4 h-4"></span>
+                What's changed
+            </a>
+        </div>
+    </div>
+
     <div class="bg-surface-50 rounded-xl p-4 md:p-6">
         <h2 class="text-lg font-semibold mb-2">About Hurrah.tv</h2>
         <p class="text-gray-400 text-sm">

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -252,12 +252,22 @@ public class ApiClient(HttpClient http)
         return response.IsSuccessStatusCode;
     }
 
-    public async Task<List<FeedbackItem>?> GetAdminFeedbackAsync(CancellationToken cancellationToken = default) =>
-        await _http.GetFromJsonAsync<List<FeedbackItem>>("api/admin/feedback", cancellationToken);
+    // returns null on failure (transient/non-2xx) — callers render their "couldn't load" state
+    // instead of GetFromJsonAsync throwing out of OnInitializedAsync (which leaves the page spinning).
+    public async Task<List<FeedbackItem>?> GetAdminFeedbackAsync(CancellationToken cancellationToken = default)
+    {
+        try { return await _http.GetFromJsonAsync<List<FeedbackItem>>("api/admin/feedback", cancellationToken); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch { return null; }
+    }
 
-    // changelog (#19)
-    public async Task<List<ChangelogEntry>> GetChangelogAsync(CancellationToken cancellationToken = default) =>
-        await _http.GetFromJsonAsync<List<ChangelogEntry>>("api/changelog", cancellationToken) ?? [];
+    // changelog (#19) — returns [] on failure for the same reason as GetAdminFeedbackAsync
+    public async Task<List<ChangelogEntry>> GetChangelogAsync(CancellationToken cancellationToken = default)
+    {
+        try { return await _http.GetFromJsonAsync<List<ChangelogEntry>>("api/changelog", cancellationToken) ?? []; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch { return []; }
+    }
 
     public async Task<HttpResponseMessage> DeleteUserAsync(string userId, CancellationToken cancellationToken = default) =>
         await _http.DeleteAsync($"api/admin/users/{userId}", cancellationToken);

--- a/HurrahTv.Client/Services/ApiClient.cs
+++ b/HurrahTv.Client/Services/ApiClient.cs
@@ -245,6 +245,20 @@ public class ApiClient(HttpClient http)
     public async Task<HttpResponseMessage> SetUserFirstNameAsync(string userId, string? firstName, CancellationToken cancellationToken = default) =>
         await _http.PutAsJsonAsync($"api/admin/users/{userId}/firstname", new AdminSetFirstNameRequest(firstName), cancellationToken);
 
+    // feedback (#19)
+    public async Task<bool> SubmitFeedbackAsync(FeedbackSubmission submission, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await _http.PostAsJsonAsync("api/feedback", submission, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<List<FeedbackItem>?> GetAdminFeedbackAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<List<FeedbackItem>>("api/admin/feedback", cancellationToken);
+
+    // changelog (#19)
+    public async Task<List<ChangelogEntry>> GetChangelogAsync(CancellationToken cancellationToken = default) =>
+        await _http.GetFromJsonAsync<List<ChangelogEntry>>("api/changelog", cancellationToken) ?? [];
+
     public async Task<HttpResponseMessage> DeleteUserAsync(string userId, CancellationToken cancellationToken = default) =>
         await _http.DeleteAsync($"api/admin/users/{userId}", cancellationToken);
 

--- a/HurrahTv.Client/wwwroot/css/app.css
+++ b/HurrahTv.Client/wwwroot/css/app.css
@@ -7,6 +7,7 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+    --color-red-300: oklch(80.8% 0.114 19.571);
     --color-red-400: oklch(70.4% 0.191 22.216);
     --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
@@ -62,6 +63,7 @@
     --text-4xl--line-height: calc(2.5 / 2.25);
     --text-5xl: 3rem;
     --text-5xl--line-height: 1;
+    --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
@@ -283,6 +285,12 @@
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
   }
+  .start {
+    inset-inline-start: var(--spacing);
+  }
+  .end {
+    inset-inline-end: var(--spacing);
+  }
   .-top-1 {
     top: calc(var(--spacing) * -1);
   }
@@ -346,6 +354,9 @@
   .left-4 {
     left: calc(var(--spacing) * 4);
   }
+  .left-\[-9999px\] {
+    left: -9999px;
+  }
   .isolate {
     isolation: isolate;
   }
@@ -357,6 +368,9 @@
   }
   .z-\[60\] {
     z-index: 60;
+  }
+  .z-\[65\] {
+    z-index: 65;
   }
   .z-\[70\] {
     z-index: 70;
@@ -563,6 +577,9 @@
   .h-full {
     height: 100%;
   }
+  .h-px {
+    height: 1px;
+  }
   .min-h-\[1\.25rem\] {
     min-height: 1.25rem;
   }
@@ -637,6 +654,9 @@
   }
   .w-full {
     width: 100%;
+  }
+  .w-px {
+    width: 1px;
   }
   .max-w-2xl {
     max-width: var(--container-2xl);
@@ -732,6 +752,12 @@
   .snap-start {
     scroll-snap-align: start;
   }
+  .list-inside {
+    list-style-position: inside;
+  }
+  .list-disc {
+    list-style-type: disc;
+  }
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
@@ -797,6 +823,13 @@
   }
   .gap-8 {
     gap: calc(var(--spacing) * 8);
+  }
+  .space-y-1 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+    }
   }
   .space-y-2 {
     :where(& > :not(:last-child)) {
@@ -1104,6 +1137,12 @@
       background-color: color-mix(in oklab, var(--color-pink-600) 30%, transparent);
     }
   }
+  .bg-red-500\/20 {
+    background-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-red-500) 20%, transparent);
+    }
+  }
   .bg-red-600\/20 {
     background-color: color-mix(in srgb, oklch(57.7% 0.245 27.325) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1232,6 +1271,9 @@
   .p-5 {
     padding: calc(var(--spacing) * 5);
   }
+  .p-6 {
+    padding: calc(var(--spacing) * 6);
+  }
   .p-8 {
     padding: calc(var(--spacing) * 8);
   }
@@ -1301,6 +1343,9 @@
   .pt-6 {
     padding-top: calc(var(--spacing) * 6);
   }
+  .pr-2 {
+    padding-right: calc(var(--spacing) * 2);
+  }
   .pr-4 {
     padding-right: calc(var(--spacing) * 4);
   }
@@ -1321,6 +1366,9 @@
   }
   .pb-24 {
     padding-bottom: calc(var(--spacing) * 24);
+  }
+  .pl-4 {
+    padding-left: calc(var(--spacing) * 4);
   }
   .pl-10 {
     padding-left: calc(var(--spacing) * 10);
@@ -1394,6 +1442,10 @@
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
   }
+  .font-normal {
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
@@ -1414,11 +1466,17 @@
     --tw-tracking: var(--tracking-widest);
     letter-spacing: var(--tracking-widest);
   }
+  .break-words {
+    overflow-wrap: break-word;
+  }
   .break-all {
     word-break: break-all;
   }
   .whitespace-nowrap {
     white-space: nowrap;
+  }
+  .whitespace-pre-wrap {
+    white-space: pre-wrap;
   }
   .text-accent {
     color: var(--color-accent);
@@ -1465,6 +1523,9 @@
   .text-pink-400 {
     color: var(--color-pink-400);
   }
+  .text-red-300 {
+    color: var(--color-red-300);
+  }
   .text-red-400 {
     color: var(--color-red-400);
   }
@@ -1479,6 +1540,9 @@
     @supports (color: color-mix(in lab, red, red)) {
       color: color-mix(in oklab, var(--color-yellow-500) 80%, transparent);
     }
+  }
+  .lowercase {
+    text-transform: lowercase;
   }
   .uppercase {
     text-transform: uppercase;

--- a/HurrahTv.Shared.Tests/ChangelogParserTests.cs
+++ b/HurrahTv.Shared.Tests/ChangelogParserTests.cs
@@ -1,0 +1,84 @@
+using HurrahTv.Shared.Changelog;
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Shared.Tests;
+
+// #19 Phase 4 — the CHANGELOG.md parser. Pinning the load-bearing cases: only `## [version]` are
+// releases, `[Unreleased]` is excluded from "latest shipped", and a plain `## Heading` (the
+// "Keeping this up to date" footer) doesn't leak its bullets into a release.
+public class ChangelogParserTests
+{
+    private const string Sample = """
+        # Changelog
+
+        Intro text, ignored.
+
+        ## [Unreleased]
+
+        ### Added
+        - Contributor onboarding
+        - 24 issues migrated
+
+        ### Changed
+        - Line endings normalized
+
+        ---
+
+        ## [2026-05-01]
+
+        ### Fixed
+        - Slow Details page
+
+        ## Keeping this up to date
+
+        - This bullet is NOT a release entry
+        """;
+
+    [Fact]
+    public void Parse_ReadsReleases_Sections_Items()
+    {
+        IReadOnlyList<ChangelogEntry> entries = ChangelogParser.Parse(Sample);
+
+        Assert.Equal(2, entries.Count); // Unreleased + dated; the footer heading is not a release
+        ChangelogEntry unreleased = entries[0];
+        Assert.Equal("Unreleased", unreleased.Version);
+        Assert.Equal(2, unreleased.Sections.Count);
+        Assert.Equal("Added", unreleased.Sections[0].Category);
+        Assert.Equal(2, unreleased.Sections[0].Items.Count);
+        Assert.Contains("Contributor onboarding", unreleased.Sections[0].Items);
+        Assert.Equal("Changed", unreleased.Sections[1].Category);
+    }
+
+    [Fact]
+    public void Parse_NonBracketedHeading_DoesNotLeakIntoPriorRelease()
+    {
+        IReadOnlyList<ChangelogEntry> entries = ChangelogParser.Parse(Sample);
+
+        Assert.DoesNotContain(entries, e => e.Version.Contains("Keeping"));
+        ChangelogEntry dated = entries.Single(e => e.Version == "2026-05-01");
+        Assert.Single(dated.Sections); // just "Fixed" — the footer bullet is not attached
+        Assert.DoesNotContain(dated.Sections.SelectMany(s => s.Items), i => i.Contains("NOT a release"));
+    }
+
+    [Fact]
+    public void LatestShippedVersion_SkipsUnreleased()
+    {
+        IReadOnlyList<ChangelogEntry> entries = ChangelogParser.Parse(Sample);
+        Assert.Equal("2026-05-01", ChangelogParser.LatestShippedVersion(entries));
+    }
+
+    [Fact]
+    public void LatestShippedVersion_NullWhenOnlyUnreleased()
+    {
+        IReadOnlyList<ChangelogEntry> entries = ChangelogParser.Parse("## [Unreleased]\n### Added\n- a thing\n");
+        Assert.Equal("Unreleased", Assert.Single(entries).Version);
+        Assert.Null(ChangelogParser.LatestShippedVersion(entries));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("# Changelog\n\nNo entries yet.")]
+    public void Parse_EmptyOrNoEntries_ReturnsEmpty(string markdown) =>
+        Assert.Empty(ChangelogParser.Parse(markdown));
+}

--- a/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
+++ b/HurrahTv.Shared.Tests/WatchlistFiltersTests.cs
@@ -242,7 +242,8 @@ public class WatchlistFiltersTests
     [Fact]
     public void AvailableLater_Excludes_NextEpisode_Beyond_Window()
     {
-        QueueItem item = TvItem(nextEpisode: Today.AddDays(15));
+        // beyond the 30-day window (#214 widened from 14) → excluded.
+        QueueItem item = TvItem(nextEpisode: Today.AddDays(31));
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
 
@@ -264,14 +265,17 @@ public class WatchlistFiltersTests
         Assert.DoesNotContain(item, result.AvailableNow);
     }
 
+    // #214: Available Later dropped the streamability gate — an upcoming episode on a service the
+    // user does NOT subscribe to (Hulu; user has only Netflix) must now surface. This test asserted
+    // the inverse before #214.
     [Fact]
-    public void AvailableLater_Excludes_NotStreamable()
+    public void AvailableLater_Includes_NonStreamable_UpcomingEpisode_PinsIssue214()
     {
         QueueItem item = TvItem(nextEpisode: Today.AddDays(3), providerId: Hulu);
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
 
-        Assert.DoesNotContain(item, result.AvailableLater);
+        Assert.Contains(item, result.AvailableLater);
     }
 
     [Fact]
@@ -432,16 +436,61 @@ public class WatchlistFiltersTests
         Assert.Contains(item, result.AvailableNow);
     }
 
-    // Available Later is a stronger claim — "available on a user service soon" — so it
-    // retains the strict streamability gate even for Watching items. Mirrors the plan's
-    // decision #4: the override is Available-Now-scoped, not blanket.
+    // #214 reverses the earlier "Later keeps the streamability gate" decision (was Available-Now-
+    // scoped only): Available Later is now the forward-looking radar for ANY show, so a Watching item
+    // with an upcoming episode on a non-subscribed service (Hulu; user has only Netflix) surfaces too.
     [Fact]
-    public void AvailableLater_Excludes_Watching_Item_With_NonStreamable_UpcomingEpisode()
+    public void AvailableLater_Includes_Watching_NonStreamable_UpcomingEpisode_PinsIssue214()
     {
         QueueItem item = TvItem(
             status: QueueStatus.Watching,
             nextEpisode: Today.AddDays(3),
             providerId: Hulu); // user only has Netflix
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableLater);
+    }
+
+    // #214: a user with ZERO configured services still sees Available Later populated. The old gate
+    // made IsStreamableOn return false for everything, emptying the row for service-less users.
+    [Fact]
+    public void AvailableLater_Includes_Upcoming_When_UserServices_Are_Empty_PinsIssue214()
+    {
+        QueueItem item = TvItem(nextEpisode: Today.AddDays(3));
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, userServices: []);
+
+        Assert.Contains(item, result.AvailableLater);
+    }
+
+    // #214 widened the window to 30 days — an episode on day 30 (inclusive upper bound) appears...
+    [Fact]
+    public void AvailableLater_Includes_NextEpisode_At_30Day_Boundary_PinsIssue214()
+    {
+        QueueItem item = TvItem(nextEpisode: Today.AddDays(30));
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableLater);
+    }
+
+    // ...and an episode 20 days out — beyond the OLD 14-day window — now surfaces where it didn't.
+    [Fact]
+    public void AvailableLater_Includes_NextEpisode_Beyond_Old_14Day_Window_PinsIssue214()
+    {
+        QueueItem item = TvItem(nextEpisode: Today.AddDays(20));
+        WatchlistFilters.Partition result = WatchlistFilters.Apply(
+            [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
+
+        Assert.Contains(item, result.AvailableLater);
+    }
+
+    // #214: dropping the streamability gate must NOT leak dismissed (NotForMe) shows into Later.
+    [Fact]
+    public void AvailableLater_Excludes_NotForMe_With_UpcomingEpisode_PinsIssue214()
+    {
+        QueueItem item = TvItem(status: QueueStatus.NotForMe, nextEpisode: Today.AddDays(3));
         WatchlistFilters.Partition result = WatchlistFilters.Apply(
             [item], Today, MediaTypes.All, AllStatusesActive, UserHasNetflix);
 

--- a/HurrahTv.Shared/Changelog/ChangelogParser.cs
+++ b/HurrahTv.Shared/Changelog/ChangelogParser.cs
@@ -1,0 +1,82 @@
+using HurrahTv.Shared.Models;
+
+namespace HurrahTv.Shared.Changelog;
+
+// parses a Keep-a-Changelog CHANGELOG.md into typed entries (#19). No markdown library — the
+// structure is regular. Only `## [version]` headers are releases; a plain `## Heading` (e.g.
+// "Keeping this up to date") closes the current release so its bullets aren't captured as content.
+public static class ChangelogParser
+{
+    public static IReadOnlyList<ChangelogEntry> Parse(string? markdown)
+    {
+        List<ChangelogEntry> entries = [];
+        if (string.IsNullOrWhiteSpace(markdown))
+            return entries;
+
+        string version = "";
+        bool inEntry = false;
+        List<ChangelogSection> sections = [];
+        string category = "";
+        List<string> items = [];
+
+        void FlushSection()
+        {
+            if (category.Length > 0 && items.Count > 0)
+                sections.Add(new ChangelogSection(category, items));
+            category = "";
+            items = [];
+        }
+
+        void FlushEntry()
+        {
+            FlushSection();
+            if (inEntry && sections.Count > 0)
+                entries.Add(new ChangelogEntry(version, sections));
+            sections = [];
+            inEntry = false;
+            version = "";
+        }
+
+        foreach (string raw in markdown.Replace("\r\n", "\n").Split('\n'))
+        {
+            string line = raw.Trim();
+
+            if (line.StartsWith("## "))
+            {
+                FlushEntry();
+                string head = line[3..].Trim();
+                if (head.StartsWith('[') && head.EndsWith(']'))
+                {
+                    version = head[1..^1].Trim();
+                    inEntry = true;
+                }
+                // a non-bracketed `## Heading` leaves inEntry false, so its content is skipped
+            }
+            else if (inEntry && line.StartsWith("### "))
+            {
+                FlushSection();
+                category = line[4..].Trim();
+            }
+            else if (inEntry && category.Length > 0 && line.StartsWith("- "))
+            {
+                items.Add(line[2..].Trim());
+            }
+        }
+
+        FlushEntry();
+        return entries;
+    }
+
+    // the newest *shipped* version — skips [Unreleased] (not yet released), so it drives the
+    // new-feature alert banner (#19). Entries are document order (Keep a Changelog lists newest
+    // first), so the first dated entry is the latest. Null when nothing has shipped yet.
+    public static string? LatestShippedVersion(IReadOnlyList<ChangelogEntry> entries)
+    {
+        foreach (ChangelogEntry e in entries)
+        {
+            if (!e.Version.Equals("Unreleased", StringComparison.OrdinalIgnoreCase))
+                return e.Version;
+        }
+        return null;
+    }
+}

--- a/HurrahTv.Shared/Filters/WatchlistFilters.cs
+++ b/HurrahTv.Shared/Filters/WatchlistFilters.cs
@@ -7,7 +7,8 @@ namespace HurrahTv.Shared.Filters;
 // would silently pass `is <= 7` and classify an unaired episode as already-available.
 public static class WatchlistFilters
 {
-    public const int AvailableLaterWindowDays = 14;
+    // forward window for Available Later — #214 widened 14 → 30. Single source of truth; tweak here only.
+    public const int AvailableLaterWindowDays = 30;
 
     public record Partition(
         List<QueueItem> AvailableNow,
@@ -54,7 +55,8 @@ public static class WatchlistFilters
 
             if (!isTv) continue;
 
-            // streamability parses AvailableOnJson — compute once and reuse for both rows below.
+            // streamability parses AvailableOnJson — used only by the Available Now gate below
+            // (Available Later no longer gates on it, #214).
             bool isStreamable = item.IsStreamableOn(userServices);
             bool isWatching = item.Status == QueueStatus.Watching;
 
@@ -104,11 +106,14 @@ public static class WatchlistFilters
                 }
             }
 
-            // Available Later also surfaces a strictly-future next episode within the window. It
-            // requires streamability — "available on a user service soon" is a stronger claim than
-            // Available Now's "you've committed to this". The addedToLater guard prevents adding an
-            // item twice when it both drops today (routed above) and has a next episode in-window.
-            if (!addedToLater && isStreamable
+            // Available Later also surfaces a strictly-future next episode within the window —
+            // regardless of streamability or status (#214). It's the user's "a new episode is coming
+            // on one of my shows" radar, so a premiere on a service the user doesn't subscribe to (or
+            // a user with zero services configured) must still appear. Contrast Available Now, which
+            // keeps the strict streamability gate — "later" is forward-looking, not "watchable now".
+            // The addedToLater guard prevents a double-add when an item both drops today (routed
+            // above) and has a next episode in-window.
+            if (!addedToLater
                 && item.NextEpisodeDate is { } next && next.Date > today && next.Date <= windowEnd)
             {
                 availableLater.Add(item);

--- a/HurrahTv.Shared/Models/ChangelogEntry.cs
+++ b/HurrahTv.Shared/Models/ChangelogEntry.cs
@@ -1,0 +1,8 @@
+namespace HurrahTv.Shared.Models;
+
+// a parsed CHANGELOG.md release (#19). Version is the bracketed header text — a date like
+// "2026-05-01" or "Unreleased". Sections group items under a Keep-a-Changelog category.
+public record ChangelogEntry(string Version, IReadOnlyList<ChangelogSection> Sections);
+
+// one category block within a release — e.g. Category "Added" with its bullet items.
+public record ChangelogSection(string Category, IReadOnlyList<string> Items);

--- a/HurrahTv.Shared/Models/FeedbackCategories.cs
+++ b/HurrahTv.Shared/Models/FeedbackCategories.cs
@@ -1,0 +1,14 @@
+namespace HurrahTv.Shared.Models;
+
+// the allowed feedback categories (#19), shared so the server's validation and the client's
+// <select> can't drift. These are the wire/storage values (lowercase); user-facing display labels
+// stay client-side (see Feedback.razor) per the shared-promotion-semantic-audit learning.
+public static class FeedbackCategories
+{
+    public const string General = "general";
+    public const string Bug = "bug";
+    public const string Feature = "feature";
+
+    // order drives the client dropdown; General first — it's also the server's safe fallback.
+    public static readonly IReadOnlyList<string> All = [General, Bug, Feature];
+}

--- a/HurrahTv.Shared/Models/FeedbackItem.cs
+++ b/HurrahTv.Shared/Models/FeedbackItem.cs
@@ -1,0 +1,12 @@
+namespace HurrahTv.Shared.Models;
+
+// one feedback row for the admin view (#19). Phone is joined from Users so an admin can see who
+// submitted; ContactEmail is the optional reply address the user chose to provide.
+public record FeedbackItem(
+    int Id,
+    string UserId,
+    string? Phone,
+    string Category,
+    string Message,
+    string? ContactEmail,
+    DateTime CreatedAt);

--- a/HurrahTv.Shared/Models/FeedbackSubmission.cs
+++ b/HurrahTv.Shared/Models/FeedbackSubmission.cs
@@ -1,8 +1,8 @@
 namespace HurrahTv.Shared.Models;
 
 // user-submitted feedback (#19). Category is validated server-side against the allowed set.
-// Website is a honeypot — hidden in the UI, so a non-empty value means a bot and the submission
-// is silently dropped (the server still returns success so bots can't tell they were filtered).
+// the Website field is a honeypot — hidden in the UI, so a non-empty value means a bot and the
+// submission is silently dropped (the server still returns success so bots can't tell).
 public class FeedbackSubmission
 {
     public string Category { get; set; } = "general"; // "bug" | "feature" | "general"

--- a/HurrahTv.Shared/Models/FeedbackSubmission.cs
+++ b/HurrahTv.Shared/Models/FeedbackSubmission.cs
@@ -1,0 +1,12 @@
+namespace HurrahTv.Shared.Models;
+
+// user-submitted feedback (#19). Category is validated server-side against the allowed set.
+// Website is a honeypot — hidden in the UI, so a non-empty value means a bot and the submission
+// is silently dropped (the server still returns success so bots can't tell they were filtered).
+public class FeedbackSubmission
+{
+    public string Category { get; set; } = "general"; // "bug" | "feature" | "general"
+    public string Message { get; set; } = "";
+    public string? ContactEmail { get; set; }
+    public string? Website { get; set; } // honeypot — real users leave this empty
+}

--- a/HurrahTv.Shared/Models/UserSettings.cs
+++ b/HurrahTv.Shared/Models/UserSettings.cs
@@ -14,4 +14,8 @@ public class UserSettings
 
     // global media type filter — tab in MainLayout, drives Home/Queue/Search
     public string MediaType { get; set; } = "all"; // "all" | "tv" | "movie"
+
+    // latest changelog version the user has dismissed/seen — drives the new-feature alert banner (#19).
+    // null = never seen (fresh user); the banner shows when this differs from the latest shipped version.
+    public string? LastSeenChangelogVersion { get; set; }
 }

--- a/Plans/19-feedback-changelog-alerts.md
+++ b/Plans/19-feedback-changelog-alerts.md
@@ -1,0 +1,111 @@
+# Feedback + Changelog + New-Feature Alerts (#19) — Implementation Plan
+
+> **Status:** Active
+> **Tracking issue:** mkerchenski/hurrah-tv#19
+
+## Context
+
+Today we have **zero structured signal from users** — bugs go unreported, feature requests die, and users
+get no sense the app is actively improving. #19 adds three connected pieces:
+1. **Feedback** — an in-app form (category / message / optional email) stored in the DB, readable in an admin view.
+2. **Changelog** — a `/changelog` page rendered from the existing repo-root `CHANGELOG.md` (Keep a Changelog format).
+3. **New-feature alert** — a dismissible banner when the latest shipped changelog entry is newer than what the user
+   has seen.
+
+Decisions already made: **build feedback in-app** (DB table + admin view, not a GitHub proxy); the changelog is
+**parsed into typed entries server-side** (no markdown library — the Keep-a-Changelog structure is regular).
+
+## Affected Projects
+
+| Project | Touched | Notes |
+|---|---|---|
+| HurrahTv.Api | yes | `Feedback` table + `UserSettings` column in `DbService.InitializeAsync`; `FeedbackEndpoints`, `ChangelogEndpoints`; admin feedback query |
+| HurrahTv.Client | yes | feedback form + admin page + `/changelog` page + alert banner + nav/settings entry points |
+| HurrahTv.Shared | yes | `FeedbackSubmission` DTO, `ChangelogEntry` DTO, pure `ChangelogParser`, `LastSeenChangelogVersion` on `UserSettings` |
+
+**DB schema changes:** additive only (expand/contract-safe for the shared-DB slot swap, per
+`Learnings/shared-db-slot-swaps-need-backward-compatible-migrations.md`) — a new `Feedback` table and a nullable
+`UserSettings.LastSeenChangelogVersion` column. Both via `IF NOT EXISTS` in `InitializeAsync`.
+**API contract:** new `/api/feedback`, `/api/admin/feedback`, `/api/changelog`; `UserSettings` DTO gains a field
+(ripples to both Api and Client — update the SELECT/INSERT in `DbService` get/save).
+
+---
+
+## Phase 1 — Schema + Shared DTOs (migration-first, independently committable)
+
+- `DbService.InitializeAsync`: add `Feedback` table (`Id` IDENTITY PK, `UserId`, `Category`, `Message`,
+  `ContactEmail` NULL, `CreatedAt TIMESTAMPTZ DEFAULT NOW()`) + `IX_Feedback_CreatedAt`; add
+  `ALTER TABLE UserSettings ADD COLUMN IF NOT EXISTS LastSeenChangelogVersion VARCHAR(50) NULL`
+  (mirror the existing `ADD COLUMN IF NOT EXISTS` block ~DbService.cs:185).
+- `HurrahTv.Shared/Models/UserSettings.cs`: add `string? LastSeenChangelogVersion`. Update `GetUserSettingsAsync`
+  / `SaveUserSettingsAsync` SELECT + upsert to carry it.
+- New Shared DTOs: `FeedbackSubmission` (Category, Message, ContactEmail?, plus a honeypot field — see Phase 2),
+  `ChangelogEntry` (Version/Date string, `IReadOnlyList<ChangelogSection>` where a section is Category + items).
+- **Tests:** Api.Tests — `UserSettings` round-trips `LastSeenChangelogVersion`. **Verify:** `dotnet test`.
+
+## Phase 2 — Feedback API + admin query (independently committable)
+
+- `FeedbackEndpoints.cs` (mirror `EpisodeEndpoints` POST shape): `POST /api/feedback` (`RequireAuthorization`,
+  `.RequireRateLimiting(<new per-user policy>)`) → validates, drops silently if the **honeypot** field is non-empty
+  (return 200 so bots can't distinguish), else `DbService.SubmitFeedbackAsync`. `GET /api/admin/feedback` on the
+  `/api/admin` group (`RequireAuthorization("Admin")`) → list newest-first.
+- `Program.cs`: add a `feedback` fixed-window rate-limit policy partitioned per user (mirror
+  `TelemetryEndpoints.RateLimitPolicy`, Program.cs:145-157).
+- `DbService`: `SubmitFeedbackAsync(userId, submission)` (INSERT) + `GetFeedbackAsync()` (admin SELECT).
+- **Tests:** Api.Tests — submit persists; honeypot-filled submission is dropped; rate limit triggers; admin list
+  returns; admin endpoint rejects non-admin. **Verify:** `dotnet test`.
+
+## Phase 3 — Feedback form + admin UI (Client; browser-verified)
+
+- Feedback form component (category `<select>`, message textarea, optional email, hidden honeypot input) →
+  `ApiClient.SubmitFeedbackAsync` → "thanks, we got it" confirmation. Entry point: "Send Feedback" in
+  `Settings.razor` (after the "Tell a friend" section ~line 84) + optionally desktop nav.
+- `AdminFeedback.razor` at `/admin/feedback` (`@attribute [Authorize(Policy = "Admin")]`, mirror `AdminUsers.razor`)
+  → `ApiClient.GetAdminFeedbackAsync`, list with category/message/time. Add to the admin nav.
+- **Tests:** none (Razor/UI). **Verify:** browser — submit feedback, see confirmation, see it in /admin/feedback.
+
+## Phase 4 — Changelog parser + endpoint + page (independently committable)
+
+- `HurrahTv.Shared`: pure `ChangelogParser.Parse(string markdown) → IReadOnlyList<ChangelogEntry>` — splits on
+  `## [version/date]` headers, `### Category` subsections, `- ` items. Skip `[Unreleased]` for the "latest shipped"
+  concept (it isn't released). Expose a `LatestShippedVersion(entries)` helper.
+- `HurrahTv.Api`: embed `CHANGELOG.md` as an `EmbeddedResource` in `HurrahTv.Api.csproj` (robust across deploy — no
+  content-root path dependency); `ChangelogEndpoints` `GET /api/changelog` (anonymous) reads the manifest stream,
+  parses, returns entries (cache in `IMemoryCache` — it only changes on deploy).
+- `HurrahTv.Client`: `/changelog` page renders entries with Razor (typed, no markdown rendering needed);
+  `ApiClient.GetChangelogAsync`. Entry point: "What's changed" link.
+- **Tests (REQUIRED — pure Shared logic per CLAUDE.md):** `ChangelogParser` — dated release parsed; `[Unreleased]`
+  excluded from latest-shipped; multiple categories/items; empty/malformed returns empty; latest-version extraction.
+  **Verify:** `dotnet test` + browser.
+
+## Phase 5 — New-feature alert banner (Client; browser-verified)
+
+- `NewFeatureAlertBanner.razor` mounted in `MainLayout.razor` (alongside `<UpdateBanner />`), mirroring
+  `UpdateBanner`/`InstallBanner` subscribe/dispose. Shows when `LatestShippedVersion` from `/api/changelog`
+  differs from `UserSettings.LastSeenChangelogVersion`. Dismiss → `PUT /api/settings` with
+  `LastSeenChangelogVersion = latest`; links to `/changelog`.
+- Self-gating per the CLAUDE.md preference (the banner decides its own visibility from settings + changelog, no
+  caller flag).
+- **Tests:** none (Razor/UI). **Verify:** browser — fresh user sees banner, dismiss persists across reload.
+
+---
+
+## API Considerations
+- `/api/feedback` is auth'd + rate-limited + honeypot-guarded; `/api/admin/feedback` uses `RequireAuthorization("Admin")`.
+- `/api/changelog` is anonymous (no PII) and memory-cached (content changes only on deploy).
+
+## Blazor WASM Considerations
+- Banner subscribes/disposes exactly like `UpdateBanner.razor` (IDisposable; unhook events/timers in `Dispose`).
+- Dismissal persists server-side in `UserSettings` (not localStorage) so it follows the user across devices.
+- Skeleton/placeholder not needed (banner is additive chrome); avoid CLS by reserving no layout until it decides to show.
+
+## Follow-on
+- After landing: append a `CHANGELOG.md` entry for #19 itself (dogfoods the feature) and `/compound` any parser gotchas.
+- Out of scope: emailing feedback, GitHub-proxy delivery (decided against), auto-generating changelog from commits.
+
+## Verification (end-to-end)
+- `dotnet test HurrahTv.slnx` (Shared parser tests + Api feedback/settings tests).
+- `dotnet format --verify-no-changes --severity info --no-restore HurrahTv.slnx` before push.
+- Browser: submit feedback → admin view; open `/changelog`; new-feature banner shows for a fresh user and its
+  dismissal persists across reload.
+- PR description: `Closes #19`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Hurrah.tv is an opinionated streaming platform that curates content across Netfl
 - **Balanced discovery** — Content is interleaved across your services so no single provider dominates your feed
 - **Language filter** — Option to show English originals only, hiding dubbed and subtitled content
 - **Installable PWA** — Add to your home screen on iOS or Android for a full-screen, app-like experience; a service worker caches the app shell so it still loads offline
-- **Admin views** — Owner-only `/admin` surface for users (with name + admin grant), AI usage and budget tracking, and onboarding funnel
+- **Feedback & changelog** — Send feedback (bug / feature request / general) from Settings; a What's Changed page renders the changelog and a dismissible banner highlights new features you haven't seen yet
+- **Admin views** — Owner-only `/admin` surface for users (with name + admin grant), submitted feedback, AI usage and budget tracking, and onboarding funnel
 
 **Live at:** [hurrah.tv](https://hurrah.tv)
 
@@ -58,10 +59,12 @@ The home page renders Netflix-style horizontal content rows, each powered by a d
 | `/api/curation` | AI-curated picks, per-show match scoring, usage tracking |
 | `/api/services` | Manage subscribed streaming services |
 | `/api/shows` | Season and episode sentiment CRUD |
-| `/api/settings` | User preferences (English-only filter, etc.) |
+| `/api/settings` | User preferences (English-only filter, last-seen changelog version, etc.) |
+| `/api/feedback` | Submit user feedback (auth'd, rate-limited); owner-only list at `/api/admin/feedback` |
+| `/api/changelog` | Parsed `CHANGELOG.md` for the in-app What's Changed page + new-feature banner |
 | `/api/auth` | Phone OTP login (SMS-based, no passwords) |
 | `/api/profile` | First-name capture for greetings + AI personalization |
-| `/api/admin` | Owner-only — users list, per-user detail, AI usage rollups, onboarding funnel, hard-delete |
+| `/api/admin` | Owner-only — users list, per-user detail, submitted feedback, AI usage rollups, onboarding funnel, hard-delete |
 
 ## Getting Started
 


### PR DESCRIPTION
Three `phase:now` features, combined into one branch (server-first, each fully tested). 243 tests pass; `dotnet format` gate clean.

## #214 — Available Later surfaces upcoming episodes for any show, any service
- `WatchlistFilters`: drop the streamability gate on the upcoming-episode (Path B) branch and widen the window 14 → 30 days, so a new episode surfaces regardless of service (and a zero-services user sees it). NotForMe still excluded.
- Tests: inverted the two old streamability pins + added #214 pins (non-subscribed service, zero-services, day-30 boundary, beyond-old-14d, dismissed-excluded).

## #11 — robots.txt + sitemap.xml (prod-only indexing)
- Per-request `/robots.txt` + `/sitemap.xml` (anonymous). Only `hurrah.tv` is indexable; staging, the raw `*.azurewebsites.net` slot hostnames, and localhost get `Disallow: /` — blocks staging from being indexed.
- SEO half only — no analytics tool (Clarity #63 + App Insights already cover behavior). Search Console verification is a user-side DNS TXT step.

## #19 — Feedback + Changelog + new-feature alerts
- **Feedback:** `/feedback` form (category/message/optional email + CSS honeypot) → `POST /api/feedback` (auth, per-user rate limit, honeypot-drop); admin list at `/admin/feedback`. Built in-app (DB `Feedback` table + admin view).
- **Changelog:** `ChangelogParser` (pure, in Shared) → `GET /api/changelog` (embedded `CHANGELOG.md`, cached); `/changelog` page renders it.
- **Alert banner:** self-gating `NewFeatureAlertBanner` in `MainLayout` — shows when the latest shipped changelog version differs from `UserSettings.LastSeenChangelogVersion`; dismissal persists server-side.
- Changelog upkeep wired into the skills: `/xreview` flags a user-visible diff missing an `[Unreleased]` entry; `/deploy` stamps `[Unreleased] → dated` at the prod swap.

## Cleanup (from /xsimplify)
- Single-sourced the production host (`PublicSite`) across `SeoEndpoints` + `OgPreviewMiddleware`.
- Elevated the feedback category list to `HurrahTv.Shared.FeedbackCategories` (server + client share it).
- Parallelized the banner's changelog + settings fetches.

## Notes
- DB changes are additive/expand-safe for the shared-DB slot swap (new `Feedback` table + nullable `UserSettings.LastSeenChangelogVersion`).
- Follow-ups filed: #223 (in-app feature guidance), #224 (shared loading-state component).

Closes #214
Closes #11
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
