### PR TITLE
ci: build staging on CHANGELOG.md pushes (fix /deploy changelog-stamp flow)

### DIFF
--- a/.claude/skills/deploy/skill.md
+++ b/.claude/skills/deploy/skill.md
@@ -64,6 +64,11 @@ Single App Service serves both the Blazor WASM client (static files) and the .NE
      triggers a fresh staging deploy: **wait for `main_hurrahtv.yml` to finish**
      (`gh run list --workflow main_hurrahtv.yml -R mkerchenski/hurrah-tv --limit 1`, poll to
      completion) so the swapped build carries the dated changelog and the banner fires for users.
+   - **The push only builds because `CHANGELOG.md` is in `main_hurrahtv.yml`'s `paths:` filter.** If
+     no run appears within ~30s of the push (someone pruned it from `paths`, or the stamp landed in a
+     root file not listed there), the push was path-filtered out — **manually dispatch** the staging
+     build instead: `gh workflow run main_hurrahtv.yml -R mkerchenski/hurrah-tv --ref main`, then poll
+     that run to completion. Don't just poll `--limit 1` forever expecting a run that will never start.
    - If `[Unreleased]` is empty (a deploy with no user-visible changes), note that and skip straight to
      the swap — don't stamp an empty release.
 3. Use AskUserQuestion to confirm: "This will swap staging to production at hurrah.tv. Proceed?"

--- a/.github/workflows/main_hurrahtv.yml
+++ b/.github/workflows/main_hurrahtv.yml
@@ -9,6 +9,11 @@ on:
       - 'HurrahTv.Client/**'
       - 'HurrahTv.Shared/**'
       - '!HurrahTv.Client/node_modules/**'
+      # CHANGELOG.md is an embedded resource in the API build (served at /api/changelog and
+      # driving the What's Changed banner), so a changelog stamp genuinely changes the deployed
+      # artifact and must trigger a staging build — do not remove. The /deploy skill relies on
+      # this: it stamps the changelog, pushes, and waits for this workflow before the prod swap.
+      - 'CHANGELOG.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What
Add `CHANGELOG.md` to `main_hurrahtv.yml`'s push `paths:` filter, and add a fallback note to the `/deploy` skill.

## Why
`CHANGELOG.md` is an embedded resource in the API build (served at `/api/changelog`, drives the What's Changed banner #19), so a changelog stamp genuinely changes the deployed artifact. But the push `paths:` filter only listed `HurrahTv.{Api,Client,Shared}/**`, so a changelog-only push to `main` was silently **not** built — staging kept the pre-stamp artifact.

Discovered during today's `/deploy now`: the stamp commit `c0cad7e` triggered no run; I polled 10 min for a build that would never start, then matched the earlier `8c40c00` release's manual `workflow_dispatch` to get the changelog into the slot before swapping. The `/deploy` skill's step-2 assumption ("this push triggers a fresh staging deploy") only holds once `CHANGELOG.md` is in `paths`.

## Changes
- `main_hurrahtv.yml`: add `CHANGELOG.md` to push `paths` (with a comment on why it's a build input / don't-remove).
- `.claude/skills/deploy/skill.md`: fallback — if no run appears ~30s after the stamp push, dispatch the staging build manually instead of polling forever.

## Verification
- Workflow YAML parses; `paths` now includes `CHANGELOG.md`.
- Behavioral verification lands on the next changelog-only deploy (a changelog push should now trigger `main_hurrahtv.yml` on its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)